### PR TITLE
Evict oldest party-message ids instead of clearing replay protection

### DIFF
--- a/src/main/java/com/osrstcg/service/CardPartyTradeService.java
+++ b/src/main/java/com/osrstcg/service/CardPartyTradeService.java
@@ -70,8 +70,12 @@ public class CardPartyTradeService
 	private long lastInviteSendAtMs;
 	private final List<Runnable> uiListeners = new CopyOnWriteArrayList<>();
 	private int tickCounter;
-	private final java.util.Set<String> processedCommitTradeIds =
-		java.util.Collections.synchronizedSet(new java.util.HashSet<>());
+	/**
+	 * Upper bound on remembered trade ids for commit-replay protection. Set well above
+	 * any realistic trade-to-redelivery gap; the exact value is not tuned.
+	 */
+	private static final int MAX_REMEMBERED_TRADE_IDS = 600;
+	private final RecentIdSet processedCommitTradeIds = new RecentIdSet(MAX_REMEMBERED_TRADE_IDS);
 
 	public static final class PendingInboundInvite
 	{
@@ -922,13 +926,6 @@ public class CardPartyTradeService
 					changed = true;
 				}
 			}
-			synchronized (processedCommitTradeIds)
-			{
-				if (processedCommitTradeIds.size() > 600)
-				{
-					processedCommitTradeIds.clear();
-				}
-			}
 		}
 		if (expiredOutboundTradeId != null)
 		{
@@ -1287,12 +1284,9 @@ public class CardPartyTradeService
 			remoteCopy = List.copyOf(session.remoteOffers);
 		}
 
-		synchronized (processedCommitTradeIds)
+		if (!processedCommitTradeIds.add(msg.getTradeId()))
 		{
-			if (!processedCommitTradeIds.add(msg.getTradeId()))
-			{
-				return;
-			}
+			return;
 		}
 
 		RewardTuningState committerTuning = tuningFromCommit(msg);
@@ -1402,10 +1396,7 @@ public class CardPartyTradeService
 		m.setXpCreditMultiplier(mine.getXpCreditMultiplier());
 		m.setCommitterDebugLogging(localDebug);
 
-		synchronized (processedCommitTradeIds)
-		{
-			processedCommitTradeIds.add(tradeId);
-		}
+		processedCommitTradeIds.add(tradeId);
 
 		if (!sendParty(m, "Could not complete trade (party connection)."))
 		{
@@ -1416,10 +1407,7 @@ public class CardPartyTradeService
 					session.commitSent = false;
 				}
 			}
-			synchronized (processedCommitTradeIds)
-			{
-				processedCommitTradeIds.remove(tradeId);
-			}
+			processedCommitTradeIds.remove(tradeId);
 			notifyUi();
 			return;
 		}

--- a/src/main/java/com/osrstcg/service/CardPartyTransferService.java
+++ b/src/main/java/com/osrstcg/service/CardPartyTransferService.java
@@ -51,7 +51,12 @@ public class CardPartyTransferService
 
 	private final java.util.Map<String, PendingOffer> pendingOffers = new java.util.concurrent.ConcurrentHashMap<>();
 	private final java.util.Set<String> pendingInstanceIds = java.util.Collections.newSetFromMap(new java.util.concurrent.ConcurrentHashMap<>());
-	private final java.util.Set<String> processedGiftTransferIds = java.util.Collections.synchronizedSet(new java.util.HashSet<>());
+	/**
+	 * Upper bound on remembered gift-transfer ids for replay protection. Set well above
+	 * any realistic gift-to-redelivery gap; the exact value is not tuned.
+	 */
+	private static final int MAX_REMEMBERED_GIFT_IDS = 600;
+	private final RecentIdSet processedGiftTransferIds = new RecentIdSet(MAX_REMEMBERED_GIFT_IDS);
 	private int tickCounter;
 
 	private static final class PendingOffer
@@ -307,13 +312,6 @@ public class CardPartyTransferService
 					"Card send timed out (no response from recipient).");
 			}
 		}
-		synchronized (processedGiftTransferIds)
-		{
-			if (processedGiftTransferIds.size() > 600)
-			{
-				processedGiftTransferIds.clear();
-			}
-		}
 	}
 
 	@Subscribe
@@ -334,12 +332,9 @@ public class CardPartyTransferService
 
 	private void handleCardGiftPartyMessageOnClientThread(TcgCardGiftPartyMessage msg)
 	{
-		synchronized (processedGiftTransferIds)
+		if (processedGiftTransferIds.contains(msg.getTransferId()))
 		{
-			if (processedGiftTransferIds.contains(msg.getTransferId()))
-			{
-				return;
-			}
+			return;
 		}
 
 		RewardTuningState senderTuning = tuningFromGift(msg);
@@ -385,10 +380,7 @@ public class CardPartyTransferService
 		String by = msg.getPulledByUsername() == null ? "" : msg.getPulledByUsername().trim();
 		long at = Math.max(0L, msg.getPulledAtEpochMs());
 		stateService.addOwnedCardInstance(OwnedCardInstance.createNew(card, foil, by, at));
-		synchronized (processedGiftTransferIds)
-		{
-			processedGiftTransferIds.add(msg.getTransferId());
-		}
+		processedGiftTransferIds.add(msg.getTransferId());
 		sendResponse(msg.getTransferId(), originalSender, true, GIFT_REJECT_NONE);
 
 		packRevealSoundService.playTransferSuccess();

--- a/src/main/java/com/osrstcg/service/RecentIdSet.java
+++ b/src/main/java/com/osrstcg/service/RecentIdSet.java
@@ -1,0 +1,46 @@
+package com.osrstcg.service;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Remembers recently processed party-message ids for replay protection, evicting the
+ * oldest id once over capacity. A wholesale clear would also forget the newest ids,
+ * reopening the replay window this set exists to close.
+ */
+final class RecentIdSet
+{
+	private final Set<String> ids;
+
+	RecentIdSet(int capacity)
+	{
+		ids = Collections.newSetFromMap(new LinkedHashMap<String, Boolean>()
+		{
+			@Override
+			protected boolean removeEldestEntry(Map.Entry<String, Boolean> eldest)
+			{
+				return size() > capacity;
+			}
+		});
+	}
+
+	/** @return false if the id was already present, i.e. a replayed message. */
+	synchronized boolean add(String id)
+	{
+		return ids.add(id);
+	}
+
+	/** True if the id was already recorded, without inserting it. */
+	synchronized boolean contains(String id)
+	{
+		return ids.contains(id);
+	}
+
+	/** Forget an id whose message failed, so a retried message is not treated as a replay. */
+	synchronized void remove(String id)
+	{
+		ids.remove(id);
+	}
+}

--- a/src/test/java/com/osrstcg/service/RecentIdSetTest.java
+++ b/src/test/java/com/osrstcg/service/RecentIdSetTest.java
@@ -1,0 +1,68 @@
+package com.osrstcg.service;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Replay protection for party messages: the id set must reject duplicates while full,
+ * evicting only the oldest entries, never the recent ones a replayed message would reuse.
+ */
+public class RecentIdSetTest
+{
+	@Test
+	public void duplicateIdIsRejected()
+	{
+		RecentIdSet ids = new RecentIdSet(600);
+		Assert.assertTrue(ids.add("msg-1"));
+		Assert.assertFalse(ids.add("msg-1"));
+	}
+
+	@Test
+	public void containsReportsMembershipWithoutInserting()
+	{
+		RecentIdSet ids = new RecentIdSet(600);
+		Assert.assertFalse(ids.contains("msg-1"));
+		ids.add("msg-1");
+		Assert.assertTrue(ids.contains("msg-1"));
+		// A bare contains() must not record the id, so a later add() still counts as first-seen.
+		Assert.assertFalse(ids.contains("msg-2"));
+		Assert.assertTrue(ids.add("msg-2"));
+	}
+
+	@Test
+	public void evictsOldestFirstWhenFull()
+	{
+		RecentIdSet ids = new RecentIdSet(3);
+		ids.add("a");
+		ids.add("b");
+		ids.add("c");
+		ids.add("d");
+		Assert.assertFalse("recent ids must survive eviction", ids.add("b"));
+		Assert.assertFalse(ids.add("c"));
+		Assert.assertFalse(ids.add("d"));
+		Assert.assertTrue("oldest id should have been evicted", ids.add("a"));
+	}
+
+	/** Regression: the old "empty the whole set on overflow" eviction forgot every recent id at once. */
+	@Test
+	public void recentIdsStillRejectedAfterOverflow()
+	{
+		RecentIdSet ids = new RecentIdSet(600);
+		for (int i = 0; i < 601; i++)
+		{
+			ids.add("msg-" + i);
+		}
+		Assert.assertFalse("just-processed id must still be deduplicated", ids.add("msg-600"));
+		Assert.assertFalse(ids.add("msg-599"));
+		Assert.assertTrue("only the oldest id should be evicted", ids.add("msg-0"));
+	}
+
+	@Test
+	public void removedIdCanBeAddedAgain()
+	{
+		RecentIdSet ids = new RecentIdSet(600);
+		ids.add("msg-1");
+		ids.remove("msg-1");
+		Assert.assertTrue("removed id must be re-addable so a failed message can retry", ids.add("msg-1"));
+	}
+}


### PR DESCRIPTION
The trade-commit and gift-transfer paths each emptied their processed-id set once it passed 600 entries, forgetting recent ids along with old ones. A redelivered commit or gift could then slip past the duplicate check and apply twice, duplicating cards.

Replaces both with a shared bounded set (`RecentIdSet`) that evicts only the oldest id. Adds `RecentIdSetTest`.