### PR TITLE
Adding settings for updating prefix colour

### DIFF
--- a/src/main/java/com/osrstcg/OsrsTcgConfig.java
+++ b/src/main/java/com/osrstcg/OsrsTcgConfig.java
@@ -1,5 +1,6 @@
 package com.osrstcg;
 
+import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -47,5 +48,16 @@ public interface OsrsTcgConfig extends Config
 	default boolean safeMode()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "chatPrefixColor",
+		name = "Chat prefix colour",
+		description = "Choose the colour used for the [OSRS TCG] chat prefix. "
+			+ "Written on plugin load/unload"
+	)
+	default Color chatPrefixColor()
+	{
+		return new Color(0xC4, 0x94, 0x1A);
 	}
 }

--- a/src/main/java/com/osrstcg/OsrsTcgPlugin.java
+++ b/src/main/java/com/osrstcg/OsrsTcgPlugin.java
@@ -201,6 +201,7 @@ public class OsrsTcgPlugin extends Plugin
 		stateService.setRewardTuningFlushBeforeCredits(tcgPanel::flushRewardTuningDraftToState);
 		tcgPanel.refresh();
 		stateService.saveToFileBackup();
+		TcgPluginGameMessages.setPrefixColor(config.chatPrefixColor());
 	}
 
 	@Override
@@ -296,11 +297,11 @@ public class OsrsTcgPlugin extends Plugin
 		String trimmed = cardName.trim();
 		Color rarity = cardDatabase.chatRarityColorForCardName(trimmed);
 		String formatted = message.isNewForCollection()
-			? TcgPluginGameMessages.formatGoldPrefixedSomeoneAddedCollection(who, trimmed, message.isFoil(), rarity)
-			: TcgPluginGameMessages.formatGoldPrefixedSomeonePulled(who, trimmed, message.isFoil(), rarity);
+			? TcgPluginGameMessages.formatPrefixedSomeoneAddedCollection(who, trimmed, message.isFoil(), rarity)
+			: TcgPluginGameMessages.formatPrefixedSomeonePulled(who, trimmed, message.isFoil(), rarity);
 		String plain = message.isNewForCollection()
-			? TcgPluginGameMessages.plainGoldPrefixedSomeoneAddedCollection(who, trimmed, message.isFoil())
-			: TcgPluginGameMessages.plainGoldPrefixedSomeonePulled(who, trimmed, message.isFoil());
+			? TcgPluginGameMessages.plainPrefixedSomeoneAddedCollection(who, trimmed, message.isFoil())
+			: TcgPluginGameMessages.plainPrefixedSomeonePulled(who, trimmed, message.isFoil());
 		TcgPluginGameMessages.queueFormattedGameMessage(chatMessageManager, formatted, plain);
 	}
 
@@ -329,7 +330,7 @@ public class OsrsTcgPlugin extends Plugin
 		String who = author != null && author.getDisplayName() != null && !author.getDisplayName().trim().isEmpty()
 			? author.getDisplayName().trim()
 			: "A party member";
-		TcgPluginGameMessages.queueGoldPluginGameMessage(chatMessageManager,
+		TcgPluginGameMessages.queuePrefixedGameMessage(chatMessageManager,
 			String.format(Locale.US, "%s just finished %s!", who, collectionName.trim()));
 	}
 

--- a/src/main/java/com/osrstcg/service/CardPartyTransferService.java
+++ b/src/main/java/com/osrstcg/service/CardPartyTransferService.java
@@ -242,7 +242,7 @@ public class CardPartyTransferService
 			if (p != null && now - p.createdAtMs > PENDING_TTL_MS && pendingOffers.remove(tid, p))
 			{
 				pendingInstanceIds.remove(p.cardInstanceId);
-				TcgPluginGameMessages.queueGoldPluginGameMessage(chatMessageManager,
+				TcgPluginGameMessages.queuePrefixedGameMessage(chatMessageManager,
 					"Card send timed out (no response from recipient).");
 			}
 		}
@@ -292,7 +292,7 @@ public class CardPartyTransferService
 		if (senderInstanceId.isEmpty())
 		{
 			sendResponse(msg.getTransferId(), originalSender, false, GIFT_REJECT_BAD_PAYLOAD);
-			TcgPluginGameMessages.queueGoldPluginGameMessage(chatMessageManager,
+			TcgPluginGameMessages.queuePrefixedGameMessage(chatMessageManager,
 				"Incoming card ignored: incompatible gift message (missing instance id).");
 			return;
 		}
@@ -301,14 +301,14 @@ public class CardPartyTransferService
 		if (senderDebug == null)
 		{
 			sendResponse(msg.getTransferId(), originalSender, false, GIFT_REJECT_SENDER_TOO_OLD);
-			TcgPluginGameMessages.queueGoldPluginGameMessage(chatMessageManager,
+			TcgPluginGameMessages.queuePrefixedGameMessage(chatMessageManager,
 				"Incoming card ignored: sender's client did not report debug mode (update OSRS TCG on both sides).");
 			return;
 		}
 		if (senderDebug.booleanValue() != stateService.isDebugLogging())
 		{
 			sendResponse(msg.getTransferId(), originalSender, false, GIFT_REJECT_DEBUG_MISMATCH);
-			TcgPluginGameMessages.queueGoldPluginGameMessage(chatMessageManager,
+			TcgPluginGameMessages.queuePrefixedGameMessage(chatMessageManager,
 				"Incoming card ignored: Overview debug mode must match the sender's.");
 			return;
 		}
@@ -316,7 +316,7 @@ public class CardPartyTransferService
 		if (!tuningOk)
 		{
 			sendResponse(msg.getTransferId(), originalSender, false, GIFT_REJECT_TUNING_MISMATCH);
-			TcgPluginGameMessages.queueGoldPluginGameMessage(chatMessageManager,
+			TcgPluginGameMessages.queuePrefixedGameMessage(chatMessageManager,
 				"Incoming card ignored: your foil / credit multipliers do not match the sender's.");
 			return;
 		}
@@ -337,8 +337,8 @@ public class CardPartyTransferService
 			? from.getDisplayName().trim()
 			: "Party member";
 		Color rarity = cardDatabase.chatRarityColorForCardName(card);
-		String formatted = TcgPluginGameMessages.formatGoldPrefixedSomeoneSentYou(who, card, foil, rarity);
-		String plain = TcgPluginGameMessages.plainGoldPrefixedSomeoneSentYou(who, card, foil);
+		String formatted = TcgPluginGameMessages.formatPrefixedSomeoneSentYou(who, card, foil, rarity);
+		String plain = TcgPluginGameMessages.plainPrefixedSomeoneSentYou(who, card, foil);
 		TcgPluginGameMessages.queueFormattedGameMessage(chatMessageManager, formatted, plain);
 		refreshAlbumIfOpen();
 	}
@@ -386,16 +386,16 @@ public class CardPartyTransferService
 			boolean removed = stateService.removeCardInstance(pending.cardInstanceId);
 			if (!removed)
 			{
-				TcgPluginGameMessages.queueGoldPluginGameMessage(chatMessageManager,
+				TcgPluginGameMessages.queuePrefixedGameMessage(chatMessageManager,
 					"Recipient accepted the card but you no longer had that copy; check your collection.");
 			}
 			else
 			{
 				packRevealSoundService.playTransferSuccess();
 				Color rarity = cardDatabase.chatRarityColorForCardName(pending.cardName);
-				String formatted = TcgPluginGameMessages.formatGoldPrefixedYouSentCard(
+				String formatted = TcgPluginGameMessages.formatPrefixedYouSentCard(
 					pending.cardName, pending.foil, target, rarity);
-				String plain = TcgPluginGameMessages.plainGoldPrefixedYouSentCard(
+				String plain = TcgPluginGameMessages.plainPrefixedYouSentCard(
 					pending.cardName, pending.foil, target);
 				TcgPluginGameMessages.queueFormattedGameMessage(chatMessageManager, formatted, plain);
 			}
@@ -428,7 +428,7 @@ public class CardPartyTransferService
 			{
 				detail = String.format(Locale.US, "%s could not accept the card. You still have it.", target);
 			}
-			TcgPluginGameMessages.queueGoldPluginGameMessage(chatMessageManager, detail);
+			TcgPluginGameMessages.queuePrefixedGameMessage(chatMessageManager, detail);
 		}
 		refreshAlbumIfOpen();
 	}

--- a/src/main/java/com/osrstcg/service/PackSafeModeService.java
+++ b/src/main/java/com/osrstcg/service/PackSafeModeService.java
@@ -119,7 +119,7 @@ public final class PackSafeModeService
 			return;
 		}
 
-		TcgPluginGameMessages.queueGoldPluginGameMessage(chatMessageManager,
+		TcgPluginGameMessages.queuePrefixedGameMessage(chatMessageManager,
 			"Combat interrupted pack reveal — your cards are in your collection.");
 
 		for (RevealCard card : cards)
@@ -135,8 +135,8 @@ public final class PackSafeModeService
 				continue;
 			}
 			Color rarity = cardDatabase.chatRarityColorForCardName(name);
-			String formatted = TcgPluginGameMessages.formatGoldPrefixedYouPulled(name, pull.isFoil(), rarity);
-			String plain = TcgPluginGameMessages.plainGoldPrefixedYouPulled(name, pull.isFoil());
+			String formatted = TcgPluginGameMessages.formatPrefixedYouPulled(name, pull.isFoil(), rarity);
+			String plain = TcgPluginGameMessages.plainPrefixedYouPulled(name, pull.isFoil());
 			TcgPluginGameMessages.queueFormattedGameMessage(chatMessageManager, formatted, plain);
 		}
 

--- a/src/main/java/com/osrstcg/service/TcgPartyAnnouncer.java
+++ b/src/main/java/com/osrstcg/service/TcgPartyAnnouncer.java
@@ -52,11 +52,11 @@ public class TcgPartyAnnouncer
 		String trimmed = cardName.trim();
 		Color rarity = cardDatabase.chatRarityColorForCardName(trimmed);
 		String formatted = newForCollection
-			? TcgPluginGameMessages.formatGoldPrefixedYouAddedCollection(trimmed, foil, rarity)
-			: TcgPluginGameMessages.formatGoldPrefixedYouPulled(trimmed, foil, rarity);
+			? TcgPluginGameMessages.formatPrefixedYouAddedCollection(trimmed, foil, rarity)
+			: TcgPluginGameMessages.formatPrefixedYouPulled(trimmed, foil, rarity);
 		String plain = newForCollection
-			? TcgPluginGameMessages.plainGoldPrefixedYouAddedCollection(trimmed, foil)
-			: TcgPluginGameMessages.plainGoldPrefixedYouPulled(trimmed, foil);
+			? TcgPluginGameMessages.plainPrefixedYouAddedCollection(trimmed, foil)
+			: TcgPluginGameMessages.plainPrefixedYouPulled(trimmed, foil);
 		TcgPluginGameMessages.queueFormattedGameMessage(chatMessageManager, formatted, plain);
 
 		if (!partyService.isInParty())

--- a/src/main/java/com/osrstcg/util/TcgPluginGameMessages.java
+++ b/src/main/java/com/osrstcg/util/TcgPluginGameMessages.java
@@ -13,8 +13,14 @@ import net.runelite.client.chat.QueuedMessage;
 public final class TcgPluginGameMessages
 {
 	/**
-	 * Warm gold for the {@code OSRS TCG} label and for Godly-tier card names in game chat (darker than
-	 * {@link com.osrstcg.service.RarityMath.Tier#GODLY} frame colour so it reads on the message background).
+	 * Warm gold for the {@code OSRS TCG} label in game chat.
+	 */
+	public static final Color DEFAULT_PREFIX_COLOR = new Color(0xC4, 0x94, 0x1A);
+
+	public static Color PREFIX_COLOR = DEFAULT_PREFIX_COLOR;
+
+	/**
+	 * Warm gold for Godly-tier card names in game chat.
 	 */
 	public static final Color CHAT_EMPHASIS_GOLD = new Color(0xC4, 0x94, 0x1A);
 
@@ -22,26 +28,31 @@ public final class TcgPluginGameMessages
 	{
 	}
 
-	private static ChatMessageBuilder goldPluginPrefixBuilder()
+	private static ChatMessageBuilder prefixBuilder()
 	{
 		return new ChatMessageBuilder()
 			.append(ChatColorType.NORMAL)
 			.append("[")
-			.append(CHAT_EMPHASIS_GOLD, "OSRS TCG")
+			.append(PREFIX_COLOR, "OSRS TCG")
 			.append(ChatColorType.NORMAL)
 			.append("] ");
+	}
+
+	public static void setPrefixColor(Color color)
+	{
+		PREFIX_COLOR = color == null ? DEFAULT_PREFIX_COLOR : color;
 	}
 
 	/**
 	 * {@code [} default {@code OSRS TCG]} gold {@code ]} default, then body. {@code body} is escaped as plain chat text.
 	 */
-	public static String withGoldPluginPrefix(String body)
+	public static String withPrefix(String body)
 	{
 		if (body == null)
 		{
 			body = "";
 		}
-		return goldPluginPrefixBuilder()
+		return prefixBuilder()
 			.append(ChatColorType.NORMAL)
 			.append(body)
 			.build();
@@ -60,9 +71,9 @@ public final class TcgPluginGameMessages
 		return foil ? n + " (foil)" : n;
 	}
 
-	public static String formatGoldPrefixedSomeonePulled(String who, String cardName, boolean foil, Color rarityColor)
+	public static String formatPrefixedSomeonePulled(String who, String cardName, boolean foil, Color rarityColor)
 	{
-		return goldPluginPrefixBuilder()
+		return prefixBuilder()
 			.append(ChatColorType.NORMAL)
 			.append(who)
 			.append(ChatColorType.NORMAL)
@@ -73,14 +84,14 @@ public final class TcgPluginGameMessages
 			.build();
 	}
 
-	public static String plainGoldPrefixedSomeonePulled(String who, String cardName, boolean foil)
+	public static String plainPrefixedSomeonePulled(String who, String cardName, boolean foil)
 	{
 		return "[OSRS TCG] " + who + " just pulled " + announcedCardLabel(cardName, foil) + "!";
 	}
 
-	public static String formatGoldPrefixedSomeoneAddedCollection(String who, String cardName, boolean foil, Color rarityColor)
+	public static String formatPrefixedSomeoneAddedCollection(String who, String cardName, boolean foil, Color rarityColor)
 	{
-		return goldPluginPrefixBuilder()
+		return prefixBuilder()
 			.append(ChatColorType.NORMAL)
 			.append(who)
 			.append(ChatColorType.NORMAL)
@@ -91,14 +102,14 @@ public final class TcgPluginGameMessages
 			.build();
 	}
 
-	public static String plainGoldPrefixedSomeoneAddedCollection(String who, String cardName, boolean foil)
+	public static String plainPrefixedSomeoneAddedCollection(String who, String cardName, boolean foil)
 	{
 		return "[OSRS TCG] " + who + " just added " + announcedCardLabel(cardName, foil) + " to their collection!";
 	}
 
-	public static String formatGoldPrefixedYouPulled(String cardName, boolean foil, Color rarityColor)
+	public static String formatPrefixedYouPulled(String cardName, boolean foil, Color rarityColor)
 	{
-		return goldPluginPrefixBuilder()
+		return prefixBuilder()
 			.append(ChatColorType.NORMAL)
 			.append("You just pulled ")
 			.append(rarityColor, announcedCardLabel(cardName, foil))
@@ -107,14 +118,14 @@ public final class TcgPluginGameMessages
 			.build();
 	}
 
-	public static String plainGoldPrefixedYouPulled(String cardName, boolean foil)
+	public static String plainPrefixedYouPulled(String cardName, boolean foil)
 	{
 		return "[OSRS TCG] You just pulled " + announcedCardLabel(cardName, foil) + "!";
 	}
 
-	public static String formatGoldPrefixedYouAddedCollection(String cardName, boolean foil, Color rarityColor)
+	public static String formatPrefixedYouAddedCollection(String cardName, boolean foil, Color rarityColor)
 	{
-		return goldPluginPrefixBuilder()
+		return prefixBuilder()
 			.append(ChatColorType.NORMAL)
 			.append("You just added ")
 			.append(rarityColor, announcedCardLabel(cardName, foil))
@@ -123,14 +134,14 @@ public final class TcgPluginGameMessages
 			.build();
 	}
 
-	public static String plainGoldPrefixedYouAddedCollection(String cardName, boolean foil)
+	public static String plainPrefixedYouAddedCollection(String cardName, boolean foil)
 	{
 		return "[OSRS TCG] You just added " + announcedCardLabel(cardName, foil) + " to your collection!";
 	}
 
-	public static String formatGoldPrefixedSomeoneSentYou(String who, String cardName, boolean foil, Color rarityColor)
+	public static String formatPrefixedSomeoneSentYou(String who, String cardName, boolean foil, Color rarityColor)
 	{
-		return goldPluginPrefixBuilder()
+		return prefixBuilder()
 			.append(ChatColorType.NORMAL)
 			.append(who)
 			.append(ChatColorType.NORMAL)
@@ -141,14 +152,14 @@ public final class TcgPluginGameMessages
 			.build();
 	}
 
-	public static String plainGoldPrefixedSomeoneSentYou(String who, String cardName, boolean foil)
+	public static String plainPrefixedSomeoneSentYou(String who, String cardName, boolean foil)
 	{
 		return "[OSRS TCG] " + who + " just sent you " + announcedCardLabel(cardName, foil) + " !";
 	}
 
-	public static String formatGoldPrefixedYouSentCard(String cardName, boolean foil, String target, Color rarityColor)
+	public static String formatPrefixedYouSentCard(String cardName, boolean foil, String target, Color rarityColor)
 	{
-		return goldPluginPrefixBuilder()
+		return prefixBuilder()
 			.append(ChatColorType.NORMAL)
 			.append("Sent ")
 			.append(rarityColor, announcedCardLabel(cardName, foil))
@@ -161,7 +172,7 @@ public final class TcgPluginGameMessages
 			.build();
 	}
 
-	public static String plainGoldPrefixedYouSentCard(String cardName, boolean foil, String target)
+	public static String plainPrefixedYouSentCard(String cardName, boolean foil, String target)
 	{
 		return "[OSRS TCG] Sent " + announcedCardLabel(cardName, foil) + " to " + target + ".";
 	}
@@ -190,12 +201,22 @@ public final class TcgPluginGameMessages
 	/**
 	 * Queues a game message with RuneLite colour markup applied (see {@link ChatMessageManager}).
 	 */
-	public static void queueGoldPluginGameMessage(ChatMessageManager chatMessageManager, String body)
+	public static void queuePrefixedGameMessage(ChatMessageManager chatMessageManager, String body)
 	{
 		if (body == null)
 		{
 			body = "";
 		}
-		queueFormattedGameMessage(chatMessageManager, withGoldPluginPrefix(body), "[OSRS TCG] " + body);
+		queueFormattedGameMessage(chatMessageManager, withPrefix(body), "[OSRS TCG] " + body);
+	}
+
+	public static String formatPrefixedNotEnoughCredits(String action)
+	{
+		return prefixBuilder()
+			.append(ChatColorType.NORMAL)
+			.append(" Not enough credits to ")
+			.append(action)
+			.append(".")
+			.build();
 	}
 }


### PR DESCRIPTION
I find the gold prefix is hard to read, especially on larger screens with higher resolutions.

I added a custom settings for users to change the prefix colour. This will open happen on plugin load/unload due to the messaging class being static, and I didn't want to do a bunch of refactoring to make it persistent. 

Settings
<img width="236" height="250" alt="Screenshot 2026-07-02 142632" src="https://github.com/user-attachments/assets/360b6ec2-ff2c-4013-a9f6-089a30b395a7" />

Gold vs Blue readability
<img width="901" height="238" alt="Screenshot 2026-07-02 142740" src="https://github.com/user-attachments/assets/6c9aa06c-02a9-4e57-b71f-d584eb3066be" />

_sidenote_
and yes, my IGN is OSRS TCG. I've had it for a few good months now because I'm a huge TCG fan and thought it would be cool to have an OSRS one. I even had the idea for something like this entire extension about a month ago, but found the PR for yours the day I thought of it haha. 

I'd love to offer more help as needed. I'm very passionate about this project! I'm a swe with 10+ yrs of experience, so I'd love to help where ever is needed.

You can contact me via discord (dillonzer) or my github email.