### PR TITLE
Skip trade-window foil repaints when no offered card is foil

### DIFF
--- a/src/main/java/com/osrstcg/ui/trade/TradeWindow.java
+++ b/src/main/java/com/osrstcg/ui/trade/TradeWindow.java
@@ -136,11 +136,19 @@ public final class TradeWindow extends JFrame
 			}
 		});
 
+		// Foil sparkles are the only animated content; skip repaints entirely for non-foil offers.
 		foilAnimTimer = new Timer(SharedCardRenderer.FOIL_SPARKLE_FRAME_MS, e ->
 		{
-			if (isShowing())
+			if (!isShowing())
+			{
+				return;
+			}
+			if (hasFoilOffer(localPanel.offers))
 			{
 				localPanel.repaint();
+			}
+			if (hasFoilOffer(remotePanel.offers))
+			{
 				remotePanel.repaint();
 			}
 		});
@@ -360,6 +368,18 @@ public final class TradeWindow extends JFrame
 	private void onCancelClicked()
 	{
 		tradeService.cancelActiveTrade();
+	}
+
+	static boolean hasFoilOffer(List<TradeOfferView> offers)
+	{
+		for (TradeOfferView offer : offers)
+		{
+			if (offer.isFoil())
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private static void styleButton(JButton btn)

--- a/src/test/java/com/osrstcg/service/TradeViewFixtures.java
+++ b/src/test/java/com/osrstcg/service/TradeViewFixtures.java
@@ -1,0 +1,16 @@
+package com.osrstcg.service;
+
+import com.osrstcg.service.CardPartyTradeService.TradeOfferView;
+
+/** Builds {@link TradeOfferView} instances for tests outside this package. */
+public final class TradeViewFixtures
+{
+	private TradeViewFixtures()
+	{
+	}
+
+	public static TradeOfferView offer(String cardName, boolean foil)
+	{
+		return new TradeOfferView("test-" + cardName, cardName, foil, "Player", 1710000000000L);
+	}
+}

--- a/src/test/java/com/osrstcg/ui/SharedCardRendererTest.java
+++ b/src/test/java/com/osrstcg/ui/SharedCardRendererTest.java
@@ -1,0 +1,65 @@
+package com.osrstcg.ui;
+
+import com.google.gson.Gson;
+import com.osrstcg.data.CardDatabase;
+import com.osrstcg.data.CardDefinition;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Characterizes that a non-foil card face renders identically across animation frames:
+ * only the foil sheen/sparkle overlays read the clock, so repaint timers may safely
+ * skip frames while no foil card is on screen.
+ */
+public class SharedCardRendererTest
+{
+	@Test
+	public void nonFoilCardFaceIsIdenticalAcrossAnimationFrames()
+	{
+		CardDatabase db = new CardDatabase(new Gson());
+		db.load();
+		CardDefinition card = db.getCards().get(0);
+		Color rarity = db.chatRarityColorForCardName(card.getName());
+
+		BufferedImage first = renderFace(card, rarity);
+		waitForNextAnimationFrame();
+		BufferedImage second = renderFace(card, rarity);
+
+		Assert.assertArrayEquals(pixels(first), pixels(second));
+	}
+
+	private static BufferedImage renderFace(CardDefinition card, Color rarity)
+	{
+		BufferedImage image = new BufferedImage(
+			SharedCardRenderer.DEFAULT_CARD_WIDTH, SharedCardRenderer.DEFAULT_CARD_HEIGHT, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g2 = image.createGraphics();
+		try
+		{
+			Rectangle bounds = new Rectangle(0, 0, image.getWidth(), image.getHeight());
+			SharedCardRenderer.drawCardFace(g2, bounds, card, false, rarity, null, 0L, false);
+		}
+		finally
+		{
+			g2.dispose();
+		}
+		return image;
+	}
+
+	private static void waitForNextAnimationFrame()
+	{
+		long start = System.currentTimeMillis();
+		while (System.currentTimeMillis() - start <= SharedCardRenderer.FOIL_SPARKLE_FRAME_MS)
+		{
+			Thread.onSpinWait();
+		}
+	}
+
+	private static int[] pixels(BufferedImage image)
+	{
+		return image.getRGB(0, 0, image.getWidth(), image.getHeight(), null, 0, image.getWidth());
+	}
+}

--- a/src/test/java/com/osrstcg/ui/trade/TradeWindowFoilGateTest.java
+++ b/src/test/java/com/osrstcg/ui/trade/TradeWindowFoilGateTest.java
@@ -1,0 +1,40 @@
+package com.osrstcg.ui.trade;
+
+import com.osrstcg.service.CardPartyTradeService.TradeOfferView;
+import com.osrstcg.service.TradeViewFixtures;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * {@code hasFoilOffer} is the gate the foil animation timer uses to decide whether an offer
+ * grid still needs 60fps repaints; non-foil trades would otherwise redraw both sides for nothing.
+ */
+public class TradeWindowFoilGateTest
+{
+	@Test
+	public void hasFoilOfferIsFalseWhenNoOfferedCardIsFoil()
+	{
+		List<TradeOfferView> offers = List.of(
+			TradeViewFixtures.offer("Abyssal whip", false),
+			TradeViewFixtures.offer("Dragon scimitar", false));
+
+		Assert.assertFalse(TradeWindow.hasFoilOffer(offers));
+	}
+
+	@Test
+	public void hasFoilOfferIsTrueWhenAnyOfferedCardIsFoil()
+	{
+		List<TradeOfferView> offers = List.of(
+			TradeViewFixtures.offer("Abyssal whip", false),
+			TradeViewFixtures.offer("Twisted bow", true));
+
+		Assert.assertTrue(TradeWindow.hasFoilOffer(offers));
+	}
+
+	@Test
+	public void hasFoilOfferIsFalseWhenNothingIsOffered()
+	{
+		Assert.assertFalse(TradeWindow.hasFoilOffer(List.of()));
+	}
+}


### PR DESCRIPTION
The trade window's foil animation timer repaints both offer grids at 60fps the whole time the window is open, even with no foil cards offered — each frame re-runs `findByName` plus a full `drawCardFace` per card. On a full 6-per-side non-foil trade that measures ~285–305 ms of EDT time per second (~28–30%) redrawing a static image.

This gates each side's repaint on a foil card actually being present, mirroring the album's `hasVisibleFoilCards()` gate. Non-foil trades drop to zero animation repaints; foil animation is unchanged, and all state changes already repaint via `refreshFromService()`. Only side effect: on all-non-foil trades, newly loaded wiki art now appears via the 500ms debounce instead of the next frame (same as the album).

Tests: `TradeWindowFoilGateTest` covers the gate; `SharedCardRendererTest` verifies non-foil card faces render pixel-identically across animation frames, which is what makes skipping these repaints safe.
