### PR TITLE
Add opt-in Group Ironman shared card collection

### DIFF
--- a/src/main/java/com/osrstcg/OsrsTcgConfig.java
+++ b/src/main/java/com/osrstcg/OsrsTcgConfig.java
@@ -335,4 +335,39 @@ public interface OsrsTcgConfig extends Config
 	{
 		return "";
 	}
+
+	@ConfigSection(
+		name = "Group",
+		description = "Group Ironman shared card collection.",
+		position = 31
+	)
+	String groupSection = "group";
+
+	@ConfigItem(
+		keyName = "groupCollectionEnabled",
+		name = "Pool card collection with group",
+		description = "Treat a card owned by ANY listed teammate as owned by you too, for challenge-plugin "
+			+ "gating (e.g. tcg-locked / bronzeman-tcg). Only card ownership is pooled — credits, packs, "
+			+ "foils and the in-game economy are never shared or moved between accounts. Every teammate "
+			+ "must also enable \"Share collection online\" above and list each other here.",
+		section = groupSection,
+		position = 0
+	)
+	default boolean groupCollectionEnabled()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "groupMembers",
+		name = "Group members",
+		description = "Teammates' OSRS display names, one per line or comma-separated. Each must have "
+			+ "\"Share collection online\" enabled. You don't need to list yourself.",
+		section = groupSection,
+		position = 1
+	)
+	default String groupMembers()
+	{
+		return "";
+	}
 }

--- a/src/main/java/com/osrstcg/OsrsTcgPlugin.java
+++ b/src/main/java/com/osrstcg/OsrsTcgPlugin.java
@@ -17,6 +17,7 @@ import com.osrstcg.overlay.CreditsInfoboxOverlay;
 import com.osrstcg.overlay.PackRevealInputListener;
 import com.osrstcg.overlay.PackRevealOverlay;
 import com.osrstcg.service.CollectionShareService;
+import com.osrstcg.service.GroupCollectionSyncService;
 import com.osrstcg.service.OwnedCardNamesApiService;
 import com.osrstcg.service.CardPartyTradeService;
 import com.osrstcg.service.CardPartyTransferService;
@@ -188,6 +189,8 @@ public class OsrsTcgPlugin extends Plugin
 	private CollectionShareService collectionShareService;
 	@Inject
 	private OwnedCardNamesApiService ownedCardNamesApiService;
+	@Inject
+	private GroupCollectionSyncService groupCollectionSyncService;
 
 	private NavigationButton navigationButton;
 	private boolean fileBackupLoadUsedThisSession;
@@ -243,6 +246,7 @@ public class OsrsTcgPlugin extends Plugin
 		stateService.setRewardTuningFlushBeforeCredits(tcgPanel::flushRewardTuningDraftToState);
 		collectionShareService.setStatusListener(() -> SwingUtilities.invokeLater(tcgPanel::updateWebShareLiveIndicator));
 		collectionShareService.start();
+		groupCollectionSyncService.start();
 		ownedCardNamesApiService.start();
 		tcgPanel.refresh();
 		TcgPluginGameMessages.setPrefixColor(config.chatPrefixColor());
@@ -296,6 +300,7 @@ public class OsrsTcgPlugin extends Plugin
 		collectionShareService.setStatusListener(null);
 		collectionShareService.stop();
 		ownedCardNamesApiService.stop();
+		groupCollectionSyncService.stop();
 		tcgPanel.stop();
 		log.info("OSRS TCG plugin stopped");
 	}
@@ -355,6 +360,10 @@ public class OsrsTcgPlugin extends Plugin
 		{
 			collectionShareService.onConfigChanged();
 			tcgPanel.updateWebShareLiveIndicator();
+		}
+		else if ("groupCollectionEnabled".equals(event.getKey()) || "groupMembers".equals(event.getKey()))
+		{
+			groupCollectionSyncService.onConfigChanged();
 		}
 		else if ("chatPrefixColor".equals(event.getKey()))
 		{
@@ -442,6 +451,7 @@ public class OsrsTcgPlugin extends Plugin
 		applyLoadedProfileState(loadResult);
 		announceLoadResult(loadResult);
 		collectionShareService.onLoginOrProfileReady();
+		groupCollectionSyncService.onProfileChanged();
 	}
 
 	/** After {@link TcgStateService#load()} on login / profile switch; clears UI when debug-tainted saves are reset. */

--- a/src/main/java/com/osrstcg/persist/GroupCollectionStore.java
+++ b/src/main/java/com/osrstcg/persist/GroupCollectionStore.java
@@ -1,0 +1,88 @@
+package com.osrstcg.persist;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.client.config.ConfigManager;
+
+/**
+ * Profile-scoped companion store for the Group Ironman shared card pool.
+ * <p>
+ * Persists the UNION of card names owned by any group member (local player + configured
+ * teammates) under a dedicated RSProfile key, kept separate from the real {@code state} blob
+ * ({@link TcgStateStore}) so downstream plugins that decode {@code state} for credits / economy
+ * (e.g. bronzeman-tcg) are never polluted with teammates' cards. Bronzeman-style integrations
+ * that want to union the pool into their own gating should read this key directly.
+ * <p>
+ * Shape: RSProfile group {@code osrstcg}, key {@code groupOwnedNames} → a plain JSON array of
+ * card name strings, e.g. {@code ["Abyssal whip","Twisted bow"]}.
+ */
+@Singleton
+public class GroupCollectionStore
+{
+	private static final String GROUP = "osrstcg";
+	public static final String OWNED_NAMES_KEY = "groupOwnedNames";
+	private static final Type NAME_SET_TYPE = new TypeToken<LinkedHashSet<String>>()
+	{
+	}.getType();
+
+	private final ConfigManager configManager;
+	private final Gson gson;
+
+	@Inject
+	public GroupCollectionStore(ConfigManager configManager, Gson gson)
+	{
+		this.configManager = configManager;
+		this.gson = gson;
+	}
+
+	/** Loads the last persisted pooled name set, or an empty set if none has been saved yet. */
+	public Set<String> load()
+	{
+		String raw = getProfileScoped(OWNED_NAMES_KEY);
+		if (raw == null || raw.isEmpty())
+		{
+			return new LinkedHashSet<>();
+		}
+		try
+		{
+			Set<String> parsed = gson.fromJson(raw, NAME_SET_TYPE);
+			return parsed == null ? new LinkedHashSet<>() : new LinkedHashSet<>(parsed);
+		}
+		catch (Exception ex)
+		{
+			return new LinkedHashSet<>();
+		}
+	}
+
+	public void save(Collection<String> names)
+	{
+		writeProfileScoped(OWNED_NAMES_KEY, gson.toJson(names == null ? Set.of() : names));
+	}
+
+	public void clear()
+	{
+		unsetProfileScoped(OWNED_NAMES_KEY);
+	}
+
+	// Package-private indirection (overridable in tests) so unit tests don't need a real ConfigManager.
+	String getProfileScoped(String key)
+	{
+		return configManager.getRSProfileConfiguration(GROUP, key);
+	}
+
+	void writeProfileScoped(String key, String value)
+	{
+		configManager.setRSProfileConfiguration(GROUP, key, value);
+	}
+
+	void unsetProfileScoped(String key)
+	{
+		configManager.unsetRSProfileConfiguration(GROUP, key);
+	}
+}

--- a/src/main/java/com/osrstcg/service/CollectionShareService.java
+++ b/src/main/java/com/osrstcg/service/CollectionShareService.java
@@ -44,8 +44,6 @@ public class CollectionShareService
 {
 	private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 	private static final MediaType ENCODED_BLOB = MediaType.parse("text/plain; charset=utf-8");
-	private static final String DEFAULT_PUBLIC_BASE = "https://osrs-tcg.xyz";
-	private static final String API_BASE = DEFAULT_PUBLIC_BASE + "/api/v1";
 	private static final long DEBOUNCE_MS = 1500L;
 	private static final long KEEPALIVE_PERIOD_MS = 4L * 60L * 1000L + 30L * 1000L; // 4.5 min
 	private static final long FAILURE_COOLDOWN_MS = 30_000L;
@@ -574,7 +572,7 @@ public class CollectionShareService
 	 */
 	private boolean createShare(String displayName) throws IOException
 	{
-		HttpUrl url = HttpUrl.parse(API_BASE + "/shares");
+		HttpUrl url = HttpUrl.parse(WebShareEndpoints.API_BASE + "/shares");
 		if (url == null)
 		{
 			throw new IOException("Invalid API URL");
@@ -629,7 +627,7 @@ public class CollectionShareService
 
 	private int putCollection(String shareId, String writeToken, String displayName, String apiKey) throws IOException
 	{
-		HttpUrl url = HttpUrl.parse(API_BASE + "/shares/" + shareId + "/collection");
+		HttpUrl url = HttpUrl.parse(WebShareEndpoints.API_BASE + "/shares/" + shareId + "/collection");
 		if (url == null)
 		{
 			throw new IOException("Invalid share PUT URL");
@@ -693,32 +691,7 @@ public class CollectionShareService
 
 	private static String publicUrlForDisplayName(String displayName)
 	{
-		return DEFAULT_PUBLIC_BASE + "/" + encodePathSegment(displayName);
-	}
-
-	private static String encodePathSegment(String value)
-	{
-		// Space → %20; keep letters/digits/_/- unescaped for readable OSRS names
-		StringBuilder sb = new StringBuilder(value.length() + 8);
-		for (int i = 0; i < value.length(); i++)
-		{
-			char c = value.charAt(i);
-			if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
-				|| c == '_' || c == '-')
-			{
-				sb.append(c);
-			}
-			else if (c == ' ')
-			{
-				sb.append("%20");
-			}
-			else
-			{
-				sb.append('%');
-				sb.append(String.format("%02X", (int) c));
-			}
-		}
-		return sb.toString();
+		return WebShareEndpoints.DEFAULT_PUBLIC_BASE + "/" + WebShareEndpoints.encodePathSegment(displayName);
 	}
 
 	private void setStatus(String text)

--- a/src/main/java/com/osrstcg/service/GroupCollectionSyncService.java
+++ b/src/main/java/com/osrstcg/service/GroupCollectionSyncService.java
@@ -1,0 +1,363 @@
+package com.osrstcg.service;
+
+import com.google.gson.Gson;
+import com.osrstcg.OsrsTcgConfig;
+import com.osrstcg.model.CardEntry;
+import com.osrstcg.persist.GroupCollectionStore;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * Opt-in Group Ironman shared card pool: periodically reads each configured teammate's public
+ * osrs-tcg.xyz album ({@code GET /api/v1/players/{displayName}}, the same endpoint the website
+ * uses) and unions their owned card NAMES with the local player's, so a card owned by ANY
+ * teammate counts as owned by everyone for challenge-plugin gating ({@link OwnedCardNamesApiService}).
+ * <p>
+ * Only card ownership is pooled — never credits, packs, foils or pity/rewardTuning state, and
+ * teammates' cards are never merged into the real {@link TcgStateService} collection (that would
+ * corrupt credits/economy/dedupe on reload). The pool is persisted separately via
+ * {@link GroupCollectionStore} so it is available immediately at startup (before any network
+ * call), survives client restarts, and keeps working regardless of who else is online.
+ * <p>
+ * The pool only ever grows: a teammate's last successfully fetched name set is cached in memory
+ * and a failed/404 fetch simply leaves that teammate's cached names untouched, so a transient
+ * outage (or a teammate who hasn't published an album yet) can never shrink the gating set.
+ */
+@Slf4j
+@Singleton
+public class GroupCollectionSyncService
+{
+	private static final long INITIAL_SYNC_DELAY_MS = 5_000L;
+	private static final long SYNC_PERIOD_MS = 5L * 60L * 1000L; // 5 minutes
+
+	private final OkHttpClient httpClient;
+	private final Gson gson;
+	private final OsrsTcgConfig config;
+	private final TcgStateService stateService;
+	private final GroupCollectionStore store;
+	private final ScheduledExecutorService scheduler;
+
+	private final AtomicBoolean started = new AtomicBoolean(false);
+	private final AtomicBoolean syncInFlight = new AtomicBoolean(false);
+	/** Per-teammate last-known owned names (normalized display name -> names). Only updated on a successful fetch. */
+	private final ConcurrentMap<String, Set<String>> memberOwnedNames = new ConcurrentHashMap<>();
+	private final AtomicReference<Set<String>> pooledOwnedNames = new AtomicReference<>(Set.of());
+	private final AtomicReference<Runnable> changeListener = new AtomicReference<>(null);
+	private final Runnable onLocalCollectionChanged = this::onLocalCollectionChanged;
+
+	private ScheduledFuture<?> periodicFuture;
+
+	@Inject
+	GroupCollectionSyncService(
+		OkHttpClient okHttpClient,
+		Gson gson,
+		OsrsTcgConfig config,
+		TcgStateService stateService,
+		GroupCollectionStore store,
+		ScheduledExecutorService scheduler)
+	{
+		this.httpClient = okHttpClient.newBuilder()
+			.connectTimeout(10, TimeUnit.SECONDS)
+			.readTimeout(15, TimeUnit.SECONDS)
+			.build();
+		this.gson = gson;
+		this.config = config;
+		this.stateService = stateService;
+		this.store = store;
+		this.scheduler = scheduler;
+	}
+
+	public void start()
+	{
+		if (!started.compareAndSet(false, true))
+		{
+			return;
+		}
+		// Load the persisted floor before any fetch so downstream readers see last-known names immediately.
+		pooledOwnedNames.set(new LinkedHashSet<>(store.load()));
+		stateService.addCollectionChangeListener(onLocalCollectionChanged);
+		periodicFuture = scheduler.scheduleWithFixedDelay(
+			this::syncNow, INITIAL_SYNC_DELAY_MS, SYNC_PERIOD_MS, TimeUnit.MILLISECONDS);
+		recomputeAndMaybeNotify();
+	}
+
+	public void stop()
+	{
+		if (!started.compareAndSet(true, false))
+		{
+			return;
+		}
+		stateService.removeCollectionChangeListener(onLocalCollectionChanged);
+		if (periodicFuture != null)
+		{
+			periodicFuture.cancel(false);
+			periodicFuture = null;
+		}
+		memberOwnedNames.clear();
+	}
+
+	/** Call on login / RSProfile switch: reset the in-memory per-teammate cache and reload the floor for this profile. */
+	public void onProfileChanged()
+	{
+		memberOwnedNames.clear();
+		pooledOwnedNames.set(new LinkedHashSet<>(store.load()));
+		if (started.get() && config.groupCollectionEnabled())
+		{
+			scheduler.execute(this::syncNow);
+		}
+	}
+
+	public void setChangeListener(Runnable listener)
+	{
+		changeListener.set(listener);
+	}
+
+	public boolean isEnabled()
+	{
+		return config.groupCollectionEnabled();
+	}
+
+	/** Union of local + all cached teammate names. Empty when group mode is disabled. */
+	public Set<String> getPooledOwnedNames()
+	{
+		if (!isEnabled())
+		{
+			return Set.of();
+		}
+		return Set.copyOf(pooledOwnedNames.get());
+	}
+
+	/** Call after config changes affecting {@code groupCollectionEnabled} / {@code groupMembers}. */
+	public void onConfigChanged()
+	{
+		if (!started.get())
+		{
+			return;
+		}
+		if (config.groupCollectionEnabled())
+		{
+			scheduler.execute(this::syncNow);
+		}
+		else
+		{
+			recomputeAndMaybeNotify();
+		}
+	}
+
+	private void onLocalCollectionChanged()
+	{
+		recomputeAndMaybeNotify();
+	}
+
+	/** Fetches every configured teammate's public album and recomputes the pool. Safe to call repeatedly. */
+	public void syncNow()
+	{
+		if (!started.get() || !config.groupCollectionEnabled())
+		{
+			return;
+		}
+		if (!syncInFlight.compareAndSet(false, true))
+		{
+			return;
+		}
+		try
+		{
+			for (String member : parseMembers(config.groupMembers()))
+			{
+				fetchMember(member);
+			}
+		}
+		finally
+		{
+			syncInFlight.set(false);
+			recomputeAndMaybeNotify();
+		}
+	}
+
+	private void fetchMember(String displayName)
+	{
+		HttpUrl url = HttpUrl.parse(
+			WebShareEndpoints.API_BASE + "/players/" + WebShareEndpoints.encodePathSegment(displayName));
+		if (url == null)
+		{
+			return;
+		}
+		Request request = new Request.Builder()
+			.url(url)
+			.header("Accept", "application/json")
+			.build();
+
+		try (Response response = httpClient.newCall(request).execute())
+		{
+			if (response.code() == 404)
+			{
+				// No published album yet (or unpublished) — keep last-known cached names, if any.
+				log.debug("No public album found for group member {}", displayName);
+				return;
+			}
+			if (!response.isSuccessful())
+			{
+				log.debug("Group member fetch for {} failed (HTTP {}); keeping last-known names", displayName,
+					response.code());
+				return;
+			}
+			ResponseBody body = response.body();
+			String json = body == null ? null : body.string();
+			Set<String> names = parseOwnedNames(json, gson);
+			memberOwnedNames.put(normalizeMemberKey(displayName), names);
+		}
+		catch (IOException ex)
+		{
+			log.debug("Group member fetch for {} errored; keeping last-known names", displayName, ex);
+		}
+	}
+
+	private void recomputeAndMaybeNotify()
+	{
+		Set<String> localNames;
+		synchronized (stateService)
+		{
+			localNames = new LinkedHashSet<>(
+				OwnedCardNamesApiService.distinctOwnedNames(stateService.getState().getCollectionState()));
+		}
+		Set<String> union = computeUnion(pooledOwnedNames.get(), localNames, memberOwnedNames);
+		Set<String> previous = pooledOwnedNames.getAndSet(union);
+		if (previous.equals(union))
+		{
+			return;
+		}
+		store.save(union);
+		Runnable listener = changeListener.get();
+		if (listener != null)
+		{
+			try
+			{
+				listener.run();
+			}
+			catch (Exception ex)
+			{
+				log.debug("Group pool change listener failed", ex);
+			}
+		}
+	}
+
+	/**
+	 * Pure merge: {@code floor} (persisted last-known pool) ∪ {@code localNames} ∪ every cached
+	 * teammate's names. Never removes anything — a missing/failed teammate fetch simply omits
+	 * that teammate's contribution for this pass while {@code floor} keeps everything ever seen.
+	 */
+	static Set<String> computeUnion(Set<String> floor, Set<String> localNames, Map<String, Set<String>> memberNames)
+	{
+		Set<String> union = new LinkedHashSet<>();
+		if (floor != null)
+		{
+			union.addAll(floor);
+		}
+		if (localNames != null)
+		{
+			union.addAll(localNames);
+		}
+		if (memberNames != null)
+		{
+			for (Set<String> names : memberNames.values())
+			{
+				if (names != null)
+				{
+					union.addAll(names);
+				}
+			}
+		}
+		List<String> sorted = new ArrayList<>(union);
+		sorted.sort(String.CASE_INSENSITIVE_ORDER);
+		return new LinkedHashSet<>(sorted);
+	}
+
+	/** Parses the decoded JSON body of {@code GET /api/v1/players/{name}} into owned card names. */
+	static Set<String> parseOwnedNames(String json, Gson gson)
+	{
+		if (json == null || json.isEmpty())
+		{
+			return Set.of();
+		}
+		try
+		{
+			PlayerSnapshotResponse parsed = gson.fromJson(json, PlayerSnapshotResponse.class);
+			if (parsed == null || parsed.cardEntries == null)
+			{
+				return Set.of();
+			}
+			Set<String> names = new LinkedHashSet<>();
+			for (CardEntry entry : parsed.cardEntries)
+			{
+				if (entry == null || entry.cardName == null)
+				{
+					continue;
+				}
+				String trimmed = entry.cardName.trim();
+				if (!trimmed.isEmpty())
+				{
+					names.add(trimmed);
+				}
+			}
+			return names;
+		}
+		catch (Exception ex)
+		{
+			return Set.of();
+		}
+	}
+
+	/** Splits the free-text {@code groupMembers} config value on commas/newlines, trims, dedupes, preserves order. */
+	static List<String> parseMembers(String configured)
+	{
+		if (configured == null || configured.isEmpty())
+		{
+			return List.of();
+		}
+		Set<String> out = new LinkedHashSet<>();
+		for (String raw : configured.split("[,\\r\\n]+"))
+		{
+			if (raw == null)
+			{
+				continue;
+			}
+			String trimmed = raw.trim();
+			if (!trimmed.isEmpty())
+			{
+				out.add(trimmed);
+			}
+		}
+		return new ArrayList<>(out);
+	}
+
+	private static String normalizeMemberKey(String name)
+	{
+		return name == null ? "" : name.trim().toLowerCase(Locale.ROOT);
+	}
+
+	/** Minimal shape of the {@code /players/{name}} response we care about; matches {@link CollectionShareSnapshotBuilder#buildPayload}. */
+	private static final class PlayerSnapshotResponse
+	{
+		List<CardEntry> cardEntries;
+	}
+}

--- a/src/main/java/com/osrstcg/service/OwnedCardNamesApiService.java
+++ b/src/main/java/com/osrstcg/service/OwnedCardNamesApiService.java
@@ -22,6 +22,11 @@ import net.runelite.client.events.PluginMessage;
  * <p>
  * Query: post {@code new PluginMessage(NAMESPACE, QUERY)} → reply {@link #REPLY} with {@link #KEY_OWNED_NAMES}.
  * Push: {@link #CHANGED} with the same payload after collection mutations.
+ * <p>
+ * When the opt-in Group Ironman shared collection is enabled ({@link GroupCollectionSyncService}),
+ * both the reply and the push payload contain the UNION of the local player's names and the pooled
+ * teammate names, so downstream challenge plugins (tcg-locked / bronzeman-tcg) see a card as owned
+ * if any group member owns it.
  */
 @Slf4j
 @Singleton
@@ -35,14 +40,17 @@ public class OwnedCardNamesApiService
 
 	private final EventBus eventBus;
 	private final TcgStateService stateService;
+	private final GroupCollectionSyncService groupCollectionSyncService;
 	private final AtomicBoolean started = new AtomicBoolean(false);
 	private final Runnable onCollectionChanged = this::broadcastChanged;
 
 	@Inject
-	OwnedCardNamesApiService(EventBus eventBus, TcgStateService stateService)
+	OwnedCardNamesApiService(
+		EventBus eventBus, TcgStateService stateService, GroupCollectionSyncService groupCollectionSyncService)
 	{
 		this.eventBus = eventBus;
 		this.stateService = stateService;
+		this.groupCollectionSyncService = groupCollectionSyncService;
 	}
 
 	public void start()
@@ -53,6 +61,7 @@ public class OwnedCardNamesApiService
 		}
 		eventBus.register(this);
 		stateService.addCollectionChangeListener(onCollectionChanged);
+		groupCollectionSyncService.setChangeListener(onCollectionChanged);
 	}
 
 	public void stop()
@@ -61,6 +70,7 @@ public class OwnedCardNamesApiService
 		{
 			return;
 		}
+		groupCollectionSyncService.setChangeListener(null);
 		stateService.removeCollectionChangeListener(onCollectionChanged);
 		eventBus.unregister(this);
 	}
@@ -95,8 +105,22 @@ public class OwnedCardNamesApiService
 			collection = stateService.getState().getCollectionState();
 		}
 		Map<String, Object> data = new HashMap<>();
-		data.put(KEY_OWNED_NAMES, distinctOwnedNames(collection));
+		data.put(KEY_OWNED_NAMES, ownedNames(collection));
 		return data;
+	}
+
+	private List<String> ownedNames(CollectionState collection)
+	{
+		List<String> localNames = distinctOwnedNames(collection);
+		if (!groupCollectionSyncService.isEnabled())
+		{
+			return localNames;
+		}
+		Set<String> union = new LinkedHashSet<>(localNames);
+		union.addAll(groupCollectionSyncService.getPooledOwnedNames());
+		List<String> sorted = new ArrayList<>(union);
+		sorted.sort(String.CASE_INSENSITIVE_ORDER);
+		return sorted;
 	}
 
 	static List<String> distinctOwnedNames(CollectionState collection)

--- a/src/main/java/com/osrstcg/service/WebShareEndpoints.java
+++ b/src/main/java/com/osrstcg/service/WebShareEndpoints.java
@@ -1,0 +1,41 @@
+package com.osrstcg.service;
+
+/**
+ * Shared osrs-tcg.xyz web share constants and helpers, used by both {@link CollectionShareService}
+ * (publishing a player's own collection) and {@link GroupCollectionSyncService} (reading teammates'
+ * published collections back for Group Ironman pooling).
+ */
+final class WebShareEndpoints
+{
+	static final String DEFAULT_PUBLIC_BASE = "https://osrs-tcg.xyz";
+	static final String API_BASE = DEFAULT_PUBLIC_BASE + "/api/v1";
+
+	private WebShareEndpoints()
+	{
+	}
+
+	static String encodePathSegment(String value)
+	{
+		// Space → %20; keep letters/digits/_/- unescaped for readable OSRS names
+		StringBuilder sb = new StringBuilder(value.length() + 8);
+		for (int i = 0; i < value.length(); i++)
+		{
+			char c = value.charAt(i);
+			if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+				|| c == '_' || c == '-')
+			{
+				sb.append(c);
+			}
+			else if (c == ' ')
+			{
+				sb.append("%20");
+			}
+			else
+			{
+				sb.append('%');
+				sb.append(String.format("%02X", (int) c));
+			}
+		}
+		return sb.toString();
+	}
+}

--- a/src/test/java/com/osrstcg/persist/GroupCollectionStoreTest.java
+++ b/src/test/java/com/osrstcg/persist/GroupCollectionStoreTest.java
@@ -1,0 +1,100 @@
+package com.osrstcg.persist;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Verifies the {@code groupOwnedNames} RSProfile companion key round-trips through
+ * {@link GroupCollectionStore} without touching the real {@code state} blob, and that a missing
+ * or corrupt value degrades to an empty set instead of throwing.
+ */
+public class GroupCollectionStoreTest
+{
+	private final Map<String, String> profile = new LinkedHashMap<>();
+	private final TestableGroupCollectionStore store = new TestableGroupCollectionStore(profile);
+
+	@Test
+	public void loadReturnsEmptySetWhenNothingPersistedYet()
+	{
+		Assert.assertTrue(store.load().isEmpty());
+	}
+
+	@Test
+	public void saveThenLoadRoundTripsNames()
+	{
+		Set<String> names = new LinkedHashSet<>();
+		names.add("Abyssal whip");
+		names.add("Twisted bow");
+
+		store.save(names);
+
+		Assert.assertEquals(names, store.load());
+		Assert.assertTrue(
+			"companion key must be plain JSON, e.g. [\"Abyssal whip\",\"Twisted bow\"]",
+			profile.get(GroupCollectionStore.OWNED_NAMES_KEY).contains("Abyssal whip"));
+	}
+
+	@Test
+	public void saveDoesNotTouchAnyOtherProfileKey()
+	{
+		profile.put("state", "RLTCG_v2:untouched");
+
+		store.save(Set.of("Rune scimitar"));
+
+		Assert.assertEquals("RLTCG_v2:untouched", profile.get("state"));
+	}
+
+	@Test
+	public void clearRemovesThePersistedValue()
+	{
+		store.save(Set.of("Rune scimitar"));
+		Assert.assertFalse(store.load().isEmpty());
+
+		store.clear();
+
+		Assert.assertTrue(store.load().isEmpty());
+		Assert.assertFalse(profile.containsKey(GroupCollectionStore.OWNED_NAMES_KEY));
+	}
+
+	@Test
+	public void loadIgnoresCorruptJsonInsteadOfThrowing()
+	{
+		profile.put(GroupCollectionStore.OWNED_NAMES_KEY, "not valid json{{{");
+
+		Assert.assertTrue(store.load().isEmpty());
+	}
+
+	/** Overrides the RSProfile accessors with an in-memory map, avoiding a real {@code ConfigManager}. */
+	private static final class TestableGroupCollectionStore extends GroupCollectionStore
+	{
+		private final Map<String, String> profile;
+
+		private TestableGroupCollectionStore(Map<String, String> profile)
+		{
+			super(null, new com.google.gson.Gson());
+			this.profile = profile;
+		}
+
+		@Override
+		String getProfileScoped(String key)
+		{
+			return profile.get(key);
+		}
+
+		@Override
+		void writeProfileScoped(String key, String value)
+		{
+			profile.put(key, value);
+		}
+
+		@Override
+		void unsetProfileScoped(String key)
+		{
+			profile.remove(key);
+		}
+	}
+}

--- a/src/test/java/com/osrstcg/service/GroupCollectionSyncServiceTest.java
+++ b/src/test/java/com/osrstcg/service/GroupCollectionSyncServiceTest.java
@@ -1,0 +1,154 @@
+package com.osrstcg.service;
+
+import com.google.gson.Gson;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Pure-logic tests for the Group Ironman shared card pool: merging teammate name sets, parsing
+ * the {@code GET /api/v1/players/{displayName}} response body (the same {@code cardEntries} shape
+ * {@link CollectionShareSnapshotBuilder#buildPayload} produces), and the never-shrink-on-failure
+ * guarantee. No live network calls are made.
+ */
+public class GroupCollectionSyncServiceTest
+{
+	private static final Gson GSON = new Gson();
+
+	/** Sample decoded {@code /players/{name}} body — same shape the website's own API serves. */
+	private static final String SAMPLE_PLAYER_PAYLOAD = ""
+		+ "{"
+		+ "\"schemaVersion\":2,"
+		+ "\"catalogVersion\":\"1.0.0\","
+		+ "\"displayName\":\"Teammate One\","
+		+ "\"updatedAt\":\"2024-01-01T00:00:00Z\","
+		+ "\"stats\":{\"collectionScore\":10,\"completionPct\":1.0,\"uniqueOwned\":2,\"uniqueFoilOwned\":1,"
+		+ "\"foilCompletionPct\":0.5,\"totalCardPool\":100,\"openedPacks\":5,\"totalCardsOwned\":3,\"customRates\":false},"
+		+ "\"cardEntries\":["
+		+ "{\"cardName\":\"Abyssal whip\",\"variants\":[{\"pulledBy\":\"Teammate One\",\"pulledAt\":1710000000000}]},"
+		+ "{\"cardName\":\"Twisted bow\",\"variants\":["
+		+ "{\"foil\":true,\"pulledBy\":\"Teammate One\",\"pulledAt\":1710000010000},"
+		+ "{\"pulledBy\":\"Teammate One\",\"pulledAt\":1710000020000}"
+		+ "]}"
+		+ "]"
+		+ "}";
+
+	/** The exact 404 body shape osrs-tcg.xyz returns for an unpublished album. */
+	private static final String NOT_FOUND_PAYLOAD = "{\"error\":\"not_found\",\"message\":\"No public album found for X\"}";
+
+	@Test
+	public void parseOwnedNamesExtractsAllCardEntryNames()
+	{
+		Set<String> names = GroupCollectionSyncService.parseOwnedNames(SAMPLE_PLAYER_PAYLOAD, GSON);
+
+		Assert.assertEquals(Set.of("Abyssal whip", "Twisted bow"), names);
+	}
+
+	@Test
+	public void parseOwnedNamesDedupesVariantsOfTheSameCardIntoOneName()
+	{
+		// "Twisted bow" has two variants (foil + normal) in the sample above but must fold to one name.
+		Set<String> names = GroupCollectionSyncService.parseOwnedNames(SAMPLE_PLAYER_PAYLOAD, GSON);
+
+		Assert.assertEquals(1, names.stream().filter("Twisted bow"::equals).count());
+	}
+
+	@Test
+	public void parseOwnedNamesReturnsEmptyForNotFoundBody()
+	{
+		Set<String> names = GroupCollectionSyncService.parseOwnedNames(NOT_FOUND_PAYLOAD, GSON);
+
+		Assert.assertTrue(names.isEmpty());
+	}
+
+	@Test
+	public void parseOwnedNamesReturnsEmptyForNullOrBlankOrGarbageInput()
+	{
+		Assert.assertTrue(GroupCollectionSyncService.parseOwnedNames(null, GSON).isEmpty());
+		Assert.assertTrue(GroupCollectionSyncService.parseOwnedNames("", GSON).isEmpty());
+		Assert.assertTrue(GroupCollectionSyncService.parseOwnedNames("not json{{{", GSON).isEmpty());
+	}
+
+	@Test
+	public void parseMembersSplitsOnCommasAndNewlinesAndTrimsAndDedupes()
+	{
+		List<String> members = GroupCollectionSyncService.parseMembers("Alice, Bob\nCarol\r\n  Alice  ,,Bob");
+
+		Assert.assertEquals(List.of("Alice", "Bob", "Carol"), members);
+	}
+
+	@Test
+	public void parseMembersReturnsEmptyForNullOrBlank()
+	{
+		Assert.assertTrue(GroupCollectionSyncService.parseMembers(null).isEmpty());
+		Assert.assertTrue(GroupCollectionSyncService.parseMembers("").isEmpty());
+	}
+
+	@Test
+	public void computeUnionMergesFloorLocalAndAllMembers()
+	{
+		Set<String> floor = Set.of("Rune scimitar");
+		Set<String> local = Set.of("Abyssal whip");
+		Map<String, Set<String>> members = new LinkedHashMap<>();
+		members.put("teammate one", Set.of("Twisted bow"));
+		members.put("teammate two", Set.of("Dragon dagger"));
+
+		Set<String> union = GroupCollectionSyncService.computeUnion(floor, local, members);
+
+		Assert.assertEquals(
+			Set.of("Rune scimitar", "Abyssal whip", "Twisted bow", "Dragon dagger"), union);
+	}
+
+	@Test
+	public void computeUnionNeverShrinksWhenAMemberFetchFails()
+	{
+		// Simulates: a prior successful sync cached "Twisted bow" for teammate two, then a later
+		// pass fails for teammate two (fetchMember leaves the cache entry untouched) — the pool
+		// recomputed from the still-populated cache must retain "Twisted bow".
+		Map<String, Set<String>> memberCache = new LinkedHashMap<>();
+		memberCache.put("teammate one", Set.of("Abyssal whip"));
+		memberCache.put("teammate two", Set.of("Twisted bow"));
+
+		Set<String> beforeFailure = GroupCollectionSyncService.computeUnion(Set.of(), Set.of(), memberCache);
+
+		// A failed fetch for teammate two does NOT touch memberCache (see fetchMember: 404/error -> return).
+		Set<String> afterFailedFetch = GroupCollectionSyncService.computeUnion(beforeFailure, Set.of(), memberCache);
+
+		Assert.assertEquals(beforeFailure, afterFailedFetch);
+		Assert.assertTrue(afterFailedFetch.contains("Twisted bow"));
+	}
+
+	@Test
+	public void computeUnionTreatsPersistedFloorAsPermanentLastKnownBaseline()
+	{
+		// The floor represents names persisted from a previous session/run; even if no member
+		// cache or local names currently reproduce them (e.g. right after a restart, before the
+		// first fetch completes), they must not be dropped from the pool.
+		Set<String> floorFromDisk = Set.of("Abyssal whip", "Twisted bow");
+
+		Set<String> union = GroupCollectionSyncService.computeUnion(floorFromDisk, Set.of(), Map.of());
+
+		Assert.assertEquals(floorFromDisk, union);
+	}
+
+	@Test
+	public void computeUnionHandlesNullInputsGracefully()
+	{
+		Set<String> union = GroupCollectionSyncService.computeUnion(null, null, null);
+
+		Assert.assertTrue(union.isEmpty());
+	}
+
+	@Test
+	public void computeUnionIsCaseInsensitivelySorted()
+	{
+		Set<String> union = GroupCollectionSyncService.computeUnion(
+			new LinkedHashSet<>(Set.of("zulrah's scales", "Abyssal whip")), Set.of(), Map.of());
+
+		Assert.assertEquals(List.of("Abyssal whip", "zulrah's scales"), List.copyOf(union));
+	}
+}


### PR DESCRIPTION
### What
Adds an opt-in Group Ironman mode that pools card *ownership* across a fixed group of accounts, so a card owned by ANY member counts as owned by EVERY member for downstream challenge plugins (tcg-locked, bronzeman-tcg).

### Why / design
Reuses the plugin's own existing backend (osrs-tcg.xyz web share) as the durable store instead of standing up new infrastructure. Each member already can publish their collection via `webShareEnabled`. This adds a periodic reader that fetches teammates' published albums (`GET /api/v1/players/{displayName}`) and unions the card names into a local, persisted pool.

### Changes
- **`WebShareEndpoints`** — extracted the osrs-tcg.xyz base URL + display-name encoder out of `CollectionShareService` for reuse (no behavior change to existing web-share publishing).
- **`GroupCollectionStore`** — new companion RSProfile key `groupOwnedNames` (plain JSON array of card names), kept separate from the real `state` blob so it never pollutes credits/economy/dedupe for plugins that decode `state` directly.
- **`GroupCollectionSyncService`** — polls each configured teammate's public album, extracts `cardEntries[].cardName`, and unions with local names. Never shrinks the pool: a 404 (no album yet) or fetch failure just leaves that teammate's last-known cached names untouched.
- **`OsrsTcgConfig`** — new "Group" section: `groupCollectionEnabled`, `groupMembers`.
- **`OwnedCardNamesApiService`** — serves the union (local ∪ pool) over the existing PluginMessage API when group mode is enabled; unchanged when disabled.
- **`OsrsTcgPlugin`** — lifecycle wiring, config-change forwarding, reset on profile switch.

### Scope guardrails
Only card **names** are pooled. Credits, packs, foils, pity/rewardTuning, and the in-game economy are never shared or moved between accounts.

### Testing
16 new unit tests covering union/merge logic, `/players/{name}` payload parsing (incl. 404), never-shrink-on-failure, and RSProfile persistence round-trip. `./gradlew clean build` passes (33 tests, 0 failures).
