### PR TITLE
fix(dink-notifications): Dink was firing regardless of threshold

### DIFF
--- a/src/main/java/com/osrstcg/service/DinkNotificationService.java
+++ b/src/main/java/com/osrstcg/service/DinkNotificationService.java
@@ -114,7 +114,7 @@ public class DinkNotificationService
 
 	void notifyPackSummary(List<PackPull> pulls)
 	{
-		if (pulls == null || pulls.isEmpty())
+		if (!hasNotificationEligiblePull(pulls))
 		{
 			return;
 		}
@@ -165,6 +165,22 @@ public class DinkNotificationService
 		{
 			log.debug("Failed to post Dink pack summary", ex);
 		}
+	}
+
+	static boolean hasNotificationEligiblePull(List<PackPull> pulls)
+	{
+		if (pulls == null || pulls.isEmpty())
+		{
+			return false;
+		}
+		for (PackPull pull : pulls)
+		{
+			if (pull != null && pull.notificationEligible)
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private static int tierRank(PackPull pull)

--- a/src/test/java/com/osrstcg/service/DinkNotificationServiceTest.java
+++ b/src/test/java/com/osrstcg/service/DinkNotificationServiceTest.java
@@ -1,0 +1,46 @@
+package com.osrstcg.service;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DinkNotificationServiceTest
+{
+	@Test
+	public void packSummaryIsSuppressedWhenNoPullIsNotificationEligible()
+	{
+		assertFalse(DinkNotificationService.hasNotificationEligiblePull(Arrays.asList(
+			pull("Common card", false),
+			pull("Rare card", false))));
+	}
+
+	@Test
+	public void packSummaryIsAllowedWhenAnyPullIsNotificationEligible()
+	{
+		assertTrue(DinkNotificationService.hasNotificationEligiblePull(Arrays.asList(
+			pull("Common card", false),
+			pull("Mythic card", true),
+			pull("Another common card", false))));
+	}
+
+	@Test
+	public void emptyOrNullPackSummaryIsSuppressed()
+	{
+		assertFalse(DinkNotificationService.hasNotificationEligiblePull(null));
+		assertFalse(DinkNotificationService.hasNotificationEligiblePull(Collections.emptyList()));
+		assertFalse(DinkNotificationService.hasNotificationEligiblePull(Collections.singletonList(null)));
+	}
+
+	private static DinkNotificationService.PackPull pull(String cardName, boolean notificationEligible)
+	{
+		return new DinkNotificationService.PackPull(
+			cardName,
+			true,
+			false,
+			RarityMath.Tier.COMMON,
+			notificationEligible);
+	}
+}


### PR DESCRIPTION
Added a fix to check if the notification is eligible, by checking all cards before firing the notifcation to see if it meets the players criteria. 