### PR TITLE
Stamp profileSavedAtUnix on master saves so crash recovery can fire

### DIFF
--- a/src/main/java/com/osrstcg/service/TcgStateService.java
+++ b/src/main/java/com/osrstcg/service/TcgStateService.java
@@ -331,6 +331,10 @@ public class TcgStateService
 		{
 			return false;
 		}
+		// Advance the save timestamp so that after a crash (no logout/shutdown checkpoint),
+		// load() sees tcg.save as strictly newer than the stale RSProfile config and
+		// restores it instead of rolling the session back.
+		state = state.withProfileSavedAtUnix(TcgState.currentUnixSeconds());
 		return stateStore.saveMasterOnly(state, trigger == null ? TcgSaveTrigger.COLLECTION_CHANGE : trigger);
 	}
 

--- a/src/test/java/com/osrstcg/persist/TcgStateMigrationTest.java
+++ b/src/test/java/com/osrstcg/persist/TcgStateMigrationTest.java
@@ -1,7 +1,9 @@
 package com.osrstcg.persist;
 
 import com.google.gson.Gson;
+import com.osrstcg.model.OwnedCardInstance;
 import com.osrstcg.model.TcgState;
+import com.osrstcg.service.TcgStateService;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -255,6 +257,30 @@ public class TcgStateMigrationTest
 		// The migration seed must also come from the freshest source, not the stale config.
 		TcgState master = diskStore.loadMaster().orElseThrow();
 		Assert.assertEquals(999L, master.getEconomyState().getCredits());
+	}
+
+	@Test
+	public void crashAfterCollectionChangeRestoresMasterOverStaleConfig()
+	{
+		// Collection changes persist only tcg.save; config is written on checkpoints.
+		// For the stale-config recovery above to ever fire in practice, the master
+		// write must advance profileSavedAtUnix past the config blob's — otherwise an
+		// abnormal exit (crash, kill, power loss) rolls the session back to the stale
+		// config, and the next master save then overwrites tcg.save from that rolled-back
+		// state, losing the session's cards permanently.
+		putEncodedConfig(SCHEMA_5_JSON); // profileSavedAtUnix = 1700000100
+
+		TcgStateService service = new TcgStateService(store, false, null, null, null);
+		service.load();
+		service.addOwnedCardInstance(
+			new OwnedCardInstance("crash-1", "Abyssal whip", false, "Player", 1710000000000L));
+		// Process dies here: no logout/shutdown checkpoint runs.
+
+		TestableTcgStateStore freshStore = new TestableTcgStateStore(codec, diskStore, profile, global);
+		TcgStateLoadResult result = freshStore.load();
+
+		Assert.assertEquals(TcgStateLoadSource.DISK, result.getSource());
+		Assert.assertEquals(2, result.getState().getCollectionState().getOwnedInstances().size());
 	}
 
 	private void putEncodedConfig(String plainJson)


### PR DESCRIPTION
## The bug

`TcgStateService.saveMasterOnly` writes `tcg.save` on every collection change, but never advances `profileSavedAtUnix` — only the checkpoint paths (`saveCheckpoint`/`saveFullCheckpoint`) stamp it. The crash-recovery comparator `TcgStateStore.newerDiskState()` requires the disk save to be **strictly** newer than the RSProfile config blob, so the master written on collection changes can never win.

Concretely:

1. Player logs in; config and in-memory state both carry the timestamp of the last checkpoint (T0).
2. Player opens packs for hours — every change writes `tcg.save`, still stamped T0.
3. Client exits abnormally (JVM crash, kill, power loss) — no logout/shutdown checkpoint runs.
4. Next launch: config loads fine at T0, master is also T0, `T0 > T0` is false → the stale config wins and the whole session is rolled back.
5. The first collection change of the new session overwrites `tcg.save` from the rolled-back state — the crashed session's cards and credits are now gone from every store, permanently.

The existing test `staleConfigDoesNotShadowStrictlyNewerDiskSave` documents the intended recovery behavior, but only passes because it hand-crafts a blob with a newer timestamp; no runtime write path ever produced one.

## The fix

Stamp `profileSavedAtUnix` in `saveMasterOnly` exactly as the two checkpoint paths already do. Healthy sessions are unaffected: a normal logout ends with a full checkpoint stamping master, snapshot, and config with the same timestamp, so config still wins the tie and load behavior is unchanged.

## Test

Added `crashAfterCollectionChangeRestoresMasterOverStaleConfig`, which drives the real path end to end: seed a config blob, load through `TcgStateService`, add a card (persists via `saveMasterOnly`), simulate a crash by loading with a fresh store — the master must be restored over the stale config. It fails on `main` (load falls back to CONFIG, the added card is lost) and passes with the fix. Full suite is green.