### PR TITLE
Award flat credits for TzKal-Zuk and TzTok-Jad

### DIFF
--- a/src/main/java/com/osrstcg/service/GameMessageCreditTracker.java
+++ b/src/main/java/com/osrstcg/service/GameMessageCreditTracker.java
@@ -55,6 +55,12 @@ public final class GameMessageCreditTracker
 	private static final long CORRUPTED_GAUNTLET_COMPLETION_CREDITS = 4_500L;
 	private static final String CORRUPTED_GAUNTLET_COMPLETION_PREFIX = "Your Corrupted Gauntlet completion count is:";
 
+	private static final long TZKAL_ZUK_KILL_CREDITS = 25_000L;
+	private static final String TZKAL_ZUK_KILL_PREFIX = "Your TzKal-Zuk kill count is:";
+
+	private static final long TZTOK_JAD_KILL_CREDITS = 10_000L;
+	private static final String TZTOK_JAD_KILL_PREFIX = "Your TzTok-Jad kill count is:";
+
 	private static final long ALCHEMICAL_HYDRA_KILL_CREDITS = 426L;
 	private static final String ALCHEMICAL_HYDRA_KILL_PREFIX = "Your Alchemical Hydra kill count is:";
 
@@ -142,6 +148,14 @@ public final class GameMessageCreditTracker
 			CORRUPTED_GAUNTLET_COMPLETION_PREFIX,
 			CORRUPTED_GAUNTLET_COMPLETION_CREDITS,
 			"Corrupted Gauntlet completion"));
+		rules.add(CreditRule.prefix(
+			TZKAL_ZUK_KILL_PREFIX,
+			TZKAL_ZUK_KILL_CREDITS,
+			"TzKal-Zuk kill"));
+		rules.add(CreditRule.prefix(
+			TZTOK_JAD_KILL_PREFIX,
+			TZTOK_JAD_KILL_CREDITS,
+			"TzTok-Jad kill"));
 		rules.add(CreditRule.prefix(
 			ALCHEMICAL_HYDRA_KILL_PREFIX,
 			ALCHEMICAL_HYDRA_KILL_CREDITS,

--- a/src/main/java/com/osrstcg/service/NpcKillCreditTracker.java
+++ b/src/main/java/com/osrstcg/service/NpcKillCreditTracker.java
@@ -46,6 +46,8 @@ public final class NpcKillCreditTracker
 		NpcExclusionRule.npcIds(ExcludedNpcIds.AMOXLIATL_UNSTABLE_ICE),
 		NpcExclusionRule.npcIds(ExcludedNpcIds.CRACKED_ICE),
 		NpcExclusionRule.npcIds(ExcludedNpcIds.GREAT_OLM),
+		NpcExclusionRule.npcIds(ExcludedNpcIds.TZHAAR_FIGHT_CAVE),
+		NpcExclusionRule.npcIds(ExcludedNpcIds.INFERNO),
 		NpcExclusionRule.npcIds(ExcludedNpcIds.THEATRE_OF_BLOOD),
 		NpcExclusionRule.npcIds(ExcludedNpcIds.TOMBS_OF_AMASCUT),
 		NpcExclusionRule.exactName("The Nightmare"),
@@ -275,6 +277,41 @@ public final class NpcKillCreditTracker
 
 		/** Great Olm — head and claws, normal and challenge mode (kill credits via {@link GameMessageCreditTracker}). */
 		static final Set<Integer> GREAT_OLM = Set.of(7550, 7551, 7552, 7553, 7554, 7555);
+
+		/**
+		 * TzHaar Fight Cave — TzTok-Jad and the wave monsters (credits via {@link GameMessageCreditTracker}).
+		 * The completion is paid flat from the TzTok-Jad kill-count message, so the whole cave is excluded from
+		 * per-kill. The TzHaar-Ket-Rak's Challenge Jad (6506) is not included: it does not fire that message and
+		 * keeps paying per kill.
+		 */
+		static final Set<Integer> TZHAAR_FIGHT_CAVE = Set.of(
+			3116, 3117,  // Tz-Kih
+			3118, 3119,  // Tz-Kek
+			3120,        // Tz-Kek (split)
+			3121, 3122,  // Tok-Xil
+			3123, 3124,  // Yt-MejKot
+			3125, 3126,  // Ket-Zek
+			3127,        // TzTok-Jad
+			3128);       // Yt-HurKot (Jad healer)
+
+		/**
+		 * The Inferno — TzKal-Zuk and the wave monsters (credits via {@link GameMessageCreditTracker}). The
+		 * completion is paid flat from the TzKal-Zuk kill-count message, so the whole encounter is excluded from
+		 * per-kill. Non-combat ids in the same range (7690 master, 7707/7709/7710 safespot markers) are omitted.
+		 */
+		static final Set<Integer> INFERNO = Set.of(
+			7691,        // Jal-Nib (nibbler)
+			7692,        // Jal-MejRah (bat)
+			7693,        // Jal-Ak (blob)
+			7694, 7695, 7696,  // Jal-AkRek-Mej / -Xil / -Ket (blob splits)
+			7697,        // Jal-ImKot (meleer)
+			7698,        // Jal-Xil (ranger)
+			7699,        // Jal-Zek (mager)
+			7700, 7701,  // JalTok-Jad and its healer
+			7702, 7703,  // Jal-Xil / Jal-Zek (final wave)
+			7704, 7705,  // JalTok-Jad and its healer (final wave)
+			7706,        // TzKal-Zuk
+			7708);       // Jal-MejJak (Zuk healer)
 
 		/**
 		 * Theatre of Blood — every NPC inside the raid, all difficulty modes (kill credits via


### PR DESCRIPTION
Adds Fight Caves (TzTok-Jad) and Inferno (TzKal-Zuk) support.

- TzTok-Jad: 10,000
- TzKal-Zuk: 25,000

Both bosses already die via ActorDeath with a combat level, so today they pay only combat-scaled per-kill credit, which undervalues the completion. This pays a flat amount from the kill-count message instead — same pattern as Alchemical Hydra, Abyssal Sire, etc. — and excludes the whole encounter from per-kill so it does not double-pay. The excluded ids (RuneLite's gameval NpcID):

- [TzHaar Fight Cave 3116–3128](https://github.com/runelite/runelite/blob/b33a991783926b2d51e009f6f0d63df592e0d131/runelite-api/src/main/java/net/runelite/api/gameval/NpcID.java#L14707-L14767)
- [Inferno 7690–7710](https://github.com/runelite/runelite/blob/b33a991783926b2d51e009f6f0d63df592e0d131/runelite-api/src/main/java/net/runelite/api/gameval/NpcID.java#L35064-L35164) (combat monsters only; the safespot/marker ids in the block are omitted)

The TzHaar-Ket-Rak's Challenge Jad (6506) does not fire the kill-count message and stays creditable.