### PR TITLE
Adding Rarity Accessability Text

### DIFF
--- a/src/main/java/com/osrstcg/OsrsTcgConfig.java
+++ b/src/main/java/com/osrstcg/OsrsTcgConfig.java
@@ -78,6 +78,19 @@ public interface OsrsTcgConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "packRarityText",
+		name = "Rarity Text",
+		description = "Show the rarity name above unflipped pack cards on hover. Helps colour blind users "
+			+ "tell rarities apart without relying on the highlight colour.",
+		section = generalSection,
+		position = 5
+	)
+	default boolean packRarityText()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "enableFileBackups",
 		name = "Backups",
 		description = "Keep up to 50 file backups under .runelite/OSRS-TCG/backups. "
@@ -85,7 +98,7 @@ public interface OsrsTcgConfig extends Config
 			+ "Preferred on load when newer than the profile configuration timestamp; "
 			+ "also used when profile configuration saves fail to load.",
 		section = generalSection,
-		position = 5
+		position = 6
 	)
 	default boolean enableFileBackups()
 	{
@@ -97,7 +110,7 @@ public interface OsrsTcgConfig extends Config
 		name = "Safe-mode",
 		description = "Block opening packs while in combat.",
 		section = generalSection,
-		position = 6
+		position = 7
 	)
 	default boolean safeMode()
 	{
@@ -109,7 +122,7 @@ public interface OsrsTcgConfig extends Config
 		name = "Chat prefix colour",
 		description = "Colour of the [OSRS TCG] chat tag.",
 		section = generalSection,
-		position = 7
+		position = 8
 	)
 	default Color chatPrefixColor()
 	{
@@ -121,7 +134,7 @@ public interface OsrsTcgConfig extends Config
 		name = "Debug messages",
 		description = "Show extra plugin details in chat.",
 		section = generalSection,
-		position = 8
+		position = 9
 	)
 	default boolean debugMessages()
 	{

--- a/src/main/java/com/osrstcg/overlay/PackRevealOverlay.java
+++ b/src/main/java/com/osrstcg/overlay/PackRevealOverlay.java
@@ -268,6 +268,10 @@ public class PackRevealOverlay extends Overlay
 			else
 			{
 				SharedCardRenderer.drawCardBack(graphics, r, card.getPull().isFoil(), card.getRarityColor());
+				if (config.packRarityText() && lift > 0.001d)
+				{
+					drawRarityLabel(graphics, r, card.getTier().getLabel(), card.getRarityColor(), (float) lift);
+				}
 			}
 		}
 
@@ -1031,6 +1035,32 @@ public class PackRevealOverlay extends Overlay
 			g2.setColor(new Color(0, 0, 0, 180));
 			g2.drawString(text, textX + 1, textY + 1);
 			g2.setColor(new Color(0xF2C94C));
+			g2.drawString(text, textX, textY);
+		}
+		finally
+		{
+			g2.dispose();
+		}
+	}
+
+	private void drawRarityLabel(Graphics2D g, Rectangle cardBounds, String text, Color color, float alpha)
+	{
+		float clampedAlpha = Math.max(0f, Math.min(1f, alpha));
+		if (text == null || clampedAlpha <= 0.01f)
+		{
+			return;
+		}
+
+		Graphics2D g2 = (Graphics2D) g.create();
+		try
+		{
+			g2.setFont(FontManager.getRunescapeBoldFont());
+			int textX = cardBounds.x + (cardBounds.width / 2) - (g2.getFontMetrics().stringWidth(text) / 2);
+			int textY = Math.max(14, cardBounds.y - 8);
+
+			g2.setColor(withAlpha(Color.BLACK, clampedAlpha * (180f / 255f)));
+			g2.drawString(text, textX + 1, textY + 1);
+			g2.setColor(withAlpha(color == null ? Color.WHITE : color, clampedAlpha));
 			g2.drawString(text, textX, textY);
 		}
 		finally


### PR DESCRIPTION
Had some users concerned over not being able to see the rarity hover colour due to colour blindess, or other eyesight issues. Decided on having a config item for showing the tier of the card on hover as well, controllable by a toggle defaulted to on.

Sorry for horrendous resolution - recorded on 4k and compressed to fit.

<img width="1000" height="800" alt="pack-rarity" src="https://github.com/user-attachments/assets/ea11a9ed-4e0b-4df9-990d-71310190458e" />
