### PR TITLE
Restore the newest disk save when profile config is stale

### DIFF
--- a/src/main/java/com/osrstcg/persist/TcgStateStore.java
+++ b/src/main/java/com/osrstcg/persist/TcgStateStore.java
@@ -52,6 +52,15 @@ public class TcgStateStore
 			{
 				log.info("OSRS TCG state has no integrity hash yet; it will be written on next checkpoint.");
 			}
+
+			TcgStateLoadResult newerDisk = newerDiskState(config.state);
+			if (newerDisk != null)
+			{
+				log.warn("OSRS TCG profile configuration is stale (saved {}); restoring newer disk save (saved {}).",
+					config.state.getProfileSavedAtUnix(), newerDisk.getState().getProfileSavedAtUnix());
+				return newerDisk;
+			}
+
 			return new TcgStateLoadResult(config.state, TcgStateLoadSource.CONFIG);
 		}
 
@@ -82,6 +91,39 @@ public class TcgStateStore
 		}
 
 		return new TcgStateLoadResult(TcgState.empty(), TcgStateLoadSource.EMPTY, configFailed, configFailed);
+	}
+
+	/**
+	 * Returns the freshest on-disk state when its {@code profileSavedAtUnix} is strictly
+	 * newer than the config state's, or null when config is current or has no timestamp.
+	 */
+	private TcgStateLoadResult newerDiskState(TcgState configState)
+	{
+		if (fileBackupStore == null || configState.getProfileSavedAtUnix() <= 0)
+		{
+			return null;
+		}
+
+		TcgState best = null;
+		TcgStateLoadSource source = null;
+		long bestSavedAt = configState.getProfileSavedAtUnix();
+
+		Optional<TcgState> master = fileBackupStore.loadMaster();
+		if (master.isPresent() && master.get().getProfileSavedAtUnix() > bestSavedAt)
+		{
+			best = master.get();
+			source = TcgStateLoadSource.DISK;
+			bestSavedAt = best.getProfileSavedAtUnix();
+		}
+
+		Optional<TcgState> snapshot = fileBackupStore.loadMostRecentSnapshot();
+		if (snapshot.isPresent() && snapshot.get().getProfileSavedAtUnix() > bestSavedAt)
+		{
+			best = snapshot.get();
+			source = TcgStateLoadSource.DISK_SNAPSHOT;
+		}
+
+		return best == null ? null : new TcgStateLoadResult(best, source);
 	}
 
 	public Optional<TcgState> loadMaster()
@@ -306,15 +348,26 @@ public class TcgStateStore
 				: tryLoadConfig(STATE_BACKUP_KEY, STATE_BACKUP_HASH_KEY);
 			if (backup.outcome == LoadOutcome.SUCCESS)
 			{
-				String json = stateCodec.toJson(backup.state);
+				TcgState seed = backup.state;
+				Optional<TcgState> newestSnapshot = fileBackupStore.loadMostRecentSnapshot();
+				if (newestSnapshot.isPresent()
+					&& seed.getProfileSavedAtUnix() > 0
+					&& newestSnapshot.get().getProfileSavedAtUnix() > seed.getProfileSavedAtUnix())
+				{
+					log.warn("OSRS TCG migration: newest disk snapshot (saved {}) is newer than profile configuration (saved {}); seeding tcg.save from the snapshot.",
+						newestSnapshot.get().getProfileSavedAtUnix(), seed.getProfileSavedAtUnix());
+					seed = newestSnapshot.get();
+				}
+
+				String json = stateCodec.toJson(seed);
 				String stored = TcgStateStorageEncoding.encode(json);
 				if (!stored.isEmpty())
 				{
-					int cardCount = backup.state.getCollectionState().getOwnedInstances().size();
-					long credits = backup.state.getEconomyState().getCredits();
+					int cardCount = seed.getCollectionState().getOwnedInstances().size();
+					long credits = seed.getEconomyState().getCredits();
 					fileBackupStore.writeMaster(stored, cardCount, credits, TcgSaveTrigger.MIGRATION);
 					fileBackupStore.writeSnapshot(stored, cardCount, credits, TcgSaveTrigger.MIGRATION);
-					log.info("OSRS TCG seeded disk saves from profile configuration during migration.");
+					log.info("OSRS TCG seeded disk saves during migration.");
 				}
 			}
 		}

--- a/src/test/java/com/osrstcg/persist/TcgStateMigrationTest.java
+++ b/src/test/java/com/osrstcg/persist/TcgStateMigrationTest.java
@@ -226,6 +226,37 @@ public class TcgStateMigrationTest
 		Assert.assertEquals(777L, result.getState().getEconomyState().getCredits());
 	}
 
+	@Test
+	public void staleConfigDoesNotShadowStrictlyNewerDiskSave()
+	{
+		// Config is only written on logout/shutdown/unload, so it can lag hours behind
+		// the throttled disk snapshots; the newer disk state must win on load.
+		putEncodedConfig(SCHEMA_5_JSON); // profileSavedAtUnix = 1700000100
+
+		String newer = "{"
+			+ "\"schemaVersion\":6,\"credits\":999,\"openedPacks\":9,"
+			+ "\"cardEntries\":["
+			+ "{\"cardName\":\"Abyssal whip\",\"variants\":[{\"pulledBy\":\"P\",\"pulledAt\":1}]},"
+			+ "{\"cardName\":\"Dragon dagger\",\"variants\":[{\"pulledBy\":\"P\",\"pulledAt\":2}]}"
+			+ "],"
+			+ "\"totalCreditsGained\":999,"
+			+ "\"profileCreatedAtUnix\":1700000000,"
+			+ "\"profileSavedAtUnix\":1700040000,"
+			+ "\"skillCreditBaseline\":{\"skillXp\":{},\"uncreditedXp\":0}"
+			+ "}";
+		diskStore.writeSnapshot(TcgStateStorageEncoding.encode(newer), 2, 999L, TcgSaveTrigger.LOGOUT);
+
+		TcgStateLoadResult result = store.load();
+
+		Assert.assertNotEquals(TcgStateLoadSource.CONFIG, result.getSource());
+		Assert.assertEquals(999L, result.getState().getEconomyState().getCredits());
+		Assert.assertEquals(2, result.getState().getCollectionState().getOwnedInstances().size());
+
+		// The migration seed must also come from the freshest source, not the stale config.
+		TcgState master = diskStore.loadMaster().orElseThrow();
+		Assert.assertEquals(999L, master.getEconomyState().getCredits());
+	}
+
 	private void putEncodedConfig(String plainJson)
 	{
 		String blob = TcgStateStorageEncoding.encode(plainJson);


### PR DESCRIPTION
Fixes #68 — the migration seeded `tcg.save` from a stale RSProfile config and `load()` kept returning it, rolling the collection back ~190 cards while the newer snapshots sat on disk (the reporter's `MIGRATION` entry matches their `2026-07-23T11:56` snapshot exactly).

The window looks still open on main: collection changes only write `tcg.save` (`saveMasterOnly`), config waits for logout/shutdown/unload, and `load()` prefers config with no freshness check — so a force-killed session should roll back on relaunch. I haven't verified that in-game; the regression test covers the artifact shape.

- `load()`: if a disk save's own `profileSavedAtUnix` is strictly newer than the config state's, restore it instead — warn log, and the existing "Restored progress from a disk snapshot" chat message surfaces it in-game
- migration: seed `tcg.save` from the freshest of config vs newest snapshot instead of config unconditionally
- states without a saved-at timestamp keep config-first behavior unchanged

Nothing is deleted at load time — a stale config just loses the comparison and is corrected by the next checkpoint. Added a regression test with the #68 shape (stale config + newer snapshot): fails on main, passes here. Full suite passes, including `loadPrefersConfigOverNewerDiskMaster` — its config is newer by embedded timestamp, so the intended config-first behavior is preserved. Multi-device (#66's cross-machine case) needs merging rather than arbitration and is out of scope.
