### PR TITLE
Configurable Dink section

### DIFF
--- a/src/main/java/com/osrstcg/OsrsTcgConfig.java
+++ b/src/main/java/com/osrstcg/OsrsTcgConfig.java
@@ -1,5 +1,6 @@
 package com.osrstcg;
 
+import com.osrstcg.model.DinkNotificationTrigger;
 import com.osrstcg.model.PullNotifyTier;
 import java.awt.Color;
 import net.runelite.client.config.Config;
@@ -193,23 +194,11 @@ public interface OsrsTcgConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "dinkNotifications",
-		name = "Dink",
-		description = "Also send pull alerts to Discord via Dink.",
-		section = pullNotificationsSection,
-		position = 5
-	)
-	default boolean dinkNotifications()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "pullWebhookUrl",
 		name = "Webhook URL",
 		description = "Discord webhook for pull alerts. Leave empty to disable.",
 		section = pullNotificationsSection,
-		position = 6
+		position = 5
 	)
 	default String pullWebhookUrl()
 	{
@@ -217,9 +206,88 @@ public interface OsrsTcgConfig extends Config
 	}
 
 	@ConfigSection(
+		name = "Dink",
+		description = "Send OSRS TCG notifications through Dink.",
+		position = 20
+	)
+	String dinkSection = "dink";
+
+	@ConfigItem(
+		keyName = "dinkNotifications",
+		name = "Enable Dink Notifications",
+		description = "Send notable pull alerts to Discord via Dink.",
+		section = dinkSection,
+		position = 0
+	)
+	default boolean dinkNotifications()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "dinkNotificationTrigger",
+		name = "Trigger notification",
+		description = "Send Dink notifications as each card is revealed or after the whole pack is revealed.",
+		section = dinkSection,
+		position = 1
+	)
+	default DinkNotificationTrigger dinkNotificationTrigger()
+	{
+		return DinkNotificationTrigger.EVERY_CARD;
+	}
+
+	@ConfigItem(
+		keyName = "dinkNewCardNotifyTier",
+		name = "New card rank threshold",
+		description = "Minimum card rank for new-card Dink notifications.",
+		section = dinkSection,
+		position = 2
+	)
+	default PullNotifyTier dinkNewCardNotifyTier()
+	{
+		return PullNotifyTier.MYTHIC;
+	}
+
+	@ConfigItem(
+		keyName = "dinkNotifyDuplicates",
+		name = "Notify duplicate cards",
+		description = "Send Dink notifications for duplicate cards at or above the selected rank threshold.",
+		section = dinkSection,
+		position = 3
+	)
+	default boolean dinkNotifyDuplicates()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "dinkDuplicateNotifyTier",
+		name = "Duplicate rank threshold",
+		description = "Minimum card rank for duplicate Dink notifications.",
+		section = dinkSection,
+		position = 4
+	)
+	default PullNotifyTier dinkDuplicateNotifyTier()
+	{
+		return PullNotifyTier.MYTHIC;
+	}
+
+	@ConfigItem(
+		keyName = "dinkAlwaysNotifyFoils",
+		name = "Always notify foils",
+		description = "Notify for foils regardless of rank. When disabled, foils must meet the relevant rank threshold.",
+		section = dinkSection,
+		position = 5
+	)
+	default boolean dinkAlwaysNotifyFoils()
+	{
+		return true;
+	}
+
+	@ConfigSection(
 		name = "Web album",
 		description = "Share your collection online via osrs-tcg.xyz.",
-		position = 20
+		position = 30
 	)
 	String webAlbumSection = "webAlbum";
 

--- a/src/main/java/com/osrstcg/model/DinkNotificationTrigger.java
+++ b/src/main/java/com/osrstcg/model/DinkNotificationTrigger.java
@@ -1,0 +1,20 @@
+package com.osrstcg.model;
+
+public enum DinkNotificationTrigger
+{
+	EVERY_CARD("Every card"),
+	AT_END("At end");
+
+	private final String label;
+
+	DinkNotificationTrigger(String label)
+	{
+		this.label = label;
+	}
+
+	@Override
+	public String toString()
+	{
+		return label;
+	}
+}

--- a/src/main/java/com/osrstcg/service/DinkNotificationService.java
+++ b/src/main/java/com/osrstcg/service/DinkNotificationService.java
@@ -3,7 +3,9 @@ package com.osrstcg.service;
 import com.osrstcg.data.CardDatabase;
 import com.osrstcg.data.CardDefinition;
 import com.osrstcg.util.PullNotificationMessages;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -19,6 +21,22 @@ import net.runelite.client.events.PluginMessage;
 @Singleton
 public class DinkNotificationService
 {
+	static final class PackPull
+	{
+		private final String cardName;
+		private final boolean newForCollection;
+		private final boolean foil;
+		private final RarityMath.Tier tier;
+
+		PackPull(String cardName, boolean newForCollection, boolean foil, RarityMath.Tier tier)
+		{
+			this.cardName = cardName;
+			this.newForCollection = newForCollection;
+			this.foil = foil;
+			this.tier = tier;
+		}
+	}
+
 	private static final String DINK_NAMESPACE = "dink";
 	private static final String DINK_NOTIFY = "notify";
 	private static final String SOURCE_PLUGIN = "OSRS TCG";
@@ -83,6 +101,55 @@ public class DinkNotificationService
 		catch (Exception ex)
 		{
 			log.debug("Failed to post Dink notification", ex);
+		}
+	}
+
+	void notifyPackSummary(List<PackPull> pulls)
+	{
+		if (pulls == null || pulls.isEmpty())
+		{
+			return;
+		}
+		List<String> newCards = new ArrayList<>();
+		List<String> duplicates = new ArrayList<>();
+		for (PackPull pull : pulls)
+		{
+			if (pull == null || pull.cardName == null || pull.cardName.trim().isEmpty())
+			{
+				continue;
+			}
+			String displayName = pull.cardName.trim() + (pull.foil ? " (foil)" : "");
+			(pull.newForCollection ? newCards : duplicates).add(displayName);
+		}
+		if (newCards.isEmpty() && duplicates.isEmpty())
+		{
+			return;
+		}
+
+		PackPull thumbnailPull = pulls.get(0);
+		String imageUrl = thumbnailPull == null ? "" : resolveCardImageUrl(thumbnailPull.cardName);
+		Map<String, Object> data = new HashMap<>();
+		data.put("sourcePlugin", SOURCE_PLUGIN);
+		data.put("text", messageWithStatsLine(PullNotificationMessages.dinkPackSummaryMessage(newCards, duplicates)));
+		data.put("title", EMBED_TITLE);
+		data.put("imageRequested", true);
+		if (!imageUrl.isEmpty())
+		{
+			data.put("thumbnail", imageUrl);
+		}
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put("notificationType", "packSummary");
+		metadata.put("newCards", new ArrayList<>(newCards));
+		metadata.put("duplicates", new ArrayList<>(duplicates));
+		data.put("metadata", metadata);
+
+		try
+		{
+			eventBus.post(new PluginMessage(DINK_NAMESPACE, DINK_NOTIFY, data));
+		}
+		catch (Exception ex)
+		{
+			log.debug("Failed to post Dink pack summary", ex);
 		}
 	}
 

--- a/src/main/java/com/osrstcg/service/PackRevealService.java
+++ b/src/main/java/com/osrstcg/service/PackRevealService.java
@@ -158,6 +158,7 @@ public class PackRevealService
 	private List<RevealCard> cards = List.of();
 	private int revealedCount;
 	private boolean[] revealedByIndex = new boolean[0];
+	private boolean dinkEndNotificationsSent;
 	private long phaseStartedAt;
 	private int cardPoolSize;
 	private final Map<String, RarityMath.Tier> rarityTierByCardName = new HashMap<>();
@@ -265,6 +266,7 @@ public class PackRevealService
 			.collect(Collectors.toList()));
 		this.revealedCount = 0;
 		this.revealedByIndex = new boolean[this.cards.size()];
+		this.dinkEndNotificationsSent = false;
 		this.phaseStartedAt = 0L;
 		this.phase = cards.isEmpty() ? Phase.IDLE : Phase.PACK_READY;
 	}
@@ -311,13 +313,11 @@ public class PackRevealService
 				{
 					packRevealSoundService.playMythicReveal();
 				}
-				if (pullNotificationService.shouldNotify(clicked.getTier(), isFoilPull(clicked), clicked.isNew()))
-				{
-					pullNotificationService.notifyPull(
-						cardNameForParty(clicked), clicked.isNew(), isFoilPull(clicked), clicked.getTier());
-				}
+				pullNotificationService.notifyPull(
+					cardNameForParty(clicked), clicked.isNew(), isFoilPull(clicked), clicked.getTier());
 				if (revealedCount >= cards.size())
 				{
+					notifyDinkAtEndOnce();
 					phase = Phase.WAIT_CLOSE;
 					phaseStartedAt = System.currentTimeMillis();
 				}
@@ -395,6 +395,7 @@ public class PackRevealService
 		{
 			revealedByIndex[i] = true;
 		}
+		notifyDinkAtEndOnce();
 		phase = Phase.WAIT_CLOSE;
 		phaseStartedAt = System.currentTimeMillis();
 	}
@@ -414,6 +415,7 @@ public class PackRevealService
 		}
 		else if (phase == Phase.CARD_REVEAL && allRevealSlotsFaceUp())
 		{
+			notifyDinkAtEndOnce();
 			phase = Phase.WAIT_CLOSE;
 			phaseStartedAt = System.currentTimeMillis();
 		}
@@ -552,6 +554,7 @@ public class PackRevealService
 		cards = List.of();
 		revealedCount = 0;
 		revealedByIndex = new boolean[0];
+		dinkEndNotificationsSent = false;
 		phaseStartedAt = 0L;
 		cardPoolSize = 0;
 		boosterDisplayName = "";
@@ -682,12 +685,19 @@ public class PackRevealService
 				continue;
 			}
 			RevealCard card = cards.get(i);
-			if (pullNotificationService.shouldNotify(card.getTier(), isFoilPull(card), card.isNew()))
-			{
-				pullNotificationService.notifyPull(
-					cardNameForParty(card), card.isNew(), isFoilPull(card), card.getTier());
-			}
+			pullNotificationService.notifyPull(
+				cardNameForParty(card), card.isNew(), isFoilPull(card), card.getTier());
 		}
+	}
+
+	private void notifyDinkAtEndOnce()
+	{
+		if (dinkEndNotificationsSent)
+		{
+			return;
+		}
+		dinkEndNotificationsSent = true;
+		pullNotificationService.notifyDinkAtEnd(cards);
 	}
 
 	/**

--- a/src/main/java/com/osrstcg/service/PullNotificationService.java
+++ b/src/main/java/com/osrstcg/service/PullNotificationService.java
@@ -2,10 +2,13 @@ package com.osrstcg.service;
 
 import com.osrstcg.OsrsTcgConfig;
 import com.osrstcg.data.CardDatabase;
+import com.osrstcg.model.DinkNotificationTrigger;
 import com.osrstcg.model.PullNotifyTier;
 import com.osrstcg.party.TcgPullPartyMessage;
 import com.osrstcg.util.TcgPluginGameMessages;
 import java.awt.Color;
+import java.util.ArrayList;
+import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
@@ -71,22 +74,31 @@ public class PullNotificationService
 
 	public void notifyPull(String cardName, boolean newForCollection, boolean foil, RarityMath.Tier tier)
 	{
-		if (cardName == null || cardName.trim().isEmpty() || !shouldNotify(tier, foil, newForCollection))
+		if (cardName == null || cardName.trim().isEmpty())
 		{
 			return;
 		}
 		String trimmed = cardName.trim();
-		Color rarity = cardDatabase.chatRarityColorForCardName(trimmed);
-		String formatted = TcgPluginGameMessages.formatPrefixedYouAddedCollection(trimmed, newForCollection, foil, rarity);
-		String plain = TcgPluginGameMessages.plainPrefixedYouAddedCollection(trimmed, newForCollection, foil);
-		TcgPluginGameMessages.queueFormattedGameMessage(chatMessageManager, formatted, plain);
+		boolean standardNotification = shouldNotify(tier, foil, newForCollection);
+		if (standardNotification)
+		{
+			Color rarity = cardDatabase.chatRarityColorForCardName(trimmed);
+			String formatted = TcgPluginGameMessages.formatPrefixedYouAddedCollection(trimmed, newForCollection, foil, rarity);
+			String plain = TcgPluginGameMessages.plainPrefixedYouAddedCollection(trimmed, newForCollection, foil);
+			TcgPluginGameMessages.queueFormattedGameMessage(chatMessageManager, formatted, plain);
+		}
 
-		if (config.dinkNotifications())
+		if (config.dinkNotifications() && dinkTrigger() == DinkNotificationTrigger.EVERY_CARD
+			&& shouldNotifyDink(tier, foil, newForCollection))
 		{
 			dinkNotificationService.notifyPackPull(trimmed, newForCollection, foil, tier);
 		}
 
-		pullWebhookNotificationService.notifyPackPull(trimmed, newForCollection, foil, tier);
+		if (standardNotification)
+		{
+			pullWebhookNotificationService.notifyPackPull(trimmed, newForCollection, foil, tier);
+			notifyParty(trimmed, newForCollection, foil);
+		}
 		log.debug(
 			"Pull notification dispatched for '{}' (foil={}, new={}, tier={}, dink={}, webhookConfigured={})",
 			trimmed,
@@ -96,12 +108,16 @@ public class PullNotificationService
 			config.dinkNotifications(),
 			isWebhookConfigured());
 
+	}
+
+	private void notifyParty(String cardName, boolean newForCollection, boolean foil)
+	{
 		if (config.partyAnnounceMythicPulls() && partyService.isInParty())
 		{
 			try
 			{
 				TcgPullPartyMessage message = new TcgPullPartyMessage();
-				message.setCardName(trimmed);
+				message.setCardName(cardName);
 				message.setNewForCollection(newForCollection);
 				message.setFoil(foil);
 				partyService.send(message);
@@ -111,6 +127,54 @@ public class PullNotificationService
 				log.debug("Could not send party pull message", ex);
 			}
 		}
+	}
+
+	public void notifyDinkAtEnd(List<PackRevealService.RevealCard> cards)
+	{
+		if (!config.dinkNotifications() || dinkTrigger() != DinkNotificationTrigger.AT_END
+			|| cards == null || cards.isEmpty())
+		{
+			return;
+		}
+		List<DinkNotificationService.PackPull> eligiblePulls = new ArrayList<>();
+		for (PackRevealService.RevealCard card : cards)
+		{
+			if (card == null || card.getPull() == null || card.getPull().getCardName() == null
+				|| !shouldNotifyDink(card.getTier(), card.getPull().isFoil(), card.isNew()))
+			{
+				continue;
+			}
+			eligiblePulls.add(new DinkNotificationService.PackPull(
+				card.getPull().getCardName().trim(), card.isNew(), card.getPull().isFoil(), card.getTier()));
+		}
+		dinkNotificationService.notifyPackSummary(eligiblePulls);
+	}
+
+	private boolean shouldNotifyDink(RarityMath.Tier tier, boolean foil, boolean newForCollection)
+	{
+		if (!newForCollection && !config.dinkNotifyDuplicates())
+		{
+			return false;
+		}
+		if (foil && config.dinkAlwaysNotifyFoils())
+		{
+			return true;
+		}
+		if (tier == null)
+		{
+			return false;
+		}
+		PullNotifyTier minimum = newForCollection
+			? config.dinkNewCardNotifyTier()
+			: config.dinkDuplicateNotifyTier();
+		RarityMath.Tier floor = minimum == null ? RarityMath.Tier.MYTHIC : minimum.toRarityTier();
+		return tier.ordinal() >= floor.ordinal();
+	}
+
+	private DinkNotificationTrigger dinkTrigger()
+	{
+		DinkNotificationTrigger trigger = config.dinkNotificationTrigger();
+		return trigger == null ? DinkNotificationTrigger.EVERY_CARD : trigger;
 	}
 
 	private boolean isWebhookConfigured()

--- a/src/main/java/com/osrstcg/util/PullNotificationMessages.java
+++ b/src/main/java/com/osrstcg/util/PullNotificationMessages.java
@@ -1,5 +1,7 @@
 package com.osrstcg.util;
 
+import java.util.List;
+
 public final class PullNotificationMessages
 {
 	private PullNotificationMessages()
@@ -18,5 +20,30 @@ public final class PullNotificationMessages
 	public static String dinkCollectionMessage(String cardName, boolean newForCollection, boolean foil)
 	{
 		return collectionMessage("%USERNAME%", cardName, newForCollection, foil);
+	}
+
+	public static String dinkPackSummaryMessage(List<String> newCards, List<String> duplicates)
+	{
+		return "%USERNAME% opened a booster pack!\n\n"
+			+ "**New cards**\n" + markdownCardList(newCards) + "\n\n"
+			+ "**Duplicates**\n" + markdownCardList(duplicates);
+	}
+
+	private static String markdownCardList(List<String> cards)
+	{
+		if (cards == null || cards.isEmpty())
+		{
+			return "- None";
+		}
+		StringBuilder result = new StringBuilder();
+		for (String card : cards)
+		{
+			if (result.length() > 0)
+			{
+				result.append('\n');
+			}
+			result.append("- ").append(card);
+		}
+		return result.toString();
 	}
 }


### PR DESCRIPTION
Following on from my suggestion in Discord, I have created a fork, made some changes and tested the logic.

I have separated Dink configuration into its own section, the configuration is as below:

- Ability to enable or disable Dink notifcations
- Ability to select when the notifcation is triggered, can be either 'every card' or 'at end'
- Ability to select new card threshold in which it will notify
- Ability to enable or disable notification of duplicate cards (obviously these will be still included in the screenshot but not in the rich embed notification)
- Ability to always notify of foils regardless of card rank

Open to any suggestions or tweaks.