### PR TITLE
Award Tombs of Amascut completion credits at parity with CoX

### DIFF
--- a/src/main/java/com/osrstcg/service/GameMessageCreditTracker.java
+++ b/src/main/java/com/osrstcg/service/GameMessageCreditTracker.java
@@ -25,6 +25,17 @@ public final class GameMessageCreditTracker
 	private static final long CHAMBERS_OF_XERIC_COMPLETION_CREDITS = 12_500L;
 	private static final String CHAMBERS_OF_XERIC_COMPLETION_PREFIX = "Your completed Chambers of Xeric count is:";
 
+	private static final long TOMBS_OF_AMASCUT_EXPERT_MODE_COMPLETION_CREDITS = 18_500L;
+	private static final String TOMBS_OF_AMASCUT_EXPERT_MODE_COMPLETION_PREFIX =
+		"Your completed Tombs of Amascut: Expert Mode count is:";
+
+	private static final long TOMBS_OF_AMASCUT_ENTRY_MODE_COMPLETION_CREDITS = 3_500L;
+	private static final String TOMBS_OF_AMASCUT_ENTRY_MODE_COMPLETION_PREFIX =
+		"Your completed Tombs of Amascut: Entry Mode count is:";
+
+	private static final long TOMBS_OF_AMASCUT_COMPLETION_CREDITS = 12_500L;
+	private static final String TOMBS_OF_AMASCUT_COMPLETION_PREFIX = "Your completed Tombs of Amascut count is:";
+
 	private static final long GAUNTLET_COMPLETION_CREDITS = 1_750L;
 	private static final String GAUNTLET_COMPLETION_PREFIX = "Your Gauntlet completion count is:";
 
@@ -78,6 +89,18 @@ public final class GameMessageCreditTracker
 			CHAMBERS_OF_XERIC_COMPLETION_PREFIX,
 			CHAMBERS_OF_XERIC_COMPLETION_CREDITS,
 			"Chambers of Xeric completion"));
+		rules.add(CreditRule.prefix(
+			TOMBS_OF_AMASCUT_EXPERT_MODE_COMPLETION_PREFIX,
+			TOMBS_OF_AMASCUT_EXPERT_MODE_COMPLETION_CREDITS,
+			"Tombs of Amascut Expert Mode completion"));
+		rules.add(CreditRule.prefix(
+			TOMBS_OF_AMASCUT_ENTRY_MODE_COMPLETION_PREFIX,
+			TOMBS_OF_AMASCUT_ENTRY_MODE_COMPLETION_CREDITS,
+			"Tombs of Amascut Entry Mode completion"));
+		rules.add(CreditRule.prefix(
+			TOMBS_OF_AMASCUT_COMPLETION_PREFIX,
+			TOMBS_OF_AMASCUT_COMPLETION_CREDITS,
+			"Tombs of Amascut completion"));
 		rules.add(CreditRule.prefix(
 			GAUNTLET_COMPLETION_PREFIX,
 			GAUNTLET_COMPLETION_CREDITS,

--- a/src/main/java/com/osrstcg/service/NpcKillCreditTracker.java
+++ b/src/main/java/com/osrstcg/service/NpcKillCreditTracker.java
@@ -48,6 +48,7 @@ public final class NpcKillCreditTracker
 		NpcExclusionRule.npcIds(ExcludedNpcIds.AMOXLIATL_UNSTABLE_ICE),
 		NpcExclusionRule.npcIds(ExcludedNpcIds.CRACKED_ICE),
 		NpcExclusionRule.npcIds(ExcludedNpcIds.GREAT_OLM),
+		NpcExclusionRule.npcIds(ExcludedNpcIds.TOA_WARDENS),
 		NpcExclusionRule.exactName("The Nightmare"),
 		NpcExclusionRule.exactName("Phosani's Nightmare"),
 		NpcExclusionRule.npcIds(ExcludedNpcIds.THE_NIGHTMARE),
@@ -275,6 +276,11 @@ public final class NpcKillCreditTracker
 
 		/** Great Olm — head and claws, normal and challenge mode (kill credits via {@link GameMessageCreditTracker}). */
 		static final Set<Integer> GREAT_OLM = Set.of(7550, 7551, 7552, 7553, 7554, 7555);
+
+		/** Tombs of Amascut Wardens fight — both Wardens, all phases, and the Obelisk (kill credits via {@link GameMessageCreditTracker}). */
+		static final Set<Integer> TOA_WARDENS = Set.of(
+			11746, 11747, 11748, 11749, 11750, 11751, 11752, 11753,
+			11754, 11755, 11756, 11757, 11758, 11759, 11760);
 
 		/** The Nightmare — minions and non-kill phases (kill credits via {@link GameMessageCreditTracker}). */
 		static final Set<Integer> THE_NIGHTMARE = Set.of(

--- a/src/main/java/com/osrstcg/service/NpcKillCreditTracker.java
+++ b/src/main/java/com/osrstcg/service/NpcKillCreditTracker.java
@@ -32,7 +32,6 @@ public final class NpcKillCreditTracker
 	/** Boss display name -> NPC ids that count as the real kill (final phase only). */
 	private static final Map<String, Set<Integer>> FINAL_PHASE_IDS = Map.ofEntries(
 		Map.entry("Kalphite Queen", Set.of(965)),
-		Map.entry("Kephri", Set.of(11722)),
 		Map.entry("Verzik Vitur", Set.of(10832, 8371, 10849))
 	);
 
@@ -48,7 +47,7 @@ public final class NpcKillCreditTracker
 		NpcExclusionRule.npcIds(ExcludedNpcIds.AMOXLIATL_UNSTABLE_ICE),
 		NpcExclusionRule.npcIds(ExcludedNpcIds.CRACKED_ICE),
 		NpcExclusionRule.npcIds(ExcludedNpcIds.GREAT_OLM),
-		NpcExclusionRule.npcIds(ExcludedNpcIds.TOA_WARDENS),
+		NpcExclusionRule.npcIds(ExcludedNpcIds.TOMBS_OF_AMASCUT),
 		NpcExclusionRule.exactName("The Nightmare"),
 		NpcExclusionRule.exactName("Phosani's Nightmare"),
 		NpcExclusionRule.npcIds(ExcludedNpcIds.THE_NIGHTMARE),
@@ -277,10 +276,18 @@ public final class NpcKillCreditTracker
 		/** Great Olm — head and claws, normal and challenge mode (kill credits via {@link GameMessageCreditTracker}). */
 		static final Set<Integer> GREAT_OLM = Set.of(7550, 7551, 7552, 7553, 7554, 7555);
 
-		/** Tombs of Amascut Wardens fight — both Wardens, all phases, and the Obelisk (kill credits via {@link GameMessageCreditTracker}). */
-		static final Set<Integer> TOA_WARDENS = Set.of(
-			11746, 11747, 11748, 11749, 11750, 11751, 11752, 11753,
-			11754, 11755, 11756, 11757, 11758, 11759, 11760);
+		/**
+		 * Tombs of Amascut — every NPC inside the raid (kill credits via {@link GameMessageCreditTracker}).
+		 * The raid's NPCs occupy the contiguous gameval id block TOA_SCABARAS_SCARAB (11697) through
+		 * AKKHA_SHADOW_ENRAGE_DUMMY (11799): path monsters and baboons, Kephri and her scarabs, Zebak and
+		 * his jugs/tail, all Warden phases including phase 3 and the cores, Ba-Ba with her boulders and
+		 * rubble, and Akkha with his Shadows. ToA ids outside this block are all non-combat (cutscene
+		 * models, lobby NPCs, pets, Akkha trail orbs).
+		 */
+		static final Set<Integer> TOMBS_OF_AMASCUT = java.util.stream.IntStream
+			.rangeClosed(11697, 11799)
+			.boxed()
+			.collect(java.util.stream.Collectors.toUnmodifiableSet());
 
 		/** The Nightmare — minions and non-kill phases (kill credits via {@link GameMessageCreditTracker}). */
 		static final Set<Integer> THE_NIGHTMARE = Set.of(


### PR DESCRIPTION
Adds ToA support — completion points match CoX.

- Tombs of Amascut: 12,500
- Tombs of Amascut: Expert Mode: 18,500
- Tombs of Amascut: Entry Mode: 3,500

All raid monsters are excluded from per-kill credits (same as Olm — the completion message pays instead). The raid occupies one contiguous block in RuneLite's gameval NpcID:

- [11697–11799 (all rooms and paths)](https://github.com/runelite/runelite/blob/b33a991783926b2d51e009f6f0d63df592e0d131/runelite-api/src/main/java/net/runelite/api/gameval/NpcID.java#L50583-L51065)

ToA ids outside this block are all non-combat (cutscene models, lobby NPCs, pets, trail orbs).