### PR TITLE
feat(dink): improve end-of-pack notification summaries

### DIFF
--- a/src/main/java/com/osrstcg/service/DinkNotificationService.java
+++ b/src/main/java/com/osrstcg/service/DinkNotificationService.java
@@ -4,6 +4,7 @@ import com.osrstcg.data.CardDatabase;
 import com.osrstcg.data.CardDefinition;
 import com.osrstcg.util.PullNotificationMessages;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,13 +28,20 @@ public class DinkNotificationService
 		private final boolean newForCollection;
 		private final boolean foil;
 		private final RarityMath.Tier tier;
+		private final boolean notificationEligible;
 
-		PackPull(String cardName, boolean newForCollection, boolean foil, RarityMath.Tier tier)
+		PackPull(
+			String cardName,
+			boolean newForCollection,
+			boolean foil,
+			RarityMath.Tier tier,
+			boolean notificationEligible)
 		{
 			this.cardName = cardName;
 			this.newForCollection = newForCollection;
 			this.foil = foil;
 			this.tier = tier;
+			this.notificationEligible = notificationEligible;
 		}
 	}
 
@@ -112,13 +120,19 @@ public class DinkNotificationService
 		}
 		List<String> newCards = new ArrayList<>();
 		List<String> duplicates = new ArrayList<>();
-		for (PackPull pull : pulls)
+		List<PackPull> sortedPulls = new ArrayList<>(pulls);
+		sortedPulls.sort(Comparator.comparingInt(DinkNotificationService::tierRank).reversed());
+		for (PackPull pull : sortedPulls)
 		{
 			if (pull == null || pull.cardName == null || pull.cardName.trim().isEmpty())
 			{
 				continue;
 			}
 			String displayName = pull.cardName.trim() + (pull.foil ? " (foil)" : "");
+			if (pull.notificationEligible)
+			{
+				displayName = "**" + displayName + "**";
+			}
 			(pull.newForCollection ? newCards : duplicates).add(displayName);
 		}
 		if (newCards.isEmpty() && duplicates.isEmpty())
@@ -151,6 +165,11 @@ public class DinkNotificationService
 		{
 			log.debug("Failed to post Dink pack summary", ex);
 		}
+	}
+
+	private static int tierRank(PackPull pull)
+	{
+		return pull == null || pull.tier == null ? -1 : pull.tier.ordinal();
 	}
 
 	private String messageWithStatsLine(String message)

--- a/src/main/java/com/osrstcg/service/PullNotificationService.java
+++ b/src/main/java/com/osrstcg/service/PullNotificationService.java
@@ -136,18 +136,21 @@ public class PullNotificationService
 		{
 			return;
 		}
-		List<DinkNotificationService.PackPull> eligiblePulls = new ArrayList<>();
+		List<DinkNotificationService.PackPull> pulls = new ArrayList<>();
 		for (PackRevealService.RevealCard card : cards)
 		{
-			if (card == null || card.getPull() == null || card.getPull().getCardName() == null
-				|| !shouldNotifyDink(card.getTier(), card.getPull().isFoil(), card.isNew()))
+			if (card == null || card.getPull() == null || card.getPull().getCardName() == null)
 			{
 				continue;
 			}
-			eligiblePulls.add(new DinkNotificationService.PackPull(
-				card.getPull().getCardName().trim(), card.isNew(), card.getPull().isFoil(), card.getTier()));
+			pulls.add(new DinkNotificationService.PackPull(
+				card.getPull().getCardName().trim(),
+				card.isNew(),
+				card.getPull().isFoil(),
+				card.getTier(),
+				shouldNotifyDink(card.getTier(), card.getPull().isFoil(), card.isNew())));
 		}
-		dinkNotificationService.notifyPackSummary(eligiblePulls);
+		dinkNotificationService.notifyPackSummary(pulls);
 	}
 
 	private boolean shouldNotifyDink(RarityMath.Tier tier, boolean foil, boolean newForCollection)

--- a/src/main/java/com/osrstcg/util/PullNotificationMessages.java
+++ b/src/main/java/com/osrstcg/util/PullNotificationMessages.java
@@ -24,26 +24,26 @@ public final class PullNotificationMessages
 
 	public static String dinkPackSummaryMessage(List<String> newCards, List<String> duplicates)
 	{
-		return "%USERNAME% opened a booster pack!\n\n"
-			+ "**New cards**\n" + markdownCardList(newCards) + "\n\n"
-			+ "**Duplicates**\n" + markdownCardList(duplicates);
+		StringBuilder message = new StringBuilder("%USERNAME% opened a booster pack!");
+		appendCardSection(message, "New cards", newCards);
+		appendCardSection(message, "Duplicates", duplicates);
+		return message.toString();
 	}
 
-	private static String markdownCardList(List<String> cards)
+	private static void appendCardSection(StringBuilder message, String heading, List<String> cards)
 	{
 		if (cards == null || cards.isEmpty())
 		{
-			return "- None";
+			return;
 		}
-		StringBuilder result = new StringBuilder();
+		message.append("\n\n**").append(heading).append("**");
 		for (String card : cards)
 		{
-			if (result.length() > 0)
+			if (card == null || card.trim().isEmpty())
 			{
-				result.append('\n');
+				continue;
 			}
-			result.append("- ").append(card);
+			message.append("\n- ").append(card);
 		}
-		return result.toString();
 	}
 }

--- a/src/test/java/com/osrstcg/util/PullNotificationMessagesTest.java
+++ b/src/test/java/com/osrstcg/util/PullNotificationMessagesTest.java
@@ -1,0 +1,40 @@
+package com.osrstcg.util;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PullNotificationMessagesTest
+{
+	@Test
+	public void packSummaryOmitsEmptyDuplicatesSection()
+	{
+		assertEquals(
+			"%USERNAME% opened a booster pack!\n\n**New cards**\n- **Zilyana**\n- Goblin",
+			PullNotificationMessages.dinkPackSummaryMessage(
+				Arrays.asList("**Zilyana**", "Goblin"),
+				Collections.emptyList()));
+	}
+
+	@Test
+	public void packSummaryOmitsEmptyNewCardsSection()
+	{
+		assertEquals(
+			"%USERNAME% opened a booster pack!\n\n**Duplicates**\n- **General Graardor**",
+			PullNotificationMessages.dinkPackSummaryMessage(
+				Collections.emptyList(),
+				Collections.singletonList("**General Graardor**")));
+	}
+
+	@Test
+	public void packSummaryContainsOnlyOpeningLineWhenBothSectionsAreEmpty()
+	{
+		assertEquals(
+			"%USERNAME% opened a booster pack!",
+			PullNotificationMessages.dinkPackSummaryMessage(
+				Collections.emptyList(),
+				Collections.emptyList()));
+	}
+}


### PR DESCRIPTION
Include all pulled cards in Dink pack summaries, sort them by rarity with Godly cards first, and bold cards that meet the configured notification threshold. Omit empty new-card and duplicate sections while preserving existing per-card notification behavior