### PR TITLE
Adding duplicate keep version and tier

### DIFF
--- a/src/main/java/com/osrstcg/OsrsTcgConfig.java
+++ b/src/main/java/com/osrstcg/OsrsTcgConfig.java
@@ -1,6 +1,8 @@
 package com.osrstcg;
 
 import com.osrstcg.model.DinkNotificationTrigger;
+import com.osrstcg.model.DuplicateKeepTier;
+import com.osrstcg.model.DuplicateKeepVersion;
 import com.osrstcg.model.PullNotifyTier;
 import java.awt.Color;
 import net.runelite.client.config.Config;
@@ -137,6 +139,37 @@ public interface OsrsTcgConfig extends Config
 	default boolean debugMessages()
 	{
 		return false;
+	}
+
+	@ConfigSection(
+		name = "Duplicates",
+		description = "Duplicates settings.",
+		position = 1
+	)
+	String duplicateSection = "duplicate";
+
+	@ConfigItem(
+		keyName = "keepTier",
+		name = "Keep tier",
+		description = "Keep duplicates for this rarity and higher.",
+		section = duplicateSection,
+		position = 0
+	)
+	default DuplicateKeepTier keepTier()
+	{
+		return DuplicateKeepTier.NONE;
+	}
+	
+	@ConfigItem(
+		keyName = "keepVersion",
+		name = "Keep version",
+		description = "Keep either the newest card or the oldest card of the duplicates.",
+		section = duplicateSection,
+		position = 1
+	)
+	default DuplicateKeepVersion keepVersion()
+	{
+		return DuplicateKeepVersion.NEWEST;
 	}
 
 	@ConfigSection(

--- a/src/main/java/com/osrstcg/data/CardDatabase.java
+++ b/src/main/java/com/osrstcg/data/CardDatabase.java
@@ -38,6 +38,8 @@ public class CardDatabase
 	private Map<String, Color> chatRarityColorByLowerCaseName = Map.of();
 	/** Exact card-name keys; display tier colours (same as collection album / pack reveal). */
 	private Map<String, Color> displayRarityColorByCardName = Map.of();
+	/** Exact card-name keys; display tiers (same as collection album / pack reveal). */
+	private Map<String, RarityMath.Tier> displayTierByCardName = Map.of();
 
 	@Inject
 	public CardDatabase(Gson gson)
@@ -128,12 +130,22 @@ public class CardDatabase
 		return displayRarityColorByCardName;
 	}
 
+	/**
+	 * Precomputed display tiers keyed by exact card name (built once with {@link #load()}).
+	 * Safe to reuse across album opens without re-running {@link RarityMath#displayTierByCardName(List)}.
+	 */
+	public synchronized Map<String, RarityMath.Tier> displayTiersByCardName()
+	{
+		return displayTierByCardName;
+	}
+
 	private void rebuildChatRarityColorIndex()
 	{
 		if (cards.isEmpty())
 		{
 			chatRarityColorByLowerCaseName = Map.of();
 			displayRarityColorByCardName = Map.of();
+			displayTierByCardName = Map.of();
 			return;
 		}
 		List<CardDefinition> all = new ArrayList<>(cards);
@@ -156,6 +168,7 @@ public class CardDatabase
 		}
 		chatRarityColorByLowerCaseName = Collections.unmodifiableMap(chatMap);
 		displayRarityColorByCardName = Collections.unmodifiableMap(displayMap);
+		displayTierByCardName = Collections.unmodifiableMap(tierByName);
 	}
 
 	private List<CardDefinition> loadFromClasspath()

--- a/src/main/java/com/osrstcg/model/DuplicateKeepTier.java
+++ b/src/main/java/com/osrstcg/model/DuplicateKeepTier.java
@@ -2,7 +2,6 @@ package com.osrstcg.model;
 
 import com.osrstcg.service.RarityMath;
 
-/** Minimum display tier for pack-pull chat / Dink notifications (this tier and higher). */
 public enum DuplicateKeepTier
 {
     NONE(null),
@@ -29,7 +28,7 @@ public enum DuplicateKeepTier
 	public String displayLabel()
 	{
         if(tier == null) return "None";
-        
+
 		return tier.getLabel();
 	}
 

--- a/src/main/java/com/osrstcg/model/DuplicateKeepTier.java
+++ b/src/main/java/com/osrstcg/model/DuplicateKeepTier.java
@@ -1,0 +1,41 @@
+package com.osrstcg.model;
+
+import com.osrstcg.service.RarityMath;
+
+/** Minimum display tier for pack-pull chat / Dink notifications (this tier and higher). */
+public enum DuplicateKeepTier
+{
+    NONE(null),
+	COMMON(RarityMath.Tier.COMMON),
+	UNCOMMON(RarityMath.Tier.UNCOMMON),
+	RARE(RarityMath.Tier.RARE),
+	EPIC(RarityMath.Tier.EPIC),
+	LEGENDARY(RarityMath.Tier.LEGENDARY),
+	MYTHIC(RarityMath.Tier.MYTHIC),
+	GODLY(RarityMath.Tier.GODLY);
+
+	private final RarityMath.Tier tier;
+
+	DuplicateKeepTier(RarityMath.Tier tier)
+	{
+		this.tier = tier;
+	}
+
+	public RarityMath.Tier toRarityTier()
+	{
+		return tier;
+	}
+
+	public String displayLabel()
+	{
+        if(tier == null) return "None";
+        
+		return tier.getLabel();
+	}
+
+	@Override
+	public String toString()
+	{
+		return displayLabel();
+	}
+}

--- a/src/main/java/com/osrstcg/model/DuplicateKeepVersion.java
+++ b/src/main/java/com/osrstcg/model/DuplicateKeepVersion.java
@@ -1,0 +1,20 @@
+package com.osrstcg.model;
+
+public enum DuplicateKeepVersion
+{
+	OLDEST("Oldest"),
+	NEWEST("Newest");
+
+	private final String label;
+
+	DuplicateKeepVersion(String label)
+	{
+		this.label = label;
+	}
+
+	@Override
+	public String toString()
+	{
+		return label;
+	}
+}

--- a/src/main/java/com/osrstcg/service/DuplicateSellPlanner.java
+++ b/src/main/java/com/osrstcg/service/DuplicateSellPlanner.java
@@ -1,7 +1,10 @@
 package com.osrstcg.service;
 
 import com.osrstcg.data.CardDefinition;
+import com.osrstcg.model.DuplicateKeepTier;
+import com.osrstcg.model.DuplicateKeepVersion;
 import com.osrstcg.model.OwnedCardInstance;
+import com.osrstcg.model.PullNotifyTier;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -45,12 +48,14 @@ public final class DuplicateSellPlanner
 	{
 	}
 
-	public static boolean hasSellableDuplicates(List<OwnedCardInstance> all)
+	public static boolean hasSellableDuplicates(List<OwnedCardInstance> all, DuplicateKeepVersion keepVersion,
+		Function<String, RarityMath.Tier> tierForName, DuplicateKeepTier keepTier)
 	{
-		return plan(all, name -> null).getCardsSold() > 0;
+		return plan(all, name -> null, keepVersion, tierForName, keepTier).getCardsSold() > 0;
 	}
 
-	public static Result plan(List<OwnedCardInstance> all, Function<String, CardDefinition> cardDefForName)
+	public static Result plan(List<OwnedCardInstance> all, Function<String, CardDefinition> cardDefForName,
+		DuplicateKeepVersion keepVersion, Function<String, RarityMath.Tier> tierForName, DuplicateKeepTier keepTier)
 	{
 		if (all == null || all.isEmpty())
 		{
@@ -76,6 +81,13 @@ public final class DuplicateSellPlanner
 			String name = entry.getKey();
 			List<OwnedCardInstance> lst = entry.getValue();
 			if (lst.size() <= 1)
+			{
+				kept.addAll(lst);
+				continue;
+			}
+
+			RarityMath.Tier tier = tierForName == null ? null : tierForName.apply(name);
+			if (keepTier != null && keepTier.toRarityTier() != null && (tier == null || tier.ordinal() >= keepTier.toRarityTier().ordinal()))
 			{
 				kept.addAll(lst);
 				continue;
@@ -119,7 +131,7 @@ public final class DuplicateSellPlanner
 			{
 				if (!unlockedFoils.isEmpty())
 				{
-					OwnedCardInstance keeper = newest(unlockedFoils);
+					OwnedCardInstance keeper = keeper(unlockedFoils, keepVersion);
 					kept.add(keeper);
 					for (OwnedCardInstance inst : unlockedFoils)
 					{
@@ -138,7 +150,7 @@ public final class DuplicateSellPlanner
 			}
 			else if (!unlockedNormals.isEmpty())
 			{
-				OwnedCardInstance keeper = newest(unlockedNormals);
+				OwnedCardInstance keeper = keeper(unlockedNormals, keepVersion);
 				kept.add(keeper);
 				for (OwnedCardInstance inst : unlockedNormals)
 				{
@@ -154,10 +166,22 @@ public final class DuplicateSellPlanner
 		return new Result(kept, creditsToAdd, cardsSold);
 	}
 
+	private static OwnedCardInstance keeper(List<OwnedCardInstance> list, DuplicateKeepVersion keepVersion)
+	{
+		return keepVersion == DuplicateKeepVersion.OLDEST ? oldest(list) : newest(list);
+	}
+
 	private static OwnedCardInstance newest(List<OwnedCardInstance> list)
 	{
 		return list.stream()
 			.max(Comparator.comparingLong(OwnedCardInstance::getPulledAtEpochMs))
+			.orElse(list.get(0));
+	}
+	
+	private static OwnedCardInstance oldest(List<OwnedCardInstance> list)
+	{
+		return list.stream()
+			.min(Comparator.comparingLong(OwnedCardInstance::getPulledAtEpochMs))
 			.orElse(list.get(0));
 	}
 }

--- a/src/main/java/com/osrstcg/ui/TcgPanel.java
+++ b/src/main/java/com/osrstcg/ui/TcgPanel.java
@@ -2070,7 +2070,8 @@ public class TcgPanel extends PluginPanel
 	private void updateSellDuplicatesButtonState()
 	{
 		List<OwnedCardInstance> instances = stateService.getState().getCollectionState().getOwnedInstances();
-		boolean hasDuplicates = DuplicateSellPlanner.hasSellableDuplicates(instances);
+		boolean hasDuplicates = DuplicateSellPlanner.hasSellableDuplicates(instances, config.keepVersion(),
+			cardDatabase.displayTiersByCardName()::get, config.keepTier());
 		sellDuplicatesButton.setEnabled(hasDuplicates);
 		sellDuplicatesButton.setToolTipText(hasDuplicates ? null : "No duplicate cards to sell.");
 	}
@@ -2085,7 +2086,8 @@ public class TcgPanel extends PluginPanel
 			return;
 		}
 
-		DuplicateSellPlanner.Result plan = DuplicateSellPlanner.plan(all, this::cardDefinitionForName);
+		DuplicateSellPlanner.Result plan = DuplicateSellPlanner.plan(all, this::cardDefinitionForName, config.keepVersion(),
+			cardDatabase.displayTiersByCardName()::get, config.keepTier());
 		int cardsSold = plan.getCardsSold();
 		long creditsToAdd = plan.getCreditsToAdd();
 


### PR DESCRIPTION
Added the following
- Config section: Duplicates
- Keep tier -> don't sell duplicates of this tier or higher
- Keep version -> keep either the oldest or newest duplicate
then the logic to support both.

Tested both, I have a vid of the keep tier but too big to toss up here. So I uploaded to imgur: https://imgur.com/a/o8VF5k0