### PR TITLE
Adding Runlite Native Notification to Config and to Shop Notification

### DIFF
--- a/src/main/java/com/osrstcg/OsrsTcgConfig.java
+++ b/src/main/java/com/osrstcg/OsrsTcgConfig.java
@@ -55,11 +55,23 @@ public interface OsrsTcgConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "runeliteNotifications",
+		name = "Runelite notifications",
+		description = "Enable certain notifications to be sent through Runelite's default notification service as well.",
+		section = generalSection,
+		position = 3
+	)
+	default boolean runeliteNotifications()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "enableSounds",
 		name = "Enable pack opening sounds",
 		description = "Play sounds when opening packs.",
 		section = generalSection,
-		position = 3
+		position = 4
 	)
 	default boolean enableSounds()
 	{
@@ -71,7 +83,7 @@ public interface OsrsTcgConfig extends Config
 		name = "Enable transfer sound",
 		description = "Play a sound when a card trade finishes.",
 		section = generalSection,
-		position = 4
+		position = 5
 	)
 	default boolean enableTransferSound()
 	{
@@ -83,7 +95,7 @@ public interface OsrsTcgConfig extends Config
 		name = "Rarity Highlight",
 		description = "Show rarity when hovering unflipped pack cards.",
 		section = generalSection,
-		position = 5
+		position = 6
 	)
 	default boolean packRarityHighlight()
 	{
@@ -96,7 +108,7 @@ public interface OsrsTcgConfig extends Config
 		description = "Show the rarity name above unflipped pack cards on hover. Helps colour blind users "
 			+ "tell rarities apart without relying on the highlight colour.",
 		section = generalSection,
-		position = 6
+		position = 7
 	)
 	default boolean packRarityText()
 	{
@@ -108,7 +120,7 @@ public interface OsrsTcgConfig extends Config
 		name = "Safe-mode",
 		description = "Block opening packs while in combat.",
 		section = generalSection,
-		position = 7
+		position = 8
 	)
 	default boolean safeMode()
 	{
@@ -120,7 +132,7 @@ public interface OsrsTcgConfig extends Config
 		name = "Chat prefix colour",
 		description = "Colour of the [OSRS TCG] chat tag.",
 		section = generalSection,
-		position = 8
+		position = 9
 	)
 	default Color chatPrefixColor()
 	{
@@ -132,7 +144,7 @@ public interface OsrsTcgConfig extends Config
 		name = "Debug messages",
 		description = "Show extra plugin details in chat.",
 		section = generalSection,
-		position = 9
+		position = 10
 	)
 	default boolean debugMessages()
 	{

--- a/src/main/java/com/osrstcg/service/ShopNotificationService.java
+++ b/src/main/java/com/osrstcg/service/ShopNotificationService.java
@@ -9,6 +9,7 @@ import java.util.Comparator;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import net.runelite.client.Notifier;
 import net.runelite.client.chat.ChatMessageManager;
 
 /**
@@ -21,18 +22,21 @@ public class ShopNotificationService
 	private final PackCatalog packCatalog;
 	private final TcgStateService stateService;
 	private final ChatMessageManager chatMessageManager;
+	private final Notifier notifier;
 
 	@Inject
 	ShopNotificationService(
 		OsrsTcgConfig config,
 		PackCatalog packCatalog,
 		TcgStateService stateService,
-		ChatMessageManager chatMessageManager)
+		ChatMessageManager chatMessageManager,
+		Notifier notifier)
 	{
 		this.config = config;
 		this.packCatalog = packCatalog;
 		this.stateService = stateService;
 		this.chatMessageManager = chatMessageManager;
+		this.notifier = notifier;
 	}
 
 	public void onCreditsIncreased(long creditsBefore, long creditsAfter)
@@ -62,9 +66,13 @@ public class ShopNotificationService
 				continue;
 			}
 
-			TcgPluginGameMessages.queuePrefixedGameMessage(
-				chatMessageManager,
-				"You have enough credits to purchase " + packDisplayName(booster) + "!");
+			String message = "You have enough credits to purchase " + packDisplayName(booster) + "!";
+			TcgPluginGameMessages.queuePrefixedGameMessage(chatMessageManager, message);
+
+			if (config.runeliteNotifications())
+			{
+				notifier.notify(message);
+			}
 		}
 	}
 


### PR DESCRIPTION
There was a request to add default Runelite notifications for the Shop notificaition, so they can get a toast or taskbar blinking or whatever they have setup with Runelite when a pack is ready, for example if they are AFKing a skill.

I don't want to have to create one of these configs for _every_ notification that someone wants going to Runelite, so I created a blanket Runelite Notification config item to turn them on for _every_ Runelite supported notification.

Currently, I only am using the Shop one since every other notification would be in-game (ripping packs). Could maybe add them to the Trade notifications as well, but I mean they most likely will be active in game anyways.

Let me know your thoughts on if you want to keep this, or just default the shop one to always go through Runelite without the config item.