### PR TITLE
Party duplicate matches QoL

### DIFF
--- a/src/main/java/com/osrstcg/OsrsTcgPlugin.java
+++ b/src/main/java/com/osrstcg/OsrsTcgPlugin.java
@@ -30,6 +30,7 @@ import com.osrstcg.party.TcgCardGiftResponsePartyMessage;
 import com.osrstcg.party.TcgChatStatsPartyMessage;
 import com.osrstcg.party.TcgCollectionSetCompletePartyMessage;
 import com.osrstcg.party.TcgPullPartyMessage;
+import com.osrstcg.party.TcgTradeListPartyMessage;
 import com.osrstcg.persist.TcgStateLoadResult;
 import com.osrstcg.persist.TcgStateLoadSource;
 import com.osrstcg.service.PackRevealSoundService;
@@ -38,6 +39,7 @@ import com.osrstcg.service.TcgChatStatsShareService;
 import com.osrstcg.service.TcgPartyAnnouncer;
 import com.osrstcg.service.TcgPublicStatsCalculator;
 import com.osrstcg.service.TcgStateService;
+import com.osrstcg.service.TcgTradeListShareService;
 import com.osrstcg.ui.TcgPanel;
 import com.osrstcg.ui.collectionalbum.CollectionAlbumManager;
 import com.osrstcg.util.NumberFormatting;
@@ -160,6 +162,8 @@ public class OsrsTcgPlugin extends Plugin
 	private PlayerCombatMonitor playerCombatMonitor;
 	@Inject
 	private PackSafeModeService packSafeModeService;
+	@Inject
+	private TcgTradeListShareService tcgTradeListShareService;
 
 	private NavigationButton navigationButton;
 	private boolean fileBackupLoadUsedThisSession;
@@ -196,11 +200,13 @@ public class OsrsTcgPlugin extends Plugin
 		eventBus.register(cardPartyTransferService);
 		eventBus.register(playerCombatMonitor);
 		eventBus.register(packSafeModeService);
+		eventBus.register(tcgTradeListShareService);
 		wsClient.registerMessage(TcgPullPartyMessage.class);
 		wsClient.registerMessage(TcgCollectionSetCompletePartyMessage.class);
 		wsClient.registerMessage(TcgCardGiftPartyMessage.class);
 		wsClient.registerMessage(TcgCardGiftResponsePartyMessage.class);
 		wsClient.registerMessage(TcgChatStatsPartyMessage.class);
+		wsClient.registerMessage(TcgTradeListPartyMessage.class);
 		chatCommandManager.registerCommandAsync(
 			TCG_PUBLIC_CHAT_COMMAND, this::lookupTcgPublicStatsChatCommand, this::submitTcgPublicStatsChatCommand);
 		tcgPanel.start();
@@ -224,12 +230,14 @@ public class OsrsTcgPlugin extends Plugin
 		eventBus.unregister(cardPartyTransferService);
 		eventBus.unregister(playerCombatMonitor);
 		eventBus.unregister(packSafeModeService);
+		eventBus.unregister(tcgTradeListShareService);
 		playerCombatMonitor.reset();
 		wsClient.unregisterMessage(TcgPullPartyMessage.class);
 		wsClient.unregisterMessage(TcgCollectionSetCompletePartyMessage.class);
 		wsClient.unregisterMessage(TcgCardGiftPartyMessage.class);
 		wsClient.unregisterMessage(TcgCardGiftResponsePartyMessage.class);
 		wsClient.unregisterMessage(TcgChatStatsPartyMessage.class);
+		wsClient.unregisterMessage(TcgTradeListPartyMessage.class);
 		chatCommandManager.unregisterCommand(TCG_PUBLIC_CHAT_COMMAND);
 		npcKillCreditTracker.shutdown();
 		overlayManager.remove(packRevealOverlay);

--- a/src/main/java/com/osrstcg/party/TcgTradeListPartyMessage.java
+++ b/src/main/java/com/osrstcg/party/TcgTradeListPartyMessage.java
@@ -1,0 +1,32 @@
+package com.osrstcg.party;
+
+import java.util.List;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import net.runelite.client.party.messages.PartyMemberMessage;
+
+/**
+ * Opt-in party sync for trade discovery. Contains only duplicate card variants the sender can offer, not their full
+ * collection.
+ */
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class TcgTradeListPartyMessage extends PartyMemberMessage
+{
+	private int schemaVersion;
+	private long sentAtEpochMs;
+	private boolean senderDebugLogging;
+	private int foilChancePercent;
+	private double killCreditMultiplier;
+	private double levelUpCreditMultiplier;
+	private double xpCreditMultiplier;
+	private List<Entry> duplicates;
+
+	@Data
+	public static class Entry
+	{
+		private String cardName;
+		private int normalAvailable;
+		private int foilAvailable;
+	}
+}

--- a/src/main/java/com/osrstcg/party/TcgTradeListPartyMessage.java
+++ b/src/main/java/com/osrstcg/party/TcgTradeListPartyMessage.java
@@ -14,6 +14,7 @@ import net.runelite.client.party.messages.PartyMemberMessage;
 public class TcgTradeListPartyMessage extends PartyMemberMessage
 {
 	private int schemaVersion;
+	private long recipientMemberId;
 	private long sentAtEpochMs;
 	private boolean senderDebugLogging;
 	private int foilChancePercent;

--- a/src/main/java/com/osrstcg/party/TcgTradeListPartyMessage.java
+++ b/src/main/java/com/osrstcg/party/TcgTradeListPartyMessage.java
@@ -5,10 +5,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import net.runelite.client.party.messages.PartyMemberMessage;
 
-/**
- * Opt-in party sync for trade discovery. Contains only duplicate card variants the sender can offer, not their full
- * collection.
- */
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class TcgTradeListPartyMessage extends PartyMemberMessage

--- a/src/main/java/com/osrstcg/service/TcgTradeListShareService.java
+++ b/src/main/java/com/osrstcg/service/TcgTradeListShareService.java
@@ -1,0 +1,313 @@
+package com.osrstcg.service;
+
+import com.osrstcg.model.CardCollectionKey;
+import com.osrstcg.model.CollectionState;
+import com.osrstcg.model.OwnedCardInstance;
+import com.osrstcg.model.RewardTuningState;
+import com.osrstcg.model.TcgState;
+import com.osrstcg.party.TcgTradeListPartyMessage;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.party.PartyMember;
+import net.runelite.client.party.PartyService;
+import net.runelite.client.util.Text;
+
+/**
+ * Shares and caches opt-in duplicate lists from RuneLite party members so players can find useful card swaps without
+ * exposing full collections or changing the existing one-way send flow.
+ */
+@Singleton
+public class TcgTradeListShareService
+{
+	private static final int SCHEMA_VERSION = 1;
+	private static final long CACHE_TTL_MS = 15L * 60L * 1000L;
+
+	private final PartyService partyService;
+	private final TcgStateService stateService;
+	private final ConcurrentHashMap<Long, CacheEntry> cacheByMemberId = new ConcurrentHashMap<>();
+
+	@Inject
+	public TcgTradeListShareService(PartyService partyService, TcgStateService stateService)
+	{
+		this.partyService = partyService;
+		this.stateService = stateService;
+	}
+
+	public String shareDuplicateList()
+	{
+		if (!partyService.isInParty())
+		{
+			return "Join a RuneLite party first.";
+		}
+		if (partyService.getLocalMember() == null)
+		{
+			return "Party session not ready.";
+		}
+
+		List<TcgTradeListPartyMessage.Entry> duplicates = buildDuplicateEntries();
+		TcgState state = stateService.getState();
+		RewardTuningState tuning = state.getRewardTuning();
+
+		TcgTradeListPartyMessage message = new TcgTradeListPartyMessage();
+		message.setSchemaVersion(SCHEMA_VERSION);
+		message.setSentAtEpochMs(System.currentTimeMillis());
+		message.setSenderDebugLogging(state.isDebugLogging());
+		message.setFoilChancePercent(tuning.getFoilChancePercent());
+		message.setKillCreditMultiplier(tuning.getKillCreditMultiplier());
+		message.setLevelUpCreditMultiplier(tuning.getLevelUpCreditMultiplier());
+		message.setXpCreditMultiplier(tuning.getXpCreditMultiplier());
+		message.setDuplicates(duplicates);
+		try
+		{
+			partyService.send(message);
+		}
+		catch (Exception ex)
+		{
+			return "Could not share dupes (party connection).";
+		}
+
+		return String.format(Locale.US, "Shared %d duplicate card variant%s.",
+			duplicates.size(), duplicates.size() == 1 ? "" : "s");
+	}
+
+	public boolean hasRecentPartyLists()
+	{
+		pruneExpired();
+		return !cacheByMemberId.isEmpty();
+	}
+
+	public String buildPartyTradeMatchSummary()
+	{
+		pruneExpired();
+		if (cacheByMemberId.isEmpty())
+		{
+			return "No party duplicate lists cached yet.\n\nAsk a party member to click Share dupes.";
+		}
+
+		Map<CardCollectionKey, Integer> mine = stateService.getState().getCollectionState().getOwnedCards();
+		List<CacheEntry> entries = new ArrayList<>(cacheByMemberId.values());
+		entries.sort(Comparator.comparing(e -> e.displayName, String.CASE_INSENSITIVE_ORDER));
+
+		StringBuilder out = new StringBuilder();
+		for (CacheEntry entry : entries)
+		{
+			List<String> matches = missingFromMine(entry, mine);
+			out.append(entry.displayName).append(" - ")
+				.append(entry.duplicates.size()).append(" duplicate variant")
+				.append(entry.duplicates.size() == 1 ? "" : "s");
+			if (!entry.transferCompatible)
+			{
+				out.append(" (rates/debug mismatch)");
+			}
+			out.append('\n');
+
+			if (matches.isEmpty())
+			{
+				out.append("  No shared duplicates are missing from your collection.\n\n");
+				continue;
+			}
+
+			for (String line : matches)
+			{
+				out.append("  ").append(line).append('\n');
+			}
+			out.append('\n');
+		}
+		return out.toString().trim();
+	}
+
+	@Subscribe
+	public void onTcgTradeListPartyMessage(TcgTradeListPartyMessage message)
+	{
+		if (message == null || message.getSchemaVersion() != SCHEMA_VERSION)
+		{
+			return;
+		}
+		PartyMember local = partyService.getLocalMember();
+		if (local != null && message.getMemberId() == local.getMemberId())
+		{
+			return;
+		}
+
+		PartyMember author = partyService.getMemberById(message.getMemberId());
+		String displayName = author == null ? "Party member" : cleanDisplayName(author.getDisplayName());
+		List<TcgTradeListPartyMessage.Entry> duplicates = normalizeEntries(message.getDuplicates());
+		if (duplicates.isEmpty())
+		{
+			cacheByMemberId.remove(message.getMemberId());
+			return;
+		}
+
+		RewardTuningState mine = stateService.getState().getRewardTuning();
+		RewardTuningState theirs = RewardTuningState.mergeSerialized(
+			message.getFoilChancePercent(),
+			message.getKillCreditMultiplier(),
+			message.getLevelUpCreditMultiplier(),
+			message.getXpCreditMultiplier());
+		boolean compatible = mine.matchesPartnerTuning(theirs)
+			&& message.isSenderDebugLogging() == stateService.isDebugLogging();
+
+		cacheByMemberId.put(message.getMemberId(), new CacheEntry(
+			displayName, duplicates, System.currentTimeMillis(), compatible));
+	}
+
+	private List<TcgTradeListPartyMessage.Entry> buildDuplicateEntries()
+	{
+		CollectionState collection = stateService.getState().getCollectionState();
+		Map<CardCollectionKey, Counts> countsByVariant = new HashMap<>();
+		for (OwnedCardInstance instance : collection.getOwnedInstances())
+		{
+			if (instance == null || instance.getCardName() == null || instance.getCardName().trim().isEmpty())
+			{
+				continue;
+			}
+			CardCollectionKey key = new CardCollectionKey(instance.getCardName().trim(), instance.isFoil());
+			Counts counts = countsByVariant.computeIfAbsent(key, k -> new Counts());
+			counts.total++;
+			if (!instance.isLocked())
+			{
+				counts.unlocked++;
+			}
+		}
+
+		Map<String, TcgTradeListPartyMessage.Entry> byName = new LinkedHashMap<>();
+		List<Map.Entry<CardCollectionKey, Counts>> variants = new ArrayList<>(countsByVariant.entrySet());
+		variants.sort(Comparator.comparing(e -> e.getKey().getCardName(), String.CASE_INSENSITIVE_ORDER));
+		for (Map.Entry<CardCollectionKey, Counts> e : variants)
+		{
+			int available = e.getValue().availableDuplicates();
+			if (available <= 0)
+			{
+				continue;
+			}
+			String name = e.getKey().getCardName();
+			TcgTradeListPartyMessage.Entry entry = byName.computeIfAbsent(name, n ->
+			{
+				TcgTradeListPartyMessage.Entry next = new TcgTradeListPartyMessage.Entry();
+				next.setCardName(n);
+				return next;
+			});
+			if (e.getKey().isFoil())
+			{
+				entry.setFoilAvailable(available);
+			}
+			else
+			{
+				entry.setNormalAvailable(available);
+			}
+		}
+		return new ArrayList<>(byName.values());
+	}
+
+	private List<String> missingFromMine(CacheEntry entry, Map<CardCollectionKey, Integer> mine)
+	{
+		List<String> matches = new ArrayList<>();
+		for (TcgTradeListPartyMessage.Entry duplicate : entry.duplicates)
+		{
+			String name = duplicate.getCardName();
+			if (duplicate.getNormalAvailable() > 0 && !ownsVariant(mine, name, false))
+			{
+				matches.add(formatMatch(name, false, duplicate.getNormalAvailable()));
+			}
+			if (duplicate.getFoilAvailable() > 0 && !ownsVariant(mine, name, true))
+			{
+				matches.add(formatMatch(name, true, duplicate.getFoilAvailable()));
+			}
+		}
+		matches.sort(String.CASE_INSENSITIVE_ORDER);
+		return matches;
+	}
+
+	private static boolean ownsVariant(Map<CardCollectionKey, Integer> owned, String cardName, boolean foil)
+	{
+		Integer count = owned.get(new CardCollectionKey(cardName, foil));
+		return count != null && count > 0;
+	}
+
+	private static String formatMatch(String cardName, boolean foil, int available)
+	{
+		return String.format(Locale.US, "%s%s (%d available)",
+			cardName, foil ? " (foil)" : "", available);
+	}
+
+	private List<TcgTradeListPartyMessage.Entry> normalizeEntries(List<TcgTradeListPartyMessage.Entry> raw)
+	{
+		if (raw == null || raw.isEmpty())
+		{
+			return List.of();
+		}
+		Map<String, TcgTradeListPartyMessage.Entry> byName = new LinkedHashMap<>();
+		for (TcgTradeListPartyMessage.Entry row : raw)
+		{
+			if (row == null || row.getCardName() == null || row.getCardName().trim().isEmpty())
+			{
+				continue;
+			}
+			String name = row.getCardName().trim();
+			int normal = Math.max(0, row.getNormalAvailable());
+			int foil = Math.max(0, row.getFoilAvailable());
+			if (normal == 0 && foil == 0)
+			{
+				continue;
+			}
+			TcgTradeListPartyMessage.Entry entry = byName.computeIfAbsent(name, n ->
+			{
+				TcgTradeListPartyMessage.Entry next = new TcgTradeListPartyMessage.Entry();
+				next.setCardName(n);
+				return next;
+			});
+			entry.setNormalAvailable(entry.getNormalAvailable() + normal);
+			entry.setFoilAvailable(entry.getFoilAvailable() + foil);
+		}
+		return new ArrayList<>(byName.values());
+	}
+
+	private void pruneExpired()
+	{
+		long now = System.currentTimeMillis();
+		cacheByMemberId.entrySet().removeIf(e -> now - e.getValue().storedAtMs > CACHE_TTL_MS);
+	}
+
+	private static String cleanDisplayName(String displayName)
+	{
+		String cleaned = displayName == null ? "" : Text.removeTags(displayName).trim();
+		return cleaned.isEmpty() ? "Party member" : cleaned;
+	}
+
+	private static final class Counts
+	{
+		private int total;
+		private int unlocked;
+
+		private int availableDuplicates()
+		{
+			return Math.min(unlocked, Math.max(0, total - 1));
+		}
+	}
+
+	private static final class CacheEntry
+	{
+		private final String displayName;
+		private final List<TcgTradeListPartyMessage.Entry> duplicates;
+		private final long storedAtMs;
+		private final boolean transferCompatible;
+
+		private CacheEntry(String displayName, List<TcgTradeListPartyMessage.Entry> duplicates,
+			long storedAtMs, boolean transferCompatible)
+		{
+			this.displayName = displayName;
+			this.duplicates = duplicates;
+			this.storedAtMs = storedAtMs;
+			this.transferCompatible = transferCompatible;
+		}
+	}
+}

--- a/src/main/java/com/osrstcg/service/TcgTradeListShareService.java
+++ b/src/main/java/com/osrstcg/service/TcgTradeListShareService.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import lombok.Value;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.party.PartyMember;
 import net.runelite.client.party.PartyService;
@@ -42,15 +43,21 @@ public class TcgTradeListShareService
 		this.stateService = stateService;
 	}
 
-	public String shareDuplicateList()
+	@Value
+	public static class TradeMatch
 	{
-		if (!partyService.isInParty())
+		String cardName;
+		boolean foil;
+		int available;
+		boolean transferCompatible;
+	}
+
+	public String shareDuplicateList(long recipientMemberId)
+	{
+		String partyError = validateRecipient(recipientMemberId);
+		if (partyError != null)
 		{
-			return "Join a RuneLite party first.";
-		}
-		if (partyService.getLocalMember() == null)
-		{
-			return "Party session not ready.";
+			return partyError;
 		}
 
 		List<TcgTradeListPartyMessage.Entry> duplicates = buildDuplicateEntries();
@@ -59,6 +66,7 @@ public class TcgTradeListShareService
 
 		TcgTradeListPartyMessage message = new TcgTradeListPartyMessage();
 		message.setSchemaVersion(SCHEMA_VERSION);
+		message.setRecipientMemberId(recipientMemberId);
 		message.setSentAtEpochMs(System.currentTimeMillis());
 		message.setSenderDebugLogging(state.isDebugLogging());
 		message.setFoilChancePercent(tuning.getFoilChancePercent());
@@ -125,6 +133,44 @@ public class TcgTradeListShareService
 		return out.toString().trim();
 	}
 
+	public List<TradeMatch> matchesForMember(long memberId)
+	{
+		pruneExpired();
+		CacheEntry entry = cacheByMemberId.get(memberId);
+		if (entry == null)
+		{
+			return List.of();
+		}
+		Map<CardCollectionKey, Integer> mine = stateService.getState().getCollectionState().getOwnedCards();
+		List<TradeMatch> matches = new ArrayList<>();
+		for (TcgTradeListPartyMessage.Entry duplicate : entry.duplicates)
+		{
+			String name = duplicate.getCardName();
+			if (duplicate.getNormalAvailable() > 0 && !ownsVariant(mine, name, false))
+			{
+				matches.add(new TradeMatch(name, false, duplicate.getNormalAvailable(), entry.transferCompatible));
+			}
+			if (duplicate.getFoilAvailable() > 0 && !ownsVariant(mine, name, true))
+			{
+				matches.add(new TradeMatch(name, true, duplicate.getFoilAvailable(), entry.transferCompatible));
+			}
+		}
+		matches.sort(Comparator.comparing(TradeMatch::getCardName, String.CASE_INSENSITIVE_ORDER)
+			.thenComparing(TradeMatch::isFoil));
+		return matches;
+	}
+
+	public String displayNameForMember(long memberId)
+	{
+		PartyMember member = partyService.getMemberById(memberId);
+		if (member != null)
+		{
+			return cleanDisplayName(member.getDisplayName());
+		}
+		CacheEntry entry = cacheByMemberId.get(memberId);
+		return entry == null ? "Party member" : entry.displayName;
+	}
+
 	@Subscribe
 	public void onTcgTradeListPartyMessage(TcgTradeListPartyMessage message)
 	{
@@ -133,7 +179,7 @@ public class TcgTradeListShareService
 			return;
 		}
 		PartyMember local = partyService.getLocalMember();
-		if (local != null && message.getMemberId() == local.getMemberId())
+		if (local == null || message.getRecipientMemberId() != local.getMemberId())
 		{
 			return;
 		}
@@ -158,6 +204,28 @@ public class TcgTradeListShareService
 
 		cacheByMemberId.put(message.getMemberId(), new CacheEntry(
 			displayName, duplicates, System.currentTimeMillis(), compatible));
+	}
+
+	private String validateRecipient(long recipientMemberId)
+	{
+		if (!partyService.isInParty())
+		{
+			return "Join a RuneLite party first.";
+		}
+		PartyMember local = partyService.getLocalMember();
+		if (local == null)
+		{
+			return "Party session not ready.";
+		}
+		if (recipientMemberId == local.getMemberId())
+		{
+			return "Choose a different party member.";
+		}
+		if (partyService.getMemberById(recipientMemberId) == null)
+		{
+			return "That player is not in your party.";
+		}
+		return null;
 	}
 
 	private List<TcgTradeListPartyMessage.Entry> buildDuplicateEntries()

--- a/src/main/java/com/osrstcg/service/TcgTradeListShareService.java
+++ b/src/main/java/com/osrstcg/service/TcgTradeListShareService.java
@@ -22,10 +22,6 @@ import net.runelite.client.party.PartyMember;
 import net.runelite.client.party.PartyService;
 import net.runelite.client.util.Text;
 
-/**
- * Shares and caches opt-in duplicate lists from RuneLite party members so players can find useful card swaps without
- * exposing full collections or changing the existing one-way send flow.
- */
 @Singleton
 public class TcgTradeListShareService
 {
@@ -85,52 +81,6 @@ public class TcgTradeListShareService
 
 		return String.format(Locale.US, "Shared %d duplicate card variant%s.",
 			duplicates.size(), duplicates.size() == 1 ? "" : "s");
-	}
-
-	public boolean hasRecentPartyLists()
-	{
-		pruneExpired();
-		return !cacheByMemberId.isEmpty();
-	}
-
-	public String buildPartyTradeMatchSummary()
-	{
-		pruneExpired();
-		if (cacheByMemberId.isEmpty())
-		{
-			return "No party duplicate lists cached yet.\n\nAsk a party member to click Share dupes.";
-		}
-
-		Map<CardCollectionKey, Integer> mine = stateService.getState().getCollectionState().getOwnedCards();
-		List<CacheEntry> entries = new ArrayList<>(cacheByMemberId.values());
-		entries.sort(Comparator.comparing(e -> e.displayName, String.CASE_INSENSITIVE_ORDER));
-
-		StringBuilder out = new StringBuilder();
-		for (CacheEntry entry : entries)
-		{
-			List<String> matches = missingFromMine(entry, mine);
-			out.append(entry.displayName).append(" - ")
-				.append(entry.duplicates.size()).append(" duplicate variant")
-				.append(entry.duplicates.size() == 1 ? "" : "s");
-			if (!entry.transferCompatible)
-			{
-				out.append(" (rates/debug mismatch)");
-			}
-			out.append('\n');
-
-			if (matches.isEmpty())
-			{
-				out.append("  No shared duplicates are missing from your collection.\n\n");
-				continue;
-			}
-
-			for (String line : matches)
-			{
-				out.append("  ").append(line).append('\n');
-			}
-			out.append('\n');
-		}
-		return out.toString().trim();
 	}
 
 	public List<TradeMatch> matchesForMember(long memberId)
@@ -276,35 +226,10 @@ public class TcgTradeListShareService
 		return new ArrayList<>(byName.values());
 	}
 
-	private List<String> missingFromMine(CacheEntry entry, Map<CardCollectionKey, Integer> mine)
-	{
-		List<String> matches = new ArrayList<>();
-		for (TcgTradeListPartyMessage.Entry duplicate : entry.duplicates)
-		{
-			String name = duplicate.getCardName();
-			if (duplicate.getNormalAvailable() > 0 && !ownsVariant(mine, name, false))
-			{
-				matches.add(formatMatch(name, false, duplicate.getNormalAvailable()));
-			}
-			if (duplicate.getFoilAvailable() > 0 && !ownsVariant(mine, name, true))
-			{
-				matches.add(formatMatch(name, true, duplicate.getFoilAvailable()));
-			}
-		}
-		matches.sort(String.CASE_INSENSITIVE_ORDER);
-		return matches;
-	}
-
 	private static boolean ownsVariant(Map<CardCollectionKey, Integer> owned, String cardName, boolean foil)
 	{
 		Integer count = owned.get(new CardCollectionKey(cardName, foil));
 		return count != null && count > 0;
-	}
-
-	private static String formatMatch(String cardName, boolean foil, int available)
-	{
-		return String.format(Locale.US, "%s%s (%d available)",
-			cardName, foil ? " (foil)" : "", available);
 	}
 
 	private List<TcgTradeListPartyMessage.Entry> normalizeEntries(List<TcgTradeListPartyMessage.Entry> raw)

--- a/src/main/java/com/osrstcg/ui/SharedCardRenderer.java
+++ b/src/main/java/com/osrstcg/ui/SharedCardRenderer.java
@@ -557,7 +557,7 @@ public final class SharedCardRenderer
 		java.awt.Shape previousClip = g2.getClip();
 		try
 		{
-			g2.setClip(rect);
+			g2.clip(rect);
 			g2.drawImage(image, x, y, w, h, null);
 		}
 		finally
@@ -584,7 +584,7 @@ public final class SharedCardRenderer
 		java.awt.Shape previousClip = g2.getClip();
 		try
 		{
-			g2.setClip(rect);
+			g2.clip(rect);
 			g2.drawImage(image, x, y, w, h, null);
 		}
 		finally

--- a/src/main/java/com/osrstcg/ui/collectionalbum/CollectionAlbumManager.java
+++ b/src/main/java/com/osrstcg/ui/collectionalbum/CollectionAlbumManager.java
@@ -4,6 +4,7 @@ import com.osrstcg.data.CardDatabase;
 import com.osrstcg.data.PackCatalog;
 import com.osrstcg.service.CardPartyTransferService;
 import com.osrstcg.service.TcgStateService;
+import com.osrstcg.service.TcgTradeListShareService;
 import com.osrstcg.service.WikiImageCacheService;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -19,6 +20,7 @@ public final class CollectionAlbumManager
 	private final WikiImageCacheService imageCacheService;
 	private final PartyService partyService;
 	private final CardPartyTransferService cardPartyTransferService;
+	private final TcgTradeListShareService tradeListShareService;
 
 	private volatile CollectionAlbumWindow window;
 
@@ -29,7 +31,8 @@ public final class CollectionAlbumManager
 		PackCatalog packCatalog,
 		WikiImageCacheService imageCacheService,
 		PartyService partyService,
-		CardPartyTransferService cardPartyTransferService)
+		CardPartyTransferService cardPartyTransferService,
+		TcgTradeListShareService tradeListShareService)
 	{
 		this.cardDatabase = cardDatabase;
 		this.stateService = stateService;
@@ -37,6 +40,7 @@ public final class CollectionAlbumManager
 		this.imageCacheService = imageCacheService;
 		this.partyService = partyService;
 		this.cardPartyTransferService = cardPartyTransferService;
+		this.tradeListShareService = tradeListShareService;
 	}
 
 	public void showOrBringToFront()
@@ -47,7 +51,7 @@ public final class CollectionAlbumManager
 			{
 				window = new CollectionAlbumWindow(
 					cardDatabase, stateService, packCatalog, imageCacheService, partyService,
-					cardPartyTransferService);
+					cardPartyTransferService, tradeListShareService);
 			}
 			window.refreshData();
 			window.prepareToShow();

--- a/src/main/java/com/osrstcg/ui/collectionalbum/CollectionAlbumWindow.java
+++ b/src/main/java/com/osrstcg/ui/collectionalbum/CollectionAlbumWindow.java
@@ -102,6 +102,7 @@ public final class CollectionAlbumWindow extends JFrame
 	private final JButton sellCardBtn = new JButton("Sell");
 	private final JLabel sendStatusLabel = new JLabel(" ");
 	private final Timer partyUiTimer;
+	private boolean suppressPartyMemberComboEvents;
 
 	private AlbumRarityTable rarityTable = AlbumRarityTable.build(List.of());
 	private List<TabFilter> tabFilters = List.of();
@@ -1217,60 +1218,67 @@ public final class CollectionAlbumWindow extends JFrame
 		Long prevId = prevSel >= 0 && prevSel < partyMemberIds.size() ? partyMemberIds.get(prevSel) : null;
 
 		partyMemberIds.clear();
-		partyMemberCombo.removeAllItems();
-		partyMemberCombo.addItem("— Select party member —");
-		partyMemberIds.add(-1L);
-
-		boolean inParty = partyService.isInParty();
-		PartyMember local = partyService.getLocalMember();
-		boolean hasOther = false;
-		if (inParty && local != null)
+		suppressPartyMemberComboEvents = true;
+		try
 		{
-			for (PartyMember m : partyService.getMembers())
-			{
-				if (m == null || m.getMemberId() == local.getMemberId())
-				{
-					continue;
-				}
-				String dn = m.getDisplayName();
-				String trimmedDn = dn == null ? "" : Text.removeTags(dn).trim();
-				if (trimmedDn.equalsIgnoreCase("<unknown>"))
-				{
-					continue;
-				}
-				if (trimmedDn.isEmpty())
-				{
-					continue;
-				}
-				if (trimmedDn.regionMatches(true, 0, "Member #", 0, "Member #".length()))
-				{
-					continue;
-				}
-				hasOther = true;
-				partyMemberCombo.addItem(trimmedDn);
-				partyMemberIds.add(m.getMemberId());
-			}
-		}
+			partyMemberCombo.removeAllItems();
+			partyMemberCombo.addItem("— Select party member —");
+			partyMemberIds.add(-1L);
 
-		boolean partyTradeReady = inParty && local != null && hasOther;
-		partyMemberCombo.setEnabled(partyTradeReady);
-		partyMemberCombo.setToolTipText(partyTradeReady ? null : PARTY_SEND_TOOLTIP);
-		sendCardBtn.setToolTipText(partyTradeReady ? null : PARTY_SEND_TOOLTIP);
-		updatePartyDiscoveryButtons();
-
-		if (prevId != null)
-		{
-			for (int i = 0; i < partyMemberIds.size(); i++)
+			boolean inParty = partyService.isInParty();
+			PartyMember local = partyService.getLocalMember();
+			boolean hasOther = false;
+			if (inParty && local != null)
 			{
-				if (prevId.equals(partyMemberIds.get(i)))
+				for (PartyMember m : partyService.getMembers())
 				{
-					partyMemberCombo.setSelectedIndex(i);
-					updateSouthBarButtons();
-					return;
+					if (m == null || m.getMemberId() == local.getMemberId())
+					{
+						continue;
+					}
+					String dn = m.getDisplayName();
+					String trimmedDn = dn == null ? "" : Text.removeTags(dn).trim();
+					if (trimmedDn.equalsIgnoreCase("<unknown>"))
+					{
+						continue;
+					}
+					if (trimmedDn.isEmpty())
+					{
+						continue;
+					}
+					if (trimmedDn.regionMatches(true, 0, "Member #", 0, "Member #".length()))
+					{
+						continue;
+					}
+					hasOther = true;
+					partyMemberCombo.addItem(trimmedDn);
+					partyMemberIds.add(m.getMemberId());
 				}
 			}
+
+			boolean partyTradeReady = inParty && local != null && hasOther;
+			partyMemberCombo.setEnabled(partyTradeReady);
+			partyMemberCombo.setToolTipText(partyTradeReady ? null : PARTY_SEND_TOOLTIP);
+			sendCardBtn.setToolTipText(partyTradeReady ? null : PARTY_SEND_TOOLTIP);
+
+			if (prevId != null)
+			{
+				for (int i = 0; i < partyMemberIds.size(); i++)
+				{
+					if (prevId.equals(partyMemberIds.get(i)))
+					{
+						partyMemberCombo.setSelectedIndex(i);
+						updateSouthBarButtons();
+						return;
+					}
+				}
+			}
+			partyMemberCombo.setSelectedIndex(0);
 		}
-		partyMemberCombo.setSelectedIndex(0);
+		finally
+		{
+			suppressPartyMemberComboEvents = false;
+		}
 		updateSouthBarButtons();
 	}
 
@@ -1281,6 +1289,11 @@ public final class CollectionAlbumWindow extends JFrame
 
 	private void onPartyMemberSelectionChanged(ActionEvent e)
 	{
+		if (suppressPartyMemberComboEvents)
+		{
+			updateSouthBarButtons();
+			return;
+		}
 		sendStatusLabel.setText(" ");
 		updateSouthBarButtons();
 	}

--- a/src/main/java/com/osrstcg/ui/collectionalbum/CollectionAlbumWindow.java
+++ b/src/main/java/com/osrstcg/ui/collectionalbum/CollectionAlbumWindow.java
@@ -464,7 +464,7 @@ public final class CollectionAlbumWindow extends JFrame
 
 		south.add(partyRow, BorderLayout.WEST);
 		south.add(sellRow, BorderLayout.EAST);
-		partyMemberCombo.addActionListener(e -> updateSouthBarButtons());
+		partyMemberCombo.addActionListener(this::onPartyMemberSelectionChanged);
 		sendCardBtn.addActionListener(this::onSendToPartyClicked);
 		shareDuplicatesBtn.addActionListener(this::onShareDuplicatesClicked);
 		viewPartyMatchesBtn.addActionListener(this::onViewPartyMatchesClicked);
@@ -566,6 +566,7 @@ public final class CollectionAlbumWindow extends JFrame
 	/** Re-applies persisted size before showing (layout during first build can reset early setSize). */
 	void prepareToShow()
 	{
+		sendStatusLabel.setText(" ");
 		applySavedWindowSize();
 	}
 
@@ -1276,6 +1277,12 @@ public final class CollectionAlbumWindow extends JFrame
 	private void onOwnedMultiCopyAlbumPress(int slotIndex, AlbumSlot slot)
 	{
 		enterAlbumVariantView(slot);
+	}
+
+	private void onPartyMemberSelectionChanged(ActionEvent e)
+	{
+		sendStatusLabel.setText(" ");
+		updateSouthBarButtons();
 	}
 
 	private void onSlotSelectionChanged()

--- a/src/main/java/com/osrstcg/ui/collectionalbum/CollectionAlbumWindow.java
+++ b/src/main/java/com/osrstcg/ui/collectionalbum/CollectionAlbumWindow.java
@@ -56,8 +56,6 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.Timer;
 import javax.swing.border.EmptyBorder;
@@ -1368,13 +1366,31 @@ public final class CollectionAlbumWindow extends JFrame
 
 	private void updatePartyDiscoveryButtons()
 	{
-		boolean inParty = partyService.isInParty() && partyService.getLocalMember() != null;
-		shareDuplicatesBtn.setEnabled(inParty);
-		shareDuplicatesBtn.setToolTipText(inParty
-			? "Share your unlocked duplicate card variants with party members."
-			: "Join a RuneLite party first.");
-		viewPartyMatchesBtn.setEnabled(inParty || tradeListShareService.hasRecentPartyLists());
-		viewPartyMatchesBtn.setToolTipText("Show party duplicates that are missing from your collection.");
+		Long selectedMemberId = selectedPartyMemberId();
+		boolean hasSelectedMember = selectedMemberId != null;
+		shareDuplicatesBtn.setEnabled(hasSelectedMember);
+		shareDuplicatesBtn.setToolTipText(hasSelectedMember
+			? "Share your unlocked duplicate card variants with the selected party member."
+			: "Choose a party member first.");
+		viewPartyMatchesBtn.setEnabled(hasSelectedMember);
+		viewPartyMatchesBtn.setToolTipText(hasSelectedMember
+			? "Show selected player's shared duplicates that are missing from your collection."
+			: "Choose a party member first.");
+	}
+
+	private Long selectedPartyMemberId()
+	{
+		int idx = partyMemberCombo.getSelectedIndex();
+		if (idx <= 0 || idx >= partyMemberIds.size())
+		{
+			return null;
+		}
+		Long id = partyMemberIds.get(idx);
+		if (id == null || id == -1L)
+		{
+			return null;
+		}
+		return id;
 	}
 
 	private boolean isChosenInstanceLocked()
@@ -1428,24 +1444,38 @@ public final class CollectionAlbumWindow extends JFrame
 
 	private void onShareDuplicatesClicked(ActionEvent e)
 	{
-		String status = tradeListShareService.shareDuplicateList();
+		Long selectedMemberId = selectedPartyMemberId();
+		if (selectedMemberId == null)
+		{
+			sendStatusLabel.setText("Choose a party member first.");
+			return;
+		}
+		String status = tradeListShareService.shareDuplicateList(selectedMemberId);
 		sendStatusLabel.setText(status);
 		updatePartyDiscoveryButtons();
 	}
 
 	private void onViewPartyMatchesClicked(ActionEvent e)
 	{
-		JTextArea text = new JTextArea(tradeListShareService.buildPartyTradeMatchSummary(), 22, 72);
-		text.setEditable(false);
-		text.setLineWrap(false);
-		text.setFont(FontManager.getRunescapeSmallFont());
-		text.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-		text.setForeground(Color.WHITE);
-		text.setCaretPosition(0);
-
-		JScrollPane scroll = new JScrollPane(text);
-		scroll.setPreferredSize(new Dimension(680, 420));
-		JOptionPane.showMessageDialog(this, scroll, "Party trade matches", JOptionPane.INFORMATION_MESSAGE);
+		Long selectedMemberId = selectedPartyMemberId();
+		if (selectedMemberId == null)
+		{
+			sendStatusLabel.setText("Choose a party member first.");
+			return;
+		}
+		PartyTradeMatchesPanel panel = new PartyTradeMatchesPanel(
+			cardDatabase,
+			imageCacheService,
+			tradeListShareService.matchesForMember(selectedMemberId),
+			tradeListShareService.displayNameForMember(selectedMemberId));
+		try
+		{
+			JOptionPane.showMessageDialog(this, panel, "Party trade matches", JOptionPane.PLAIN_MESSAGE);
+		}
+		finally
+		{
+			panel.stopTimers();
+		}
 		updatePartyDiscoveryButtons();
 	}
 

--- a/src/main/java/com/osrstcg/ui/collectionalbum/CollectionAlbumWindow.java
+++ b/src/main/java/com/osrstcg/ui/collectionalbum/CollectionAlbumWindow.java
@@ -11,6 +11,7 @@ import com.osrstcg.service.CardPartyTransferService;
 import com.osrstcg.service.DuplicateSellCredits;
 import com.osrstcg.service.RarityMath;
 import com.osrstcg.service.TcgStateService;
+import com.osrstcg.service.TcgTradeListShareService;
 import com.osrstcg.service.WikiImageCacheService;
 import com.osrstcg.ui.SharedCardRenderer;
 import com.osrstcg.util.CollectionAlbumWindowSizeUtil;
@@ -55,6 +56,8 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.Timer;
 import javax.swing.border.EmptyBorder;
@@ -91,10 +94,13 @@ public final class CollectionAlbumWindow extends JFrame
 	private final WikiImageCacheService imageCacheService;
 	private final PartyService partyService;
 	private final CardPartyTransferService cardPartyTransferService;
+	private final TcgTradeListShareService tradeListShareService;
 
 	private final List<Long> partyMemberIds = new ArrayList<>();
 	private final JComboBox<String> partyMemberCombo = new JComboBox<>();
 	private final JButton sendCardBtn = new JButton("Send");
+	private final JButton shareDuplicatesBtn = new JButton("Share dupes");
+	private final JButton viewPartyMatchesBtn = new JButton("Party matches");
 	private final JButton sellCardBtn = new JButton("Sell");
 	private final JLabel sendStatusLabel = new JLabel(" ");
 	private final Timer partyUiTimer;
@@ -155,7 +161,8 @@ public final class CollectionAlbumWindow extends JFrame
 		PackCatalog packCatalog,
 		WikiImageCacheService imageCacheService,
 		PartyService partyService,
-		CardPartyTransferService cardPartyTransferService)
+		CardPartyTransferService cardPartyTransferService,
+		TcgTradeListShareService tradeListShareService)
 	{
 		super("OSRS TCG — Collection album");
 		if (WINDOW_ICON != null)
@@ -168,6 +175,7 @@ public final class CollectionAlbumWindow extends JFrame
 		this.imageCacheService = imageCacheService;
 		this.partyService = partyService;
 		this.cardPartyTransferService = cardPartyTransferService;
+		this.tradeListShareService = tradeListShareService;
 		this.grid = new CollectionAlbumGridPanel(imageCacheService,
 			this::onOwnedMultiCopyAlbumPress, this::onAlbumCardLockToggle, this::onSlotSelectionChanged);
 		this.variantsPanel = new CollectionAlbumVariantsPanel(imageCacheService, this::onVariantInstancePicked,
@@ -438,6 +446,14 @@ public final class CollectionAlbumWindow extends JFrame
 		sendCardBtn.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
 		sendCardBtn.setForeground(Color.WHITE);
 		partyRow.add(sendCardBtn);
+		shareDuplicatesBtn.setFocusable(false);
+		shareDuplicatesBtn.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
+		shareDuplicatesBtn.setForeground(Color.WHITE);
+		partyRow.add(shareDuplicatesBtn);
+		viewPartyMatchesBtn.setFocusable(false);
+		viewPartyMatchesBtn.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
+		viewPartyMatchesBtn.setForeground(Color.WHITE);
+		partyRow.add(viewPartyMatchesBtn);
 		partyRow.add(sendStatusLabel);
 
 		JPanel sellRow = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 0));
@@ -452,6 +468,8 @@ public final class CollectionAlbumWindow extends JFrame
 		south.add(sellRow, BorderLayout.EAST);
 		partyMemberCombo.addActionListener(e -> updateSouthBarButtons());
 		sendCardBtn.addActionListener(this::onSendToPartyClicked);
+		shareDuplicatesBtn.addActionListener(this::onShareDuplicatesClicked);
+		viewPartyMatchesBtn.addActionListener(this::onViewPartyMatchesClicked);
 		sellCardBtn.addActionListener(this::onSellSelectedCardClicked);
 		add(south, BorderLayout.SOUTH);
 
@@ -597,6 +615,8 @@ public final class CollectionAlbumWindow extends JFrame
 		variantPagingLabel.setFont(small);
 		variantCardTitleLbl.setFont(FontManager.getRunescapeBoldFont());
 		sendCardBtn.setFont(small);
+		shareDuplicatesBtn.setFont(small);
+		viewPartyMatchesBtn.setFont(small);
 		sellCardBtn.setFont(small);
 		sendStatusLabel.setFont(small);
 	}
@@ -1237,6 +1257,7 @@ public final class CollectionAlbumWindow extends JFrame
 		partyMemberCombo.setEnabled(partyTradeReady);
 		partyMemberCombo.setToolTipText(partyTradeReady ? null : PARTY_SEND_TOOLTIP);
 		sendCardBtn.setToolTipText(partyTradeReady ? null : PARTY_SEND_TOOLTIP);
+		updatePartyDiscoveryButtons();
 
 		if (prevId != null)
 		{
@@ -1303,6 +1324,7 @@ public final class CollectionAlbumWindow extends JFrame
 
 	private void updateSouthBarButtons()
 	{
+		updatePartyDiscoveryButtons();
 		boolean partyReady = partyMemberCombo.isEnabled();
 		int pi = partyMemberCombo.getSelectedIndex();
 		boolean recipientOk = partyReady && pi > 0 && pi < partyMemberIds.size()
@@ -1342,6 +1364,17 @@ public final class CollectionAlbumWindow extends JFrame
 		sellCardBtn.setText("Sell for " + NumberFormatting.format(sellValue));
 		sellCardBtn.setEnabled(true);
 		sellCardBtn.setToolTipText(null);
+	}
+
+	private void updatePartyDiscoveryButtons()
+	{
+		boolean inParty = partyService.isInParty() && partyService.getLocalMember() != null;
+		shareDuplicatesBtn.setEnabled(inParty);
+		shareDuplicatesBtn.setToolTipText(inParty
+			? "Share your unlocked duplicate card variants with party members."
+			: "Join a RuneLite party first.");
+		viewPartyMatchesBtn.setEnabled(inParty || tradeListShareService.hasRecentPartyLists());
+		viewPartyMatchesBtn.setToolTipText("Show party duplicates that are missing from your collection.");
 	}
 
 	private boolean isChosenInstanceLocked()
@@ -1391,6 +1424,29 @@ public final class CollectionAlbumWindow extends JFrame
 	private void onSellSelectedCardClicked(ActionEvent e)
 	{
 		sellSelectedCard();
+	}
+
+	private void onShareDuplicatesClicked(ActionEvent e)
+	{
+		String status = tradeListShareService.shareDuplicateList();
+		sendStatusLabel.setText(status);
+		updatePartyDiscoveryButtons();
+	}
+
+	private void onViewPartyMatchesClicked(ActionEvent e)
+	{
+		JTextArea text = new JTextArea(tradeListShareService.buildPartyTradeMatchSummary(), 22, 72);
+		text.setEditable(false);
+		text.setLineWrap(false);
+		text.setFont(FontManager.getRunescapeSmallFont());
+		text.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		text.setForeground(Color.WHITE);
+		text.setCaretPosition(0);
+
+		JScrollPane scroll = new JScrollPane(text);
+		scroll.setPreferredSize(new Dimension(680, 420));
+		JOptionPane.showMessageDialog(this, scroll, "Party trade matches", JOptionPane.INFORMATION_MESSAGE);
+		updatePartyDiscoveryButtons();
 	}
 
 	private void sellSelectedCard()

--- a/src/main/java/com/osrstcg/ui/collectionalbum/PartyTradeMatchesPanel.java
+++ b/src/main/java/com/osrstcg/ui/collectionalbum/PartyTradeMatchesPanel.java
@@ -59,7 +59,8 @@ final class PartyTradeMatchesPanel extends JPanel
 		statusLabel.setFont(FontManager.getRunescapeSmallFont());
 		statusLabel.setText(statusText(matches));
 		JPanel south = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 4));
-		south.setOpaque(false);
+		south.setOpaque(true);
+		south.setBackground(ColorScheme.DARK_GRAY_COLOR);
 		south.add(statusLabel);
 		add(south, BorderLayout.SOUTH);
 

--- a/src/main/java/com/osrstcg/ui/collectionalbum/PartyTradeMatchesPanel.java
+++ b/src/main/java/com/osrstcg/ui/collectionalbum/PartyTradeMatchesPanel.java
@@ -8,6 +8,7 @@ import com.osrstcg.service.WikiImageCacheService;
 import com.osrstcg.ui.SharedCardRenderer;
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Graphics;
@@ -17,38 +18,85 @@ import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import javax.swing.BoxLayout;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.ScrollPaneConstants;
+import javax.swing.JTextField;
 import javax.swing.Timer;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 
 final class PartyTradeMatchesPanel extends JPanel
 {
+	private static final String RARITY_FILTER_ALL = "All";
+	private static final List<String> RARITY_TIERS_LOW_TO_HIGH = List.of(
+		"Common", "Uncommon", "Rare", "Epic", "Legendary", "Mythic", "Godly");
+
+	private final CardDatabase cardDatabase;
+	private final AlbumRarityTable rarityTable;
+	private final List<TcgTradeListShareService.TradeMatch> allMatches;
 	private final MatchGridPanel grid;
 	private final JLabel statusLabel = new JLabel(" ");
+	private final JTextField searchField = new JTextField(16);
+	private final JComboBox<AlbumSortMode> sortCombo = new JComboBox<>(AlbumSortMode.values());
+	private final JComboBox<String> rarityCombo = new JComboBox<>();
+	private final JCheckBox foilOnlyCheck = new JCheckBox("Foil only");
 	private final Timer imagePollTimer;
 
 	PartyTradeMatchesPanel(CardDatabase cardDatabase, WikiImageCacheService imageCacheService,
 		List<TcgTradeListShareService.TradeMatch> matches, String displayName)
 	{
 		super(new BorderLayout(0, 8));
+		this.cardDatabase = cardDatabase;
+		this.rarityTable = AlbumRarityTable.build(cardDatabase.getCards());
+		this.allMatches = matches == null ? List.of() : List.copyOf(matches);
+
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
 		setPreferredSize(new Dimension(760, 560));
 
 		JLabel title = new JLabel(displayName == null ? "Party trade matches" : displayName);
 		title.setFont(FontManager.getRunescapeBoldFont());
 		title.setForeground(Color.WHITE);
-		JPanel north = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 6));
+		JPanel titleRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 6));
+		titleRow.setOpaque(false);
+		titleRow.add(title);
+
+		JPanel filterRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 2));
+		filterRow.setOpaque(false);
+		JLabel searchLbl = new JLabel("Search:");
+		searchLbl.setForeground(Color.WHITE);
+		filterRow.add(searchLbl);
+		filterRow.add(searchField);
+		JLabel sortLbl = new JLabel("Sort:");
+		sortLbl.setForeground(Color.WHITE);
+		filterRow.add(sortLbl);
+		filterRow.add(sortCombo);
+		JLabel rarityLbl = new JLabel("Rarity:");
+		rarityLbl.setForeground(Color.WHITE);
+		filterRow.add(rarityLbl);
+		filterRow.add(rarityCombo);
+		filterRow.add(foilOnlyCheck);
+
+		JPanel north = new JPanel();
+		north.setLayout(new BoxLayout(north, BoxLayout.Y_AXIS));
 		north.setOpaque(false);
-		north.add(title);
+		titleRow.setAlignmentX(Component.LEFT_ALIGNMENT);
+		filterRow.setAlignmentX(Component.LEFT_ALIGNMENT);
+		north.add(titleRow);
+		north.add(filterRow);
 		add(north, BorderLayout.NORTH);
 
-		grid = new MatchGridPanel(cardDatabase, imageCacheService, matches);
+		grid = new MatchGridPanel(cardDatabase, imageCacheService, List.of());
 		JScrollPane scrollPane = new JScrollPane(grid);
 		scrollPane.getViewport().setBackground(new Color(0x1E1E1E));
 		scrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
@@ -58,7 +106,6 @@ final class PartyTradeMatchesPanel extends JPanel
 
 		statusLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
 		statusLabel.setFont(FontManager.getRunescapeSmallFont());
-		statusLabel.setText(statusText(matches));
 		JPanel south = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 4));
 		south.setOpaque(true);
 		south.setBackground(ColorScheme.DARK_GRAY_COLOR);
@@ -77,6 +124,8 @@ final class PartyTradeMatchesPanel extends JPanel
 				imagePollTimer.stop();
 			}
 		});
+		setupFilters();
+		rebuildModel();
 		if (grid.needsImageLoadRepaint())
 		{
 			imagePollTimer.start();
@@ -88,21 +137,189 @@ final class PartyTradeMatchesPanel extends JPanel
 		imagePollTimer.stop();
 	}
 
-	private static String statusText(List<TcgTradeListShareService.TradeMatch> matches)
+	private void setupFilters()
 	{
-		if (matches == null || matches.isEmpty())
+		searchField.setForeground(Color.WHITE);
+		searchField.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		searchField.getDocument().addDocumentListener(new DocumentListener()
+		{
+			@Override
+			public void insertUpdate(DocumentEvent e)
+			{
+				rebuildModel();
+			}
+
+			@Override
+			public void removeUpdate(DocumentEvent e)
+			{
+				rebuildModel();
+			}
+
+			@Override
+			public void changedUpdate(DocumentEvent e)
+			{
+				rebuildModel();
+			}
+		});
+
+		sortCombo.setForeground(Color.WHITE);
+		sortCombo.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		sortCombo.addActionListener(e -> rebuildModel());
+
+		rarityCombo.addItem(RARITY_FILTER_ALL);
+		for (String tier : RARITY_TIERS_LOW_TO_HIGH)
+		{
+			rarityCombo.addItem(tier);
+		}
+		rarityCombo.setSelectedIndex(0);
+		rarityCombo.setForeground(Color.WHITE);
+		rarityCombo.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		rarityCombo.addActionListener(e -> rebuildModel());
+
+		foilOnlyCheck.setForeground(Color.WHITE);
+		foilOnlyCheck.setOpaque(false);
+		foilOnlyCheck.addActionListener(e -> rebuildModel());
+	}
+
+	private void rebuildModel()
+	{
+		List<TcgTradeListShareService.TradeMatch> working = allMatches.stream()
+			.filter(m -> m != null && m.getCardName() != null && !m.getCardName().trim().isEmpty())
+			.collect(Collectors.toCollection(ArrayList::new));
+
+		String q = searchField.getText().trim().toLowerCase(Locale.ROOT);
+		if (!q.isEmpty())
+		{
+			working.removeIf(m -> !m.getCardName().toLowerCase(Locale.ROOT).contains(q));
+		}
+
+		String rarityPick = (String) rarityCombo.getSelectedItem();
+		if (rarityPick != null && !RARITY_FILTER_ALL.equals(rarityPick))
+		{
+			working.removeIf(m ->
+			{
+				CardDefinition card = cardForName(m.getCardName());
+				return card == null || !rarityPick.equals(rarityTable.tierLabelForCard(card));
+			});
+		}
+
+		if (foilOnlyCheck.isSelected())
+		{
+			working.removeIf(m -> !m.isFoil());
+		}
+
+		sortMatches(working);
+		grid.setMatches(working);
+		statusLabel.setText(statusText(allMatches, working));
+		if (grid.needsImageLoadRepaint())
+		{
+			imagePollTimer.restart();
+		}
+	}
+
+	private void sortMatches(List<TcgTradeListShareService.TradeMatch> matches)
+	{
+		AlbumSortMode mode = (AlbumSortMode) sortCombo.getSelectedItem();
+		if (mode == null)
+		{
+			mode = AlbumSortMode.SCORE_DESC;
+		}
+		Comparator<TcgTradeListShareService.TradeMatch> byName = Comparator.comparing(
+			m -> m.getCardName() == null ? "" : m.getCardName(),
+			String.CASE_INSENSITIVE_ORDER);
+		switch (mode)
+		{
+			case SCORE_DESC:
+				matches.sort(Comparator.<TcgTradeListShareService.TradeMatch>comparingDouble(this::matchScore)
+					.reversed()
+					.thenComparing(byName)
+					.thenComparing(TcgTradeListShareService.TradeMatch::isFoil));
+				break;
+			case RARITY_DESC:
+				matches.sort(Comparator.<TcgTradeListShareService.TradeMatch>comparingInt(
+					m -> tierSortKey(rarityTable.tierLabelForCard(cardForName(m.getCardName()))))
+					.reversed()
+					.thenComparing(byName)
+					.thenComparing(TcgTradeListShareService.TradeMatch::isFoil));
+				break;
+			case NAME_ASC:
+			default:
+				matches.sort(byName.thenComparing(TcgTradeListShareService.TradeMatch::isFoil));
+				break;
+		}
+	}
+
+	private double matchScore(TcgTradeListShareService.TradeMatch match)
+	{
+		CardDefinition card = cardForName(match.getCardName());
+		if (card == null)
+		{
+			return 0.0d;
+		}
+		return match.isFoil() ? RarityMath.foilAdjustedScoreRounded(card) : RarityMath.score(card);
+	}
+
+	private CardDefinition cardForName(String name)
+	{
+		if (name == null || name.trim().isEmpty())
+		{
+			return null;
+		}
+		return cardDatabase.findByName(name).orElse(null);
+	}
+
+	private static String statusText(List<TcgTradeListShareService.TradeMatch> allMatches,
+		List<TcgTradeListShareService.TradeMatch> filteredMatches)
+	{
+		if (allMatches == null || allMatches.isEmpty())
 		{
 			return "No shared duplicates from this player are missing from your collection.";
 		}
-		boolean incompatible = matches.stream().anyMatch(m -> !m.isTransferCompatible());
+		if (filteredMatches == null || filteredMatches.isEmpty())
+		{
+			return "No matches for the current filters.";
+		}
+		boolean incompatible = filteredMatches.stream().anyMatch(m -> !m.isTransferCompatible());
+		String count = filteredMatches.size() == allMatches.size()
+			? String.format(Locale.US, "Showing %d shared duplicate variant%s.",
+				filteredMatches.size(), filteredMatches.size() == 1 ? "" : "s")
+			: String.format(Locale.US, "Showing %d of %d shared duplicate variants.",
+				filteredMatches.size(), allMatches.size());
 		return incompatible
 			? "These matches were shared, but rates/debug do not match for direct sending."
-			: "Showing shared duplicate variants missing from your collection.";
+			: count;
+	}
+
+	private static int tierSortKey(String label)
+	{
+		if (label == null)
+		{
+			return 0;
+		}
+		switch (label)
+		{
+			case "Common":
+				return 0;
+			case "Uncommon":
+				return 1;
+			case "Rare":
+				return 2;
+			case "Epic":
+				return 3;
+			case "Legendary":
+				return 4;
+			case "Mythic":
+				return 5;
+			case "Godly":
+				return 6;
+			default:
+				return 0;
+		}
 	}
 
 	private static final class MatchGridPanel extends JPanel
 	{
-		private static final int COLS = 4;
+		private static final int COLS = 5;
 		private static final int GAP = 12;
 		private static final int CARD_W = 126;
 		private static final int CARD_H = 182;
@@ -110,7 +327,7 @@ final class PartyTradeMatchesPanel extends JPanel
 
 		private final CardDatabase cardDatabase;
 		private final WikiImageCacheService imageCacheService;
-		private final List<TcgTradeListShareService.TradeMatch> matches;
+		private List<TcgTradeListShareService.TradeMatch> matches;
 		private final AlbumRarityTable rarityTable;
 
 		private MatchGridPanel(CardDatabase cardDatabase, WikiImageCacheService imageCacheService,
@@ -124,6 +341,15 @@ final class PartyTradeMatchesPanel extends JPanel
 			setOpaque(true);
 			setPreferredSize(preferredGridSize(this.matches.size()));
 			preloadVisibleArtwork();
+		}
+
+		private void setMatches(List<TcgTradeListShareService.TradeMatch> matches)
+		{
+			this.matches = matches == null ? List.of() : List.copyOf(matches);
+			setPreferredSize(preferredGridSize(this.matches.size()));
+			preloadVisibleArtwork();
+			revalidate();
+			repaint();
 		}
 
 		boolean needsImageLoadRepaint()

--- a/src/main/java/com/osrstcg/ui/collectionalbum/PartyTradeMatchesPanel.java
+++ b/src/main/java/com/osrstcg/ui/collectionalbum/PartyTradeMatchesPanel.java
@@ -14,6 +14,7 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
+import java.awt.Shape;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
@@ -160,6 +161,11 @@ final class PartyTradeMatchesPanel extends JPanel
 			Graphics2D g2 = (Graphics2D) g.create();
 			try
 			{
+				Rectangle visible = getVisibleRect();
+				Shape oldClip = g2.getClip();
+				g2.setClip(visible);
+				g2.setColor(getBackground());
+				g2.fillRect(visible.x, visible.y, visible.width, visible.height);
 				g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 				g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 
@@ -168,28 +174,36 @@ final class PartyTradeMatchesPanel extends JPanel
 					g2.setFont(FontManager.getRunescapeSmallFont());
 					g2.setColor(ColorScheme.LIGHT_GRAY_COLOR);
 					g2.drawString("No matches for the selected party member.", 16, 28);
-					return;
 				}
-
-				for (int i = 0; i < matches.size(); i++)
+				else
 				{
-					TcgTradeListShareService.TradeMatch match = matches.get(i);
-					int col = i % COLS;
-					int row = i / COLS;
-					int x = GAP + col * (CARD_W + GAP);
-					int y = GAP + row * (CARD_H + LABEL_H + GAP);
-					Rectangle cardBounds = new Rectangle(x, y, CARD_W, CARD_H);
-					CardDefinition card = cardForName(match.getCardName());
-					Color rarity = rarityTable.colorForCardName(match.getCardName());
-					BufferedImage art = imageCacheService.getCached(card == null ? null : card.getImageUrl());
-					SharedCardRenderer.drawCardFace(g2, cardBounds, card, match.isFoil(), rarity, art, 0L, match.isFoil());
+					for (int i = 0; i < matches.size(); i++)
+					{
+						TcgTradeListShareService.TradeMatch match = matches.get(i);
+						int col = i % COLS;
+						int row = i / COLS;
+						int x = GAP + col * (CARD_W + GAP);
+						int y = GAP + row * (CARD_H + LABEL_H + GAP);
+						Rectangle slotBounds = new Rectangle(x, y, CARD_W, CARD_H + LABEL_H);
+						if (!slotBounds.intersects(visible))
+						{
+							continue;
+						}
 
-					g2.setFont(FontManager.getRunescapeSmallFont());
-					g2.setColor(match.isTransferCompatible() ? Color.WHITE : new Color(0xE6, 0xA8, 0x4A));
-					String label = label(match);
-					int tx = x + Math.max(0, (CARD_W - g2.getFontMetrics().stringWidth(label)) / 2);
-					g2.drawString(label, tx, y + CARD_H + 18);
+						Rectangle cardBounds = new Rectangle(x, y, CARD_W, CARD_H);
+						CardDefinition card = cardForName(match.getCardName());
+						Color rarity = rarityTable.colorForCardName(match.getCardName());
+						BufferedImage art = imageCacheService.getCached(card == null ? null : card.getImageUrl());
+						SharedCardRenderer.drawCardFace(g2, cardBounds, card, match.isFoil(), rarity, art, 0L, match.isFoil());
+
+						g2.setFont(FontManager.getRunescapeSmallFont());
+						g2.setColor(match.isTransferCompatible() ? Color.WHITE : new Color(0xE6, 0xA8, 0x4A));
+						String label = label(match);
+						int tx = x + Math.max(0, (CARD_W - g2.getFontMetrics().stringWidth(label)) / 2);
+						g2.drawString(label, tx, y + CARD_H + 18);
+					}
 				}
+				g2.setClip(oldClip);
 			}
 			finally
 			{

--- a/src/main/java/com/osrstcg/ui/collectionalbum/PartyTradeMatchesPanel.java
+++ b/src/main/java/com/osrstcg/ui/collectionalbum/PartyTradeMatchesPanel.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.ScrollPaneConstants;
 import javax.swing.Timer;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
@@ -49,6 +50,9 @@ final class PartyTradeMatchesPanel extends JPanel
 		grid = new MatchGridPanel(cardDatabase, imageCacheService, matches);
 		JScrollPane scrollPane = new JScrollPane(grid);
 		scrollPane.getViewport().setBackground(new Color(0x1E1E1E));
+		scrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+		scrollPane.setPreferredSize(MatchGridPanel.viewportSizeForRows(2));
 		add(scrollPane, BorderLayout.CENTER);
 
 		statusLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
@@ -98,9 +102,9 @@ final class PartyTradeMatchesPanel extends JPanel
 	{
 		private static final int COLS = 4;
 		private static final int GAP = 12;
-		private static final int CARD_W = 144;
-		private static final int CARD_H = 208;
-		private static final int LABEL_H = 32;
+		private static final int CARD_W = 126;
+		private static final int CARD_H = 182;
+		private static final int LABEL_H = 28;
 
 		private final CardDatabase cardDatabase;
 		private final WikiImageCacheService imageCacheService;
@@ -210,12 +214,20 @@ final class PartyTradeMatchesPanel extends JPanel
 		{
 			if (count <= 0)
 			{
-				return new Dimension(720, 420);
+				return viewportSizeForRows(2);
 			}
 			int rows = (int) Math.ceil(count / (double) COLS);
 			int width = GAP + COLS * (CARD_W + GAP);
 			int height = GAP + rows * (CARD_H + LABEL_H + GAP);
-			return new Dimension(width, Math.max(420, height));
+			return new Dimension(width, Math.max(viewportSizeForRows(2).height, height));
+		}
+
+		private static Dimension viewportSizeForRows(int rows)
+		{
+			int safeRows = Math.max(1, rows);
+			int width = GAP + COLS * (CARD_W + GAP) + 20;
+			int height = GAP + safeRows * (CARD_H + LABEL_H + GAP);
+			return new Dimension(width, height);
 		}
 	}
 }

--- a/src/main/java/com/osrstcg/ui/collectionalbum/PartyTradeMatchesPanel.java
+++ b/src/main/java/com/osrstcg/ui/collectionalbum/PartyTradeMatchesPanel.java
@@ -1,0 +1,221 @@
+package com.osrstcg.ui.collectionalbum;
+
+import com.osrstcg.data.CardDatabase;
+import com.osrstcg.data.CardDefinition;
+import com.osrstcg.service.RarityMath;
+import com.osrstcg.service.TcgTradeListShareService;
+import com.osrstcg.service.WikiImageCacheService;
+import com.osrstcg.ui.SharedCardRenderer;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.Timer;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.FontManager;
+
+final class PartyTradeMatchesPanel extends JPanel
+{
+	private final MatchGridPanel grid;
+	private final JLabel statusLabel = new JLabel(" ");
+	private final Timer imagePollTimer;
+
+	PartyTradeMatchesPanel(CardDatabase cardDatabase, WikiImageCacheService imageCacheService,
+		List<TcgTradeListShareService.TradeMatch> matches, String displayName)
+	{
+		super(new BorderLayout(0, 8));
+		setBackground(ColorScheme.DARK_GRAY_COLOR);
+		setPreferredSize(new Dimension(760, 560));
+
+		JLabel title = new JLabel(displayName == null ? "Party trade matches" : displayName);
+		title.setFont(FontManager.getRunescapeBoldFont());
+		title.setForeground(Color.WHITE);
+		JPanel north = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 6));
+		north.setOpaque(false);
+		north.add(title);
+		add(north, BorderLayout.NORTH);
+
+		grid = new MatchGridPanel(cardDatabase, imageCacheService, matches);
+		JScrollPane scrollPane = new JScrollPane(grid);
+		scrollPane.getViewport().setBackground(new Color(0x1E1E1E));
+		add(scrollPane, BorderLayout.CENTER);
+
+		statusLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+		statusLabel.setFont(FontManager.getRunescapeSmallFont());
+		statusLabel.setText(statusText(matches));
+		JPanel south = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 4));
+		south.setOpaque(false);
+		south.add(statusLabel);
+		add(south, BorderLayout.SOUTH);
+
+		imagePollTimer = new Timer(250, null);
+		imagePollTimer.addActionListener(e ->
+		{
+			if (grid.needsImageLoadRepaint())
+			{
+				grid.repaint();
+			}
+			else
+			{
+				imagePollTimer.stop();
+			}
+		});
+		if (grid.needsImageLoadRepaint())
+		{
+			imagePollTimer.start();
+		}
+	}
+
+	void stopTimers()
+	{
+		imagePollTimer.stop();
+	}
+
+	private static String statusText(List<TcgTradeListShareService.TradeMatch> matches)
+	{
+		if (matches == null || matches.isEmpty())
+		{
+			return "No shared duplicates from this player are missing from your collection.";
+		}
+		boolean incompatible = matches.stream().anyMatch(m -> !m.isTransferCompatible());
+		return incompatible
+			? "These matches were shared, but rates/debug do not match for direct sending."
+			: "Showing shared duplicate variants missing from your collection.";
+	}
+
+	private static final class MatchGridPanel extends JPanel
+	{
+		private static final int COLS = 4;
+		private static final int GAP = 12;
+		private static final int CARD_W = 144;
+		private static final int CARD_H = 208;
+		private static final int LABEL_H = 32;
+
+		private final CardDatabase cardDatabase;
+		private final WikiImageCacheService imageCacheService;
+		private final List<TcgTradeListShareService.TradeMatch> matches;
+		private final AlbumRarityTable rarityTable;
+
+		private MatchGridPanel(CardDatabase cardDatabase, WikiImageCacheService imageCacheService,
+			List<TcgTradeListShareService.TradeMatch> matches)
+		{
+			this.cardDatabase = cardDatabase;
+			this.imageCacheService = imageCacheService;
+			this.matches = matches == null ? List.of() : List.copyOf(matches);
+			this.rarityTable = AlbumRarityTable.build(cardDatabase.getCards());
+			setBackground(new Color(0x1E1E1E));
+			setOpaque(true);
+			setPreferredSize(preferredGridSize(this.matches.size()));
+			preloadVisibleArtwork();
+		}
+
+		boolean needsImageLoadRepaint()
+		{
+			for (TcgTradeListShareService.TradeMatch match : matches)
+			{
+				CardDefinition card = cardForName(match.getCardName());
+				String url = card == null ? null : card.getImageUrl();
+				if (url != null && !url.trim().isEmpty() && imageCacheService.needsLoad(url))
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
+		private void preloadVisibleArtwork()
+		{
+			List<String> urls = new ArrayList<>();
+			for (TcgTradeListShareService.TradeMatch match : matches)
+			{
+				CardDefinition card = cardForName(match.getCardName());
+				if (card != null && card.getImageUrl() != null && !card.getImageUrl().trim().isEmpty())
+				{
+					urls.add(card.getImageUrl());
+				}
+			}
+			imageCacheService.preload(urls);
+		}
+
+		@Override
+		protected void paintComponent(Graphics g)
+		{
+			super.paintComponent(g);
+			Graphics2D g2 = (Graphics2D) g.create();
+			try
+			{
+				g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+				g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+
+				if (matches.isEmpty())
+				{
+					g2.setFont(FontManager.getRunescapeSmallFont());
+					g2.setColor(ColorScheme.LIGHT_GRAY_COLOR);
+					g2.drawString("No matches for the selected party member.", 16, 28);
+					return;
+				}
+
+				for (int i = 0; i < matches.size(); i++)
+				{
+					TcgTradeListShareService.TradeMatch match = matches.get(i);
+					int col = i % COLS;
+					int row = i / COLS;
+					int x = GAP + col * (CARD_W + GAP);
+					int y = GAP + row * (CARD_H + LABEL_H + GAP);
+					Rectangle cardBounds = new Rectangle(x, y, CARD_W, CARD_H);
+					CardDefinition card = cardForName(match.getCardName());
+					Color rarity = rarityTable.colorForCardName(match.getCardName());
+					BufferedImage art = imageCacheService.getCached(card == null ? null : card.getImageUrl());
+					SharedCardRenderer.drawCardFace(g2, cardBounds, card, match.isFoil(), rarity, art, 0L, match.isFoil());
+
+					g2.setFont(FontManager.getRunescapeSmallFont());
+					g2.setColor(match.isTransferCompatible() ? Color.WHITE : new Color(0xE6, 0xA8, 0x4A));
+					String label = label(match);
+					int tx = x + Math.max(0, (CARD_W - g2.getFontMetrics().stringWidth(label)) / 2);
+					g2.drawString(label, tx, y + CARD_H + 18);
+				}
+			}
+			finally
+			{
+				g2.dispose();
+			}
+		}
+
+		private CardDefinition cardForName(String name)
+		{
+			if (name == null || name.trim().isEmpty())
+			{
+				return null;
+			}
+			return cardDatabase.findByName(name).orElse(null);
+		}
+
+		private static String label(TcgTradeListShareService.TradeMatch match)
+		{
+			return String.format("%d available%s", match.getAvailable(), match.isFoil() ? " foil" : "");
+		}
+
+		private static Dimension preferredGridSize(int count)
+		{
+			if (count <= 0)
+			{
+				return new Dimension(720, 420);
+			}
+			int rows = (int) Math.ceil(count / (double) COLS);
+			int width = GAP + COLS * (CARD_W + GAP);
+			int height = GAP + rows * (CARD_H + LABEL_H + GAP);
+			return new Dimension(width, Math.max(420, height));
+		}
+	}
+}


### PR DESCRIPTION
Hi! I wanted to contribute a small quality-of-life feature for players trading OSRS TCG cards through RuneLite Party.

This PR adds an opt-in duplicate match discovery flow. The goal is not to replace the existing card send system or add a full trade window, but to help two party members see which duplicate cards may be useful to send manually.

A player can select a party member in the collection album, click `Share dupes`, and send only their unlocked duplicate card variant counts. The selected recipient can then click `Party matches` to see which of those shared duplicates are missing from their own collection.

I tried to keep this close to the plugin's existing patterns:

- Uses RuneLite Party messages like the existing party/card features.
- Reuses `CollectionState` / `OwnedCardInstance` for collection data.
- Reuses existing card rendering, image cache, rarity table, and album sort mode.
- Does not expose the full collection.
- Does not send instance IDs.
- Does not move cards automatically.
- Keeps received lists in memory only, with a short 15 minute cache.

I also added a visual match dialog with search, sort, rarity, and foil-only filters so the feature stays useful with larger collections.

I tested this manually with two RuneLite clients/accounts in the same party, sharing duplicate lists in both directions, and also ran:

.\gradlew.bat test

No worries if this does not match the direction you want for the plugin, I mainly wanted to share the idea in a way that fits the existing one-way send flow.