### PR TITLE
docs: add Javadoc across the entire plugin source tree

### DIFF
--- a/src/main/java/com/osrstcg/OsrsTcgConfig.java
+++ b/src/main/java/com/osrstcg/OsrsTcgConfig.java
@@ -9,6 +9,11 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
 
+/**
+ * RuneLite config schema for OSRS TCG. Each default method is a config item; the value shown to
+ * the player is driven by the {@code name}/{@code description} on the {@link ConfigItem}
+ * annotation, and the default method's return value is the out-of-the-box default.
+ */
 @ConfigGroup("osrstcg")
 public interface OsrsTcgConfig extends Config
 {
@@ -26,6 +31,7 @@ public interface OsrsTcgConfig extends Config
 	)
 	String creditsSection = "credits";
 
+	/** Whether to show the on-screen credits infobox. */
 	@ConfigItem(
 		keyName = "creditsInfobox",
 		name = "Credits infobox",
@@ -39,6 +45,7 @@ public interface OsrsTcgConfig extends Config
 		return false;
 	}
 
+	/** Whether the credits infobox also shows a credits/hour rate. */
 	@ConfigItem(
 		keyName = "creditsPerHour",
 		name = "Credits per hour",
@@ -51,6 +58,7 @@ public interface OsrsTcgConfig extends Config
 		return true;
 	}
 
+	/** Sliding window used to compute the credits/hour rate shown on the infobox. */
 	@ConfigItem(
 		keyName = "creditsPerHourWindow",
 		name = "Credits/h window",
@@ -64,6 +72,7 @@ public interface OsrsTcgConfig extends Config
 		return CreditsPerHourWindow.PERSISTENT;
 	}
 
+	/** Whether to post a chat message when the credits threshold in {@link #creditNotificationAmount()} is reached. */
 	@ConfigItem(
 		keyName = "creditNotifications",
 		name = "Credit notifications",
@@ -76,6 +85,7 @@ public interface OsrsTcgConfig extends Config
 		return true;
 	}
 
+	/** Credit balance threshold that triggers {@link #creditNotifications()}. */
 	@ConfigItem(
 		keyName = "creditNotificationAmount",
 		name = "Notification amount",
@@ -88,6 +98,7 @@ public interface OsrsTcgConfig extends Config
 		return 2500;
 	}
 
+	/** Whether credit notifications are also routed through RuneLite's OS-level notification service. */
 	@ConfigItem(
 		keyName = "runeliteNotifications",
 		name = "RuneLite notifications",
@@ -100,6 +111,7 @@ public interface OsrsTcgConfig extends Config
 		return false;
 	}
 
+	/** Whether the sidebar shop hides pack thumbnails to fit more packs on screen. */
 	@ConfigItem(
 		keyName = "compactShop",
 		name = "Compact shop",
@@ -119,6 +131,7 @@ public interface OsrsTcgConfig extends Config
 	)
 	String packOpeningSection = "packOpening";
 
+	/** Whether pack-opening sound effects play. */
 	@ConfigItem(
 		keyName = "enableSounds",
 		name = "Enable pack opening sounds",
@@ -131,6 +144,7 @@ public interface OsrsTcgConfig extends Config
 		return true;
 	}
 
+	/** Whether condition/wear visual effects render on cards in the pack reveal overlay. */
 	@ConfigItem(
 		keyName = "showGradeWear",
 		name = "Show grade wear",
@@ -143,6 +157,7 @@ public interface OsrsTcgConfig extends Config
 		return true;
 	}
 
+	/** Whether hovering an unflipped pack card highlights it by rarity. */
 	@ConfigItem(
 		keyName = "packRarityHighlight",
 		name = "Rarity Highlight",
@@ -155,6 +170,7 @@ public interface OsrsTcgConfig extends Config
 		return true;
 	}
 
+	/** Whether hovering an unflipped pack card shows its rarity name as text (accessibility aid alongside the highlight color). */
 	@ConfigItem(
 		keyName = "packRarityText",
 		name = "Rarity Text",
@@ -168,6 +184,7 @@ public interface OsrsTcgConfig extends Config
 		return false;
 	}
 
+	/** Whether beta-variant copies are excluded when deciding if a pulled card counts as "new". */
 	@ConfigItem(
 		keyName = "ignoreBetaForNewStatus",
 		name = "Ignore beta for new status",
@@ -180,6 +197,7 @@ public interface OsrsTcgConfig extends Config
 		return true;
 	}
 
+	/** Whether the sidebar shows the player's OSRS hiscores rank under overview stats after opening a pack. */
 	@ConfigItem(
 		keyName = "showSidebarRanks",
 		name = "Sidebar hiscores ranks",
@@ -192,6 +210,7 @@ public interface OsrsTcgConfig extends Config
 		return true;
 	}
 
+	/** Color of the "[OSRS TCG]" chat message prefix. */
 	@ConfigItem(
 		keyName = "chatPrefixColor",
 		name = "Chat prefix colour",
@@ -211,6 +230,7 @@ public interface OsrsTcgConfig extends Config
 	)
 	String pullNotificationsSection = "pullNotifications";
 
+	/** Minimum rarity tier that triggers a pull notification. */
 	@ConfigItem(
 		keyName = "notifyTier",
 		name = "Notify tier",
@@ -223,6 +243,7 @@ public interface OsrsTcgConfig extends Config
 		return PullNotifyTier.MYTHIC;
 	}
 
+	/** Minimum rarity tier that triggers a notification when the pull is a duplicate. */
 	@ConfigItem(
 		keyName = "duplicateNotifyTier",
 		name = "Duplicate notify tier",
@@ -235,6 +256,7 @@ public interface OsrsTcgConfig extends Config
 		return PullNotifyTier.LEGENDARY;
 	}
 
+	/** Whether non-foil (normal) card pulls can trigger notifications. */
 	@ConfigItem(
 		keyName = "notifyNonFoils",
 		name = "Notify non-foils",
@@ -247,6 +269,7 @@ public interface OsrsTcgConfig extends Config
 		return true;
 	}
 
+	/** Whether every foil card pull triggers a notification, regardless of rarity tier. */
 	@ConfigItem(
 		keyName = "notifyFoils",
 		name = "Notify all foils",
@@ -259,6 +282,7 @@ public interface OsrsTcgConfig extends Config
 		return true;
 	}
 
+	/** Whether pull notifications are limited to cards new to the player's collection. */
 	@ConfigItem(
 		keyName = "notifyNewCardsOnly",
 		name = "Only notify new cards",
@@ -271,6 +295,7 @@ public interface OsrsTcgConfig extends Config
 		return true;
 	}
 
+	/** Whether pull notifications fire per card as the pack is revealed, or as one summary at pack end. */
 	@ConfigItem(
 		keyName = "pullNotificationTrigger",
 		name = "Notification trigger",
@@ -283,6 +308,7 @@ public interface OsrsTcgConfig extends Config
 		return PullNotificationTrigger.EVERY_CARD;
 	}
 
+	/** Whether pull alerts are also posted to game chat and shared with party members. */
 	@ConfigItem(
 		keyName = "partyAnnouncePulls",
 		name = "Party/chat announcements",
@@ -295,6 +321,7 @@ public interface OsrsTcgConfig extends Config
 		return true;
 	}
 
+	/** Discord webhook URL that pull alerts are posted to; empty disables webhook posting. */
 	@ConfigItem(
 		keyName = "pullWebhookUrl",
 		name = "Webhook URL",
@@ -307,6 +334,7 @@ public interface OsrsTcgConfig extends Config
 		return "";
 	}
 
+	/** Whether pull alerts are also sent through the Dink plugin's notification channel. */
 	@ConfigItem(
 		keyName = "dinkNotifications",
 		name = "Enable Dink notifications",
@@ -326,6 +354,7 @@ public interface OsrsTcgConfig extends Config
 	)
 	String debugSection = "debug";
 
+	/** Whether verbose debug messages are printed to chat. */
 	@ConfigItem(
 		keyName = "debugMessages",
 		name = "Debug messages",

--- a/src/main/java/com/osrstcg/OsrsTcgPlugin.java
+++ b/src/main/java/com/osrstcg/OsrsTcgPlugin.java
@@ -75,6 +75,13 @@ import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.Text;
 
+/**
+ * RuneLite plugin entry point for OSRS TCG. Wires up the sidebar panel, pack-opening overlays,
+ * credit-earning trackers, and cloud sync services via Guice injection, and forwards RuneLite
+ * events to the relevant subsystem. Most of the actual logic lives in the injected services;
+ * this class is mainly lifecycle wiring ({@link #startUp()}/{@link #shutDown()}) and event
+ * dispatch.
+ */
 @Slf4j
 @PluginDescriptor(
 	name = "OSRS TCG",
@@ -84,6 +91,7 @@ import net.runelite.client.util.Text;
 )
 public class OsrsTcgPlugin extends Plugin
 {
+	/** Public chat command players can send/receive to look up another player's TCG stats. */
 	private static final String TCG_PUBLIC_CHAT_COMMAND = "!tcg";
 
 	@Inject
@@ -166,8 +174,13 @@ public class OsrsTcgPlugin extends Plugin
 	private ConfigManager configManager;
 
 	private NavigationButton navigationButton;
+	/** Account hash whose state was last loaded via {@link #loadStateIfLoggedIn()}, or -1 if none yet. */
 	private long loadedAccountHash = -1L;
 
+	/**
+	 * Registers the sidebar panel, overlays, input listeners, and event subscriptions, and kicks
+	 * off catalog prefetch and (if already logged in) state loading and cloud connect.
+	 */
 	@Override
 	protected void startUp()
 	{
@@ -235,6 +248,10 @@ public class OsrsTcgPlugin extends Plugin
 		TcgPluginGameMessages.setPrefixColor(config.chatPrefixColor());
 	}
 
+	/**
+	 * Flushes pending credit/state writes, disconnects from the cloud session, and tears down
+	 * everything registered in {@link #startUp()}.
+	 */
 	@Override
 	protected void shutDown()
 	{
@@ -288,6 +305,7 @@ public class OsrsTcgPlugin extends Plugin
 		cloudSessionCoordinator.onLoggedInGameTick();
 	}
 
+	/** Times out an in-flight pack reveal still waiting on server pull results, closing the sidebar freeze if it does. */
 	private void handlePendingPackOpenTimeout()
 	{
 		if (!packRevealService.isAwaitingServerPulls())
@@ -308,6 +326,7 @@ public class OsrsTcgPlugin extends Plugin
 		tcgPanel.refreshAfterPackRevealClose();
 	}
 
+	/** Saves a final checkpoint and blocks client shutdown until queued attests are flushed to the cloud. */
 	@Subscribe
 	public void onClientShutdown(ClientShutdown event)
 	{
@@ -316,18 +335,21 @@ public class OsrsTcgPlugin extends Plugin
 		event.waitFor(CompletableFuture.runAsync(cloudSessionCoordinator::flushAttestsForShutdown, scheduledExecutorService));
 	}
 
+	/** Awards XP-based credits for the stat gain, refreshing the sidebar if any credits were granted. */
 	@Subscribe
 	public void onStatChanged(StatChanged event)
 	{
 		refreshCreditsIf(creditAwardService.onStatChanged(event));
 	}
 
+	/** Awards credits for a fake (non-tracked-skill) XP drop, refreshing the sidebar if any were granted. */
 	@Subscribe
 	public void onFakeXpDrop(FakeXpDrop event)
 	{
 		refreshCreditsIf(creditAwardService.onFakeXpDrop(event));
 	}
 
+	/** On login, loads the account's saved state; on logout, checkpoints and clears the loaded-account marker. */
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged event)
 	{
@@ -353,6 +375,7 @@ public class OsrsTcgPlugin extends Plugin
 		cloudSessionCoordinator.onWorldChanged(event);
 	}
 
+	/** Reacts to plugin config changes: chat prefix color and compact-shop layout take effect live. */
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
@@ -370,12 +393,14 @@ public class OsrsTcgPlugin extends Plugin
 		}
 	}
 
+	/** Handles an incoming party pull announcement from another party member. */
 	@Subscribe
 	public void onTcgPullPartyMessage(TcgPullPartyMessage message)
 	{
 		tcgPartyInboundHandler.onPull(message);
 	}
 
+	/** Handles an incoming party announcement that a member completed a collection set. */
 	@Subscribe
 	public void onTcgCollectionSetCompletePartyMessage(TcgCollectionSetCompletePartyMessage message)
 	{
@@ -388,24 +413,28 @@ public class OsrsTcgPlugin extends Plugin
 		cloudSessionCoordinator.connect();
 	}
 
+	/** Adds the TCG trade menu entry to eligible right-click menus. */
 	@Subscribe
 	public void onMenuEntryAdded(MenuEntryAdded event)
 	{
 		tcgTradeMenuHandler.onMenuEntryAdded(event);
 	}
 
+	/** Handles clicks on the TCG trade menu entry. */
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
 		tcgTradeMenuHandler.onMenuOptionClicked(event);
 	}
 
+	/** Resets the XP credit baseline and refreshes the sidebar after a profile's state finishes loading. */
 	private void applyLoadedProfileState(TcgStateLoadResult loadResult)
 	{
 		creditAwardService.resetExperienceCreditBaseline();
 		tcgPanel.refresh();
 	}
 
+	/** Loads saved state for the current account once per login, no-op if already loaded or logged out. */
 	private void loadStateIfLoggedIn()
 	{
 		long accountHash = client.getAccountHash();
@@ -434,6 +463,11 @@ public class OsrsTcgPlugin extends Plugin
 		creditsInfoboxMenuHandler.onOverlayMenuClicked(event);
 	}
 
+	/**
+	 * Handles the {@code !tcg} public/private chat command: serves a cached stats line if we have
+	 * one for the requesting player, otherwise fetches from the cloud API asynchronously and
+	 * patches the chat message in once the result arrives.
+	 */
 	private void lookupPublicStatsChatCommand(ChatMessage chatMessage, String message)
 	{
 		if (!message.trim().equalsIgnoreCase(TCG_PUBLIC_CHAT_COMMAND))
@@ -496,6 +530,7 @@ public class OsrsTcgPlugin extends Plugin
 		});
 	}
 
+	/** Refreshes the sidebar's credits display, but only if the caller reports credits were awarded. */
 	private void refreshCreditsIf(boolean awarded)
 	{
 		if (awarded)
@@ -504,16 +539,19 @@ public class OsrsTcgPlugin extends Plugin
 		}
 	}
 
+	/** Schedules a full sidebar refresh on the Swing EDT. */
 	private void refreshPanelOnEdt()
 	{
 		SwingUtilities.invokeLater(tcgPanel::refresh);
 	}
 
+	/** Loads the sidebar navigation button icon from plugin resources. */
 	private BufferedImage buildPanelIcon()
 	{
 		return ImageUtil.loadImageResource(OsrsTcgPlugin.class, "/com/osrstcg/images/sidebar.png");
 	}
 
+	/** Guice provider wiring the RuneLite-generated config proxy for {@link OsrsTcgConfig}. */
 	@Provides
 	OsrsTcgConfig provideConfig(ConfigManager configManager)
 	{

--- a/src/main/java/com/osrstcg/catalog/BoosterPackDefinition.java
+++ b/src/main/java/com/osrstcg/catalog/BoosterPackDefinition.java
@@ -8,6 +8,10 @@ import java.util.List;
 import java.util.Set;
 import lombok.Data;
 
+/**
+ * Catalog definition of a purchasable booster pack: identity, price, category/region filters,
+ * and the image assets used for its thumbnail and reveal sleeve.
+ */
 @Data
 public class BoosterPackDefinition
 {
@@ -20,6 +24,7 @@ public class BoosterPackDefinition
 	private String thumbnail;
 	private String image;
 
+	/** Key used to group this pack's pulls in the collection: {@link #collectionName} if set, else {@link #id}. */
 	public String getCollectionKey()
 	{
 		if (collectionName != null && !collectionName.isBlank())
@@ -29,6 +34,7 @@ public class BoosterPackDefinition
 		return id;
 	}
 
+	/** Whether {@code path} is a hosted asset reference (site-relative or {@code https://}) rather than a bundled resource path. */
 	public static boolean isHostedImagePath(String path)
 	{
 		if (path == null || path.isBlank())
@@ -39,11 +45,13 @@ public class BoosterPackDefinition
 		return t.startsWith("/") || t.startsWith("https://");
 	}
 
+	/** The pack's reveal-sleeve image path, or {@code null} if {@link #image} isn't a hosted path. */
 	public String revealSleevePath()
 	{
 		return isHostedImagePath(image) ? image.trim() : null;
 	}
 
+	/** {@link #category}, trimmed of blanks/nulls; empty list if unset. */
 	public List<String> getCategoryFilters()
 	{
 		if (category == null)
@@ -61,6 +69,10 @@ public class BoosterPackDefinition
 		return out;
 	}
 
+	/**
+	 * Whether {@code card} matches at least one filter in {@code regionFilters}, comparing against the
+	 * card's combined category and region tags. An empty (non-null) filter list matches everything.
+	 */
 	public static boolean cardMatchesRegion(CardDefinition card, List<String> regionFilters)
 	{
 		if (card == null || regionFilters == null)
@@ -82,6 +94,7 @@ public class BoosterPackDefinition
 		return false;
 	}
 
+	/** Canonical keys for every compound-tag part across {@code card}'s category and region tags. */
 	static Set<String> cardPartKeys(CardDefinition card)
 	{
 		Set<String> cardPartKeys = new HashSet<>();
@@ -90,6 +103,7 @@ public class BoosterPackDefinition
 		return cardPartKeys;
 	}
 
+	/** Expands each tag in {@code rawTags} into its compound parts and adds their canonical keys to {@code into}. */
 	private static void addCanonicalParts(Set<String> into, List<String> rawTags)
 	{
 		for (String tag : rawTags)
@@ -105,6 +119,7 @@ public class BoosterPackDefinition
 		}
 	}
 
+	/** Whether every compound part of {@code filter} has a matching canonical key in {@code cardPartKeys}. */
 	private static boolean filterMatchesCard(Set<String> cardPartKeys, String filter)
 	{
 		if (filter.isEmpty())

--- a/src/main/java/com/osrstcg/catalog/CardDatabase.java
+++ b/src/main/java/com/osrstcg/catalog/CardDatabase.java
@@ -16,6 +16,10 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * In-memory holder for the loaded card catalog. Owns the normalized card list plus indexes
+ * (lookup by name, chat rarity color by name) rebuilt whenever the catalog is replaced.
+ */
 @Singleton
 @Slf4j
 public class CardDatabase
@@ -24,16 +28,19 @@ public class CardDatabase
 	private Map<String, Color> chatRarityColors = Map.of();
 	private Map<String, CardDefinition> byLowerCaseName = Map.of();
 
+	/** No-arg constructor for DI. */
 	@Inject
 	public CardDatabase()
 	{
 	}
 
+	/** The current catalog, in load order. */
 	public synchronized List<CardDefinition> getCards()
 	{
 		return cards;
 	}
 
+	/** Card counts grouped by primary category, in first-seen order. */
 	public synchronized Map<String, Long> categoryCounts()
 	{
 		return cards.stream()
@@ -44,11 +51,13 @@ public class CardDatabase
 			));
 	}
 
+	/** Number of cards currently loaded. */
 	public synchronized int size()
 	{
 		return cards.size();
 	}
 
+	/** Case-insensitive lookup by trimmed card name; first card wins on duplicate names. */
 	public synchronized Optional<CardDefinition> findByName(String cardName)
 	{
 		if (isBlank(cardName))
@@ -59,6 +68,7 @@ public class CardDatabase
 		return Optional.ofNullable(byLowerCaseName.get(key));
 	}
 
+	/** Normalizes and swaps in a new catalog, rebuilds the lookup indexes, and logs the load. */
 	public synchronized void replaceCards(List<CardDefinition> incoming, String sourceLabel)
 	{
 		List<CardDefinition> normalized = normalize(incoming == null ? List.of() : incoming);
@@ -68,6 +78,7 @@ public class CardDatabase
 			sourceLabel == null || sourceLabel.isBlank() ? "catalog" : sourceLabel);
 	}
 
+	/** Chat prefix color for {@code cardName}'s rarity tier, or {@link Color#WHITE} if unknown/blank. */
 	public synchronized Color chatRarityColorForCardName(String cardName)
 	{
 		if (cardName == null || cardName.trim().isEmpty())
@@ -78,6 +89,7 @@ public class CardDatabase
 		return c != null ? c : Color.WHITE;
 	}
 
+	/** Rebuilds {@link #chatRarityColors} and {@link #byLowerCaseName} from {@link #cards}; Godly uses the default chat prefix color instead of its tier color. */
 	private void rebuildIndexes()
 	{
 		if (cards.isEmpty())
@@ -107,6 +119,7 @@ public class CardDatabase
 		byLowerCaseName = Collections.unmodifiableMap(nameMap);
 	}
 
+	/** Drops nameless cards, decodes HTML entities in name/examine text, and normalizes tags and image paths for the rest. */
 	private List<CardDefinition> normalize(List<CardDefinition> parsed)
 	{
 		List<CardDefinition> normalized = new ArrayList<>();
@@ -144,6 +157,7 @@ public class CardDatabase
 		return normalized;
 	}
 
+	/** Trims {@code raw}, returning {@code null} for a null or blank value. */
 	static String normalizeImageUrl(String raw)
 	{
 		if (raw == null)
@@ -154,11 +168,13 @@ public class CardDatabase
 		return url.isEmpty() ? null : url;
 	}
 
+	/** Same trimming rule as {@link #normalizeImageUrl}, applied to a foil image path. */
 	static String normalizeFoilImagePath(String raw)
 	{
 		return normalizeImageUrl(raw);
 	}
 
+	/** Replaces {@code card}'s category list with a trimmed, blank-filtered copy (empty list if null). */
 	private static void normalizeCategoryTags(CardDefinition card)
 	{
 		List<String> raw = card.getCategory();
@@ -178,11 +194,13 @@ public class CardDatabase
 		card.setCategory(trimmed);
 	}
 
+	/** {@code rawCategory} trimmed, or {@code "Unknown"} if blank. */
 	private static String safeCategory(String rawCategory)
 	{
 		return isBlank(rawCategory) ? "Unknown" : rawCategory.trim();
 	}
 
+	/** Whether {@code value} is null or all-whitespace. */
 	private static boolean isBlank(String value)
 	{
 		return value == null || value.trim().isEmpty();

--- a/src/main/java/com/osrstcg/catalog/CardDefinition.java
+++ b/src/main/java/com/osrstcg/catalog/CardDefinition.java
@@ -5,6 +5,10 @@ import java.util.Collections;
 import java.util.List;
 import lombok.Data;
 
+/**
+ * Catalog definition of a single card: identity, artwork, rarity tier, and the raw/override
+ * score fields used to compute display and pack-odds values.
+ */
 @Data
 public class CardDefinition
 {
@@ -39,6 +43,14 @@ public class CardDefinition
 	private String examine;
 	private String wikiPage;
 
+	/**
+	 * The score to display/use for odds math. When {@code foil} is true, prefers {@link #foilScore}
+	 * then {@link #overrideFoilScore} (both must be non-negative); otherwise, and as a fallback,
+	 * uses {@link #score} then {@link #overrideScore}, clamped to non-negative. Defaults to 0.
+	 *
+	 * @param foil whether to prefer the foil-specific score
+	 * @return the resolved score, never negative
+	 */
 	public long displayScore(boolean foil)
 	{
 		if (foil)
@@ -63,16 +75,19 @@ public class CardDefinition
 		return 0L;
 	}
 
+	/** {@link #category}, or an empty list if unset. */
 	public List<String> getCategoryTags()
 	{
 		return category == null ? Collections.emptyList() : category;
 	}
 
+	/** {@link #regions}, or an empty list if unset. */
 	public List<String> getRegionTags()
 	{
 		return regions == null ? Collections.emptyList() : regions;
 	}
 
+	/** Display label for the first part of the first category tag (e.g. "Skilling"), or "Unknown" if none. */
 	public String getPrimaryCategory()
 	{
 		List<String> tags = getCategoryTags();

--- a/src/main/java/com/osrstcg/catalog/CardImageCacheService.java
+++ b/src/main/java/com/osrstcg/catalog/CardImageCacheService.java
@@ -39,6 +39,11 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
+/**
+ * Loads and caches card/pack artwork fetched over HTTP. Keeps a bounded in-memory LRU of decoded
+ * images plus an on-disk cache keyed by a normalized URL identity, deduplicates concurrent fetches
+ * of the same image, and cools down repeated failures for a URL instead of retrying every call.
+ */
 @Slf4j
 @Singleton
 public class CardImageCacheService
@@ -63,6 +68,7 @@ public class CardImageCacheService
 	private final Map<String, BufferedImage> memoryCache = Collections.synchronizedMap(
 		new LinkedHashMap<String, BufferedImage>(MEMORY_CACHE_MAX_ENTRIES + 1, 0.75f, true)
 		{
+			/** Evicts the least-recently-used entry once the cache exceeds {@link #MEMORY_CACHE_MAX_ENTRIES}. */
 			@Override
 			protected boolean removeEldestEntry(Map.Entry<String, BufferedImage> eldest)
 			{
@@ -74,6 +80,7 @@ public class CardImageCacheService
 	private static final long FAIL_COOLDOWN_MS = 60_000L;
 	private static final long PACK_FAIL_COOLDOWN_MS = 5_000L;
 
+	/** Wires the HTTP client used to fetch images and the token store used to gate osrs-tcg.net requests. */
 	@Inject
 	public CardImageCacheService(OkHttpClient okHttpClient, CloudTokenStore tokenStore)
 	{
@@ -81,6 +88,7 @@ public class CardImageCacheService
 		this.tokenStore = tokenStore;
 	}
 
+	/** Kicks off background loads for every non-blank URL and returns a future that completes once they've all settled. */
 	public CompletableFuture<Void> preloadAsync(Collection<String> urls)
 	{
 		if (urls == null)
@@ -101,6 +109,10 @@ public class CardImageCacheService
 		return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
 	}
 
+	/**
+	 * Non-blocking lookup: returns the decoded image if it's already in the memory cache, otherwise
+	 * kicks off a background load (unless the URL is in its failure cooldown) and returns {@code null}.
+	 */
 	public BufferedImage getCached(String pathOrUrl)
 	{
 		String fetchUrl = resolveFetchUrl(pathOrUrl);
@@ -123,6 +135,12 @@ public class CardImageCacheService
 		return null;
 	}
 
+	/**
+	 * Returns the in-flight or newly-started load future for {@code rawUrl}, or {@code null} if the
+	 * URL can't be resolved, is already cached, or is in its failure cooldown. Loads run on
+	 * {@link #imageLoadExecutor} gated by {@link #loadPermits}; on completion the result is written
+	 * to {@link #memoryCache} or {@link #failedAtMs} as appropriate.
+	 */
 	private CompletableFuture<BufferedImage> ensureLoad(String rawUrl)
 	{
 		String fetchUrl = resolveFetchUrl(rawUrl);
@@ -174,6 +192,7 @@ public class CardImageCacheService
 			}));
 	}
 
+	/** Whether {@code cacheKey} failed recently enough to still be within its cooldown window (pack/card-back URLs use a shorter one); clears expired entries. */
 	private boolean isInFailCooldown(String cacheKey, String fetchUrl)
 	{
 		Long failedAt = failedAtMs.get(cacheKey);
@@ -192,6 +211,12 @@ public class CardImageCacheService
 		return true;
 	}
 
+	/**
+	 * Loads one image: tries disk cache first, then (for {@code https://} URLs, and gated by cloud
+	 * consent for osrs-tcg.net hosts) fetches over HTTP, persisting the bytes to disk and re-reading
+	 * via {@link #tryLoadFromDisk} so the result is subsampled the same way either path takes.
+	 * Returns {@code null} on any failure.
+	 */
 	private BufferedImage loadImage(String fetchUrl, String cacheKey)
 	{
 		BufferedImage fromDisk = tryLoadFromDisk(cacheKey, fetchUrl);
@@ -257,6 +282,7 @@ public class CardImageCacheService
 		return null;
 	}
 
+	/** Bilinearly downscales {@code source} so its longer edge is at most {@code maxEdgePx}; returns it unchanged if already within the cap. */
 	private static BufferedImage downscaleForMemoryCache(BufferedImage source, int maxEdgePx)
 	{
 		if (source == null)
@@ -286,6 +312,7 @@ public class CardImageCacheService
 		return scaled;
 	}
 
+	/** Deletes disk cache directories from prior cache-format versions, freeing space left behind by upgrades. */
 	public void deleteObsoleteImageCacheDirs()
 	{
 		Path root = tcgCacheRoot();
@@ -294,6 +321,7 @@ public class CardImageCacheService
 		deleteDirectoryQuietly(root.resolve("images"));
 	}
 
+	/** Recursively deletes {@code dir} if it exists, logging but not throwing on failure. */
 	private static void deleteDirectoryQuietly(Path dir)
 	{
 		if (dir == null || !Files.isDirectory(dir))
@@ -321,6 +349,7 @@ public class CardImageCacheService
 		}
 	}
 
+	/** Disk cache path for {@code cacheKey}: a name derived from the pack/card-back URL for pack assets, else a hashed filename under the general cache dir. */
 	private Path diskCacheFile(String cacheKey)
 	{
 		String packName = ImageCacheIdentity.packDiskFileName(cacheKey);
@@ -331,6 +360,11 @@ public class CardImageCacheService
 		return diskCacheDir().resolve(TcgStateHash.hexOfUtf8(cacheKey) + ".png");
 	}
 
+	/**
+	 * Reads and decodes the disk-cached image for {@code cacheKey}, if present and readable, subsampling
+	 * during decode so the result is already near the target memory-cache size (deletes the file and
+	 * returns {@code null} if it can't be decoded as an image).
+	 */
 	private BufferedImage tryLoadFromDisk(String cacheKey, String edgeHintUrl)
 	{
 		Path file = diskCacheFile(cacheKey);
@@ -390,6 +424,7 @@ public class CardImageCacheService
 		}
 	}
 
+	/** Writes {@code bytes} to the disk cache file for {@code cacheKey}, atomically; no-ops on empty input and logs (not throws) on write failure. */
 	private void persistBytesToDisk(String cacheKey, byte[] bytes)
 	{
 		if (bytes == null || bytes.length == 0)
@@ -407,6 +442,7 @@ public class CardImageCacheService
 		}
 	}
 
+	/** Resolves {@code rawUrl} to an absolute fetchable URL via {@link CloudEndpoints#resolvePublicUrl}, or {@code null} if it can't be resolved. */
 	private static String resolveFetchUrl(String rawUrl)
 	{
 		if (rawUrl == null)
@@ -421,16 +457,19 @@ public class CardImageCacheService
 		return fetchUrl;
 	}
 
+	/** The plugin's cache root directory under the RuneLite data dir. */
 	private static Path tcgCacheRoot()
 	{
 		return Path.of(RuneLite.RUNELITE_DIR.getAbsolutePath(), "OSRS-TCG");
 	}
 
+	/** Disk cache directory for general card images (current format version). */
 	private Path diskCacheDir()
 	{
 		return tcgCacheRoot().resolve("images-v4");
 	}
 
+	/** Disk cache directory for pack sleeve/card-back assets, kept separate since they're keyed by filename rather than hash. */
 	private Path packDiskCacheDir()
 	{
 		return tcgCacheRoot().resolve("packs");

--- a/src/main/java/com/osrstcg/catalog/CategoryListTypeAdapter.java
+++ b/src/main/java/com/osrstcg/catalog/CategoryListTypeAdapter.java
@@ -14,6 +14,7 @@ import java.util.List;
  */
 public final class CategoryListTypeAdapter extends TypeAdapter<List<String>>
 {
+	/** Writes {@code value} as a JSON array of strings, or {@code null} if the list is null. */
 	@Override
 	public void write(JsonWriter out, List<String> value) throws IOException
 	{
@@ -30,6 +31,7 @@ public final class CategoryListTypeAdapter extends TypeAdapter<List<String>>
 		out.endArray();
 	}
 
+	/** Reads a JSON null as an empty list, a single string as a one-element list, or an array as its string elements (non-strings skipped). Any other token is skipped and returns an empty list. */
 	@Override
 	public List<String> read(JsonReader in) throws IOException
 	{

--- a/src/main/java/com/osrstcg/catalog/CategoryTagUtil.java
+++ b/src/main/java/com/osrstcg/catalog/CategoryTagUtil.java
@@ -5,12 +5,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
+/**
+ * Helpers for parsing and normalizing category/region tags, which may be compound values joined
+ * with {@code &} (e.g. {@code "Bosses & Slayer"}).
+ */
 public final class CategoryTagUtil
 {
 	private CategoryTagUtil()
 	{
 	}
 
+	/** Splits {@code raw} on {@code &} into its trimmed, non-empty parts; empty list if {@code raw} is null/blank. */
 	public static List<String> expandCompoundParts(String raw)
 	{
 		if (raw == null)
@@ -34,6 +39,7 @@ public final class CategoryTagUtil
 		return out;
 	}
 
+	/** Lowercased, trimmed form of a single (non-compound) tag part, used as a comparison/lookup key; empty string if null. */
 	public static String canonicalKey(String singleTagPart)
 	{
 		if (singleTagPart == null)
@@ -43,6 +49,7 @@ public final class CategoryTagUtil
 		return singleTagPart.trim().toLowerCase(Locale.ROOT);
 	}
 
+	/** Title-cases each whitespace-separated word of {@code canonicalKey} for display (e.g. "bosses" to "Bosses"). */
 	public static String toDisplayLabel(String canonicalKey)
 	{
 		if (canonicalKey == null || canonicalKey.isEmpty())

--- a/src/main/java/com/osrstcg/catalog/CollectionSetCompletionUtil.java
+++ b/src/main/java/com/osrstcg/catalog/CollectionSetCompletionUtil.java
@@ -9,12 +9,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Derives category/collection-set completion status from an owned-cards map: which card names are
+ * owned, and which primary categories in the roll pool are fully collected.
+ */
 public final class CollectionSetCompletionUtil
 {
 	private CollectionSetCompletionUtil()
 	{
 	}
 
+	/** Card names with at least one owned copy (summed across normal/foil variants), from {@code owned} quantities keyed by {@link CardCollectionKey}. */
 	public static Set<String> collectedNamesFromOwned(Map<CardCollectionKey, Integer> owned)
 	{
 		if (owned == null || owned.isEmpty())
@@ -43,6 +48,7 @@ public final class CollectionSetCompletionUtil
 		return collectedNames;
 	}
 
+	/** Whether {@code owned} has at least one foil copy of {@code cardName}. */
 	public static boolean hasFoilOwned(Map<CardCollectionKey, Integer> owned, String cardName)
 	{
 		if (owned == null || cardName == null)
@@ -53,6 +59,7 @@ public final class CollectionSetCompletionUtil
 		return n != null && n > 0;
 	}
 
+	/** Primary category names from {@code rollPool} where every card in that category is owned per {@code owned}. */
 	public static Set<String> completedPrimaryCategoryNames(Map<CardCollectionKey, Integer> owned,
 		List<CardDefinition> rollPool)
 	{
@@ -87,6 +94,7 @@ public final class CollectionSetCompletionUtil
 		return done;
 	}
 
+	/** Categories completed in {@code ownedAfter} but not in {@code ownedBefore}, i.e. completed by the change between the two snapshots. */
 	public static List<String> newlyCompletedCategories(Map<CardCollectionKey, Integer> ownedBefore,
 		Map<CardCollectionKey, Integer> ownedAfter, List<CardDefinition> rollPool)
 	{

--- a/src/main/java/com/osrstcg/catalog/ImageCacheIdentity.java
+++ b/src/main/java/com/osrstcg/catalog/ImageCacheIdentity.java
@@ -4,6 +4,10 @@ import com.osrstcg.persist.TcgStateHash;
 import java.util.Locale;
 import okhttp3.HttpUrl;
 
+/**
+ * URL classification and normalization helpers for {@link CardImageCacheService}: strips volatile
+ * query params to derive a stable cache key, and picks decode-size caps and disk filenames by URL shape.
+ */
 final class ImageCacheIdentity
 {
 	static final int MAX_MEMORY_IMAGE_EDGE_PX = 130;
@@ -14,6 +18,7 @@ final class ImageCacheIdentity
 	{
 	}
 
+	/** Stable cache key for {@code absoluteUrl}: strips all query params for artwork-file paths (their auth tokens vary per request), else strips only the {@code token} query param. */
 	static String cacheIdentity(String absoluteUrl)
 	{
 		if (absoluteUrl == null || absoluteUrl.isEmpty())
@@ -29,6 +34,7 @@ final class ImageCacheIdentity
 		return stripQueryParam(absoluteUrl, "token");
 	}
 
+	/** Whether {@code absoluteUrl} is an artwork-file URL carrying a short-lived auth token, meaning fetch failures shouldn't be cached as a cooldown. */
 	static boolean isEphemeralAuthUrl(String absoluteUrl)
 	{
 		if (absoluteUrl == null || absoluteUrl.isEmpty())
@@ -39,6 +45,7 @@ final class ImageCacheIdentity
 		return lower.contains("/artwork/files/") && lower.contains("token=");
 	}
 
+	/** Removes every occurrence of the query param named {@code paramName} from {@code absoluteUrl}, dropping the {@code ?} entirely if nothing remains. */
 	static String stripQueryParam(String absoluteUrl, String paramName)
 	{
 		if (absoluteUrl == null || paramName == null || paramName.isEmpty())
@@ -78,6 +85,7 @@ final class ImageCacheIdentity
 		return kept.length() == 0 ? base : base + '?' + kept;
 	}
 
+	/** Max decoded-image edge length (px) to keep in memory for {@code url}: larger for card backs, full-art/foil, and pack sleeves (thumbnails excepted); default otherwise. */
 	static int maxMemoryEdgeForUrl(String url)
 	{
 		if (url == null || url.isEmpty())
@@ -104,23 +112,32 @@ final class ImageCacheIdentity
 		return MAX_MEMORY_IMAGE_EDGE_PX;
 	}
 
+	/** Whether {@code normalizedUrl} points at a pack sleeve/thumbnail asset. */
 	static boolean isPackAssetUrl(String normalizedUrl)
 	{
 		return normalizedUrl != null
 			&& normalizedUrl.toLowerCase(Locale.ROOT).contains("/images/packs/");
 	}
 
+	/** Whether {@code normalizedUrl} points at the card-back image. */
 	static boolean isCardBackUrl(String normalizedUrl)
 	{
 		return normalizedUrl != null
 			&& normalizedUrl.toLowerCase(Locale.ROOT).contains("/images/cardback");
 	}
 
+	/** Whether {@code normalizedUrl} should use the shorter fetch-failure cooldown (pack/card-back assets, expected to be more transiently unavailable). */
 	static boolean isShortFailCooldownUrl(String normalizedUrl)
 	{
 		return isPackAssetUrl(normalizedUrl) || isCardBackUrl(normalizedUrl);
 	}
 
+	/**
+	 * Disk cache filename for a pack asset URL, or {@code null} if {@code normalizedUrl} isn't a pack
+	 * asset/card-back URL. Card backs always use {@code "cardback.png"}; other pack assets keep the
+	 * URL's last path segment with unsafe characters replaced by {@code _}, falling back to a hash
+	 * of the URL if that segment is blank or unusable.
+	 */
 	static String packDiskFileName(String normalizedUrl)
 	{
 		if (isCardBackUrl(normalizedUrl))
@@ -167,6 +184,7 @@ final class ImageCacheIdentity
 		return cleaned;
 	}
 
+	/** Whether {@code url}'s host is {@code osrs-tcg.net} or a subdomain of it. */
 	static boolean isOsrsTcgNetUrl(String url)
 	{
 		HttpUrl parsed = HttpUrl.parse(url);

--- a/src/main/java/com/osrstcg/catalog/RarityMath.java
+++ b/src/main/java/com/osrstcg/catalog/RarityMath.java
@@ -9,6 +9,7 @@ import java.util.Optional;
  */
 public final class RarityMath
 {
+	/** Rarity tiers from most to least common, each with a display label and UI color. */
 	public enum Tier
 	{
 		COMMON("Common", new Color(0xFFFFFF)),
@@ -22,17 +23,20 @@ public final class RarityMath
 		private final String label;
 		private final Color color;
 
+		/** Stores the tier's display label and color. */
 		Tier(String label, Color color)
 		{
 			this.label = label;
 			this.color = color;
 		}
 
+		/** The tier's display label (e.g. "Legendary"). */
 		public String getLabel()
 		{
 			return label;
 		}
 
+		/** The tier's UI color. */
 		public Color getColor()
 		{
 			return color;
@@ -43,6 +47,7 @@ public final class RarityMath
 	{
 	}
 
+	/** Parses {@code label} against each {@link Tier#getLabel()}, case-insensitively; empty if null/blank/unmatched. */
 	public static Optional<Tier> tryParseTierLabel(String label)
 	{
 		if (label == null)
@@ -64,6 +69,7 @@ public final class RarityMath
 		return Optional.empty();
 	}
 
+	/** Like {@link #tryParseTierLabel}, but defaults to {@link Tier#COMMON} instead of empty. */
 	public static Tier tierFromLabel(String label)
 	{
 		return tryParseTierLabel(label).orElse(Tier.COMMON);

--- a/src/main/java/com/osrstcg/catalog/RollPoolFilter.java
+++ b/src/main/java/com/osrstcg/catalog/RollPoolFilter.java
@@ -11,6 +11,7 @@ public final class RollPoolFilter
 	{
 	}
 
+	/** Currently a passthrough (empty list stays empty); filtering already happened at catalog build time. */
 	public static List<CardDefinition> filterRollPool(List<CardDefinition> cards)
 	{
 		if (cards == null || cards.isEmpty())

--- a/src/main/java/com/osrstcg/cloud/activity/ActivityConfigModels.java
+++ b/src/main/java/com/osrstcg/cloud/activity/ActivityConfigModels.java
@@ -3,19 +3,27 @@ package com.osrstcg.cloud.activity;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Raw Gson DTOs for the server's activity-config JSON payload, plus the response wrapper for the
+ * conditional-GET fetch. {@link ActivityConfigService} compiles these into {@link CompiledActivityConfig}.
+ */
 public final class ActivityConfigModels
 {
+	/** Namespace only; not instantiable. */
 	private ActivityConfigModels()
 	{
 	}
 
+	/** Top-level activity config payload as returned by the cloud API or read from the disk cache. */
 	public static final class ActivityConfigDto
 	{
+		/** Opaque version/ETag string used for change detection. */
 		public String version;
 		public List<ActivityChatRuleDto> chatRules = new ArrayList<>();
 		public NpcExclusionsDto npcExclusions = new NpcExclusionsDto();
 	}
 
+	/** One chat-message-to-credits rule, matched by literal prefix or regex against a chat line. */
 	public static final class ActivityChatRuleDto
 	{
 		public String activityId;
@@ -26,6 +34,7 @@ public final class ActivityConfigModels
 		public String label;
 	}
 
+	/** NPC ids excluded from credit-earning activities, given as individual ids and/or inclusive ranges. */
 	public static final class NpcExclusionsDto
 	{
 		public List<Integer> npcIds = new ArrayList<>();
@@ -33,6 +42,7 @@ public final class ActivityConfigModels
 		public List<List<Integer>> npcIdRanges = new ArrayList<>();
 	}
 
+	/** Result of a conditional-GET activity config fetch: either "unchanged" (304) or a fresh body. */
 	public static final class ActivitiesConfigResponse
 	{
 		private final boolean notModified;
@@ -44,21 +54,25 @@ public final class ActivityConfigModels
 			this.body = body;
 		}
 
+		/** Server reported the client's cached version is still current; no new body was returned. */
 		public static ActivitiesConfigResponse notModified()
 		{
 			return new ActivitiesConfigResponse(true, null);
 		}
 
+		/** Server returned a fresh config body to replace the cached one. */
 		public static ActivitiesConfigResponse ok(ActivityConfigDto body)
 		{
 			return new ActivitiesConfigResponse(false, body);
 		}
 
+		/** True if the server responded 304 Not Modified and {@link #getBody()} is null. */
 		public boolean isNotModified()
 		{
 			return notModified;
 		}
 
+		/** The fresh config body, or null when {@link #isNotModified()} is true. */
 		public ActivityConfigDto getBody()
 		{
 			return body;

--- a/src/main/java/com/osrstcg/cloud/activity/ActivityConfigService.java
+++ b/src/main/java/com/osrstcg/cloud/activity/ActivityConfigService.java
@@ -31,6 +31,13 @@ import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.RuneLite;
 
+/**
+ * Fetches, caches, and compiles the server-driven activity config (chat-based credit rules and NPC
+ * exclusions) used to award activity credits. Holds the current {@link CompiledActivityConfig} in an
+ * {@link AtomicReference} for lock-free reads; network refreshes run asynchronously on {@link #scheduler}
+ * and never block callers of the getters. A copy is persisted to disk so the last-good config survives
+ * restarts and cloud API failures.
+ */
 @Slf4j
 @Singleton
 public final class ActivityConfigService
@@ -48,6 +55,7 @@ public final class ActivityConfigService
 	private final Object pollLock = new Object();
 	private ScheduledFuture<?> quietPollFuture;
 
+	/** Wires collaborators and registers to be notified when the cloud API observes a new remote version. */
 	@Inject
 	ActivityConfigService(CloudApiClient api, Gson gson, ScheduledExecutorService scheduler)
 	{
@@ -57,6 +65,7 @@ public final class ActivityConfigService
 		api.setActivitiesVersionListener(this::noteRemoteVersion);
 	}
 
+	/** Synchronously loads the on-disk cached config, if any, so a compiled config is available before any network fetch. Blocks on disk I/O; call off the client thread during startup. */
 	public void loadDiskCacheIfPresent()
 	{
 		Path file = diskCacheFile();
@@ -81,17 +90,20 @@ public final class ActivityConfigService
 		}
 	}
 
+	/** Kicks off an async, best-effort refresh without blocking the caller. */
 	public void prefetchAsync()
 	{
 		scheduler.execute(this::ensureFreshSafe);
 	}
 
+	/** Starts the periodic quiet poll and triggers an immediate async refresh; call once per login. */
 	public void refreshOnLogin()
 	{
 		startQuietPoll();
 		scheduler.execute(this::ensureFreshSafe);
 	}
 
+	/** Cancels the periodic quiet poll, if running; call on logout. */
 	public void stopQuietPoll()
 	{
 		synchronized (pollLock)
@@ -104,6 +116,11 @@ public final class ActivityConfigService
 		}
 	}
 
+	/**
+	 * Callback for {@link CloudApiClient}'s version listener: if {@code remoteVersion} differs from the
+	 * cached version, schedules a single async refresh (coalesced via {@link #softRefreshScheduled} so
+	 * repeated notifications don't queue duplicate refreshes).
+	 */
 	public void noteRemoteVersion(String remoteVersion)
 	{
 		if (remoteVersion == null || remoteVersion.isBlank())
@@ -133,6 +150,12 @@ public final class ActivityConfigService
 		});
 	}
 
+	/**
+	 * Synchronously checks the remote version and, if stale, fetches and applies a fresh config; a single
+	 * refresh runs at a time ({@link #ensureInFlight} guards re-entry) and failures are logged and swallowed,
+	 * keeping the last-good compiled config. Performs blocking network I/O; call from {@link #scheduler}, not
+	 * the client thread.
+	 */
 	public void ensureFresh()
 	{
 		if (!ensureInFlight.compareAndSet(false, true))
@@ -159,6 +182,7 @@ public final class ActivityConfigService
 		}
 	}
 
+	/** {@link #ensureFresh()} wrapped with a catch-all so a scheduled task never dies from an unexpected exception. */
 	private void ensureFreshSafe()
 	{
 		try
@@ -171,6 +195,10 @@ public final class ActivityConfigService
 		}
 	}
 
+	/**
+	 * Does the actual version check and conditional-GET fetch: skips the fetch entirely if a lightweight
+	 * version check confirms the cache is current, and skips applying the body on a 304. Blocking network I/O.
+	 */
 	private void ensureFreshLocked() throws CloudApiException, IOException
 	{
 		String cachedVersion = getVersion();
@@ -209,21 +237,25 @@ public final class ActivityConfigService
 			getVersion(), getChatRules().size());
 	}
 
+	/** Version of the currently compiled config; non-blocking. */
 	public String getVersion()
 	{
 		return compiled.get().getVersion();
 	}
 
+	/** Chat rules from the currently compiled config; non-blocking. */
 	public List<CompiledActivityConfig.CompiledChatRule> getChatRules()
 	{
 		return compiled.get().getChatRules();
 	}
 
+	/** Currently compiled config snapshot; non-blocking. */
 	public CompiledActivityConfig getCompiled()
 	{
 		return compiled.get();
 	}
 
+	/** Starts a fixed-rate background refresh poll if one isn't already running. */
 	private void startQuietPoll()
 	{
 		synchronized (pollLock)
@@ -240,6 +272,7 @@ public final class ActivityConfigService
 		}
 	}
 
+	/** Compiles {@code dto} and publishes it as the current config, optionally persisting the raw DTO to disk. */
 	private void applyDto(ActivityConfigDto dto, boolean persistDisk)
 	{
 		CompiledActivityConfig next = compile(dto);
@@ -250,6 +283,10 @@ public final class ActivityConfigService
 		}
 	}
 
+	/**
+	 * Converts a raw {@link ActivityConfigDto} into an immutable {@link CompiledActivityConfig}: compiles
+	 * each chat rule (dropping invalid ones), and expands NPC exclusion ids/ranges into a flat id set.
+	 */
 	static CompiledActivityConfig compile(ActivityConfigDto dto)
 	{
 		if (dto == null)
@@ -306,6 +343,10 @@ public final class ActivityConfigService
 		return new CompiledActivityConfig(version, rules, npcIds);
 	}
 
+	/**
+	 * Compiles one raw chat rule, or returns null if it's missing required fields or (for a regex rule)
+	 * has an invalid pattern.
+	 */
 	private static CompiledActivityConfig.CompiledChatRule compileChatRule(ActivityChatRuleDto rule)
 	{
 		if (rule == null || rule.activityId == null || rule.activityId.isBlank()
@@ -332,6 +373,7 @@ public final class ActivityConfigService
 			rule.activityId.trim(), rule.credits, rule.label, rule.value, null);
 	}
 
+	/** Best-effort atomic write of the raw DTO JSON to the disk cache; failures are logged and swallowed. */
 	private void persistDiskCache(ActivityConfigDto dto)
 	{
 		Path target = diskCacheFile();
@@ -345,11 +387,13 @@ public final class ActivityConfigService
 		}
 	}
 
+	/** Directory under the RuneLite home dir holding the activity config disk cache. */
 	private static Path diskCacheDir()
 	{
 		return Path.of(RuneLite.RUNELITE_DIR.getAbsolutePath(), "OSRS-TCG", "activities");
 	}
 
+	/** Path to the cached raw activity config JSON file. */
 	private static Path diskCacheFile()
 	{
 		return diskCacheDir().resolve("activities.json");

--- a/src/main/java/com/osrstcg/cloud/activity/CompiledActivityConfig.java
+++ b/src/main/java/com/osrstcg/cloud/activity/CompiledActivityConfig.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
  */
 public final class CompiledActivityConfig
 {
+	/** Empty config used before any fetch/disk-cache load has succeeded. */
 	public static final CompiledActivityConfig EMPTY = new CompiledActivityConfig(
 		"",
 		List.of(),
@@ -18,6 +19,7 @@ public final class CompiledActivityConfig
 	private final List<CompiledChatRule> chatRules;
 	private final Set<Integer> excludedNpcIds;
 
+	/** Normalizes nulls to empty and defensively copies the collections into immutable ones. */
 	CompiledActivityConfig(
 		String version,
 		List<CompiledChatRule> chatRules,
@@ -28,6 +30,7 @@ public final class CompiledActivityConfig
 		this.excludedNpcIds = excludedNpcIds == null ? Set.of() : Set.copyOf(excludedNpcIds);
 	}
 
+	/** Opaque version string this config was compiled from; empty for {@link #EMPTY}. */
 	public String getVersion()
 	{
 		return version;
@@ -38,11 +41,13 @@ public final class CompiledActivityConfig
 		return chatRules;
 	}
 
+	/** Whether {@code npcId} is excluded from credit-earning activities. */
 	public boolean isExcludedNpc(int npcId)
 	{
 		return excludedNpcIds.contains(npcId);
 	}
 
+	/** Precompiled chat-message match rule: literal prefix or regex, mutually exclusive. */
 	public static final class CompiledChatRule
 	{
 		private final String activityId;
@@ -51,6 +56,7 @@ public final class CompiledActivityConfig
 		private final String prefix;
 		private final Pattern pattern;
 
+		/** Normalizes nulls and clamps credits to non-negative; exactly one of {@code prefix}/{@code pattern} is expected. */
 		CompiledChatRule(String activityId, long credits, String label, String prefix, Pattern pattern)
 		{
 			this.activityId = activityId == null ? "" : activityId;
@@ -60,6 +66,7 @@ public final class CompiledActivityConfig
 			this.pattern = pattern;
 		}
 
+		/** True if {@code message} satisfies this rule's regex or prefix match. */
 		public boolean matches(String message)
 		{
 			if (message == null)

--- a/src/main/java/com/osrstcg/cloud/api/CloudApiClient.java
+++ b/src/main/java/com/osrstcg/cloud/api/CloudApiClient.java
@@ -33,6 +33,13 @@ import static com.osrstcg.cloud.api.JsonObjects.textTrimmed;
 import com.osrstcg.cloud.session.ProfileKeyHasher;
 import com.osrstcg.cloud.trade.TradeInboxItem;
 
+/**
+ * Blocking HTTP client for the cloud API. Every method that issues a request performs a
+ * synchronous network call and must not be invoked on the client thread; callers are expected
+ * to run these off-thread (e.g. via a scheduler). Handles auth headers, one-shot token refresh
+ * on 401, consent gating before the account has migrated, and mapping HTTP error bodies to
+ * {@link CloudApiException}.
+ */
 @Slf4j
 @Singleton
 public final class CloudApiClient
@@ -50,6 +57,7 @@ public final class CloudApiClient
 	/** Nesting depth for {@link #openConsentTraffic()} (create-profile after Yes). */
 	private final ThreadLocal<Integer> consentTrafficDepth = ThreadLocal.withInitial(() -> 0);
 
+	/** Builds a dedicated {@link OkHttpClient} from the injected one with fixed connect/read/write timeouts. */
 	@Inject
 	CloudApiClient(
 		OkHttpClient okHttpClient,
@@ -102,26 +110,31 @@ public final class CloudApiClient
 			"Accept cloud consent before contacting the server");
 	}
 
+	/** Called when a token refresh fails because the refresh token itself is stale, so credentials get cleared. */
 	public void setStaleRefreshHandler(Runnable handler)
 	{
 		staleRefreshHandler = handler;
 	}
 
+	/** Called whenever a request fails with an account-banned or account-quarantined error. */
 	public void setAccountLockHandler(Consumer<CloudApiException> handler)
 	{
 		accountLockHandler = handler;
 	}
 
+	/** Called with the trimmed {@code X-Activities-Version} header value whenever a response carries one. */
 	public void setActivitiesVersionListener(Consumer<String> listener)
 	{
 		activitiesVersionCb = listener;
 	}
 
+	/** Last catalog version observed from any response, or null if none yet. */
 	public String getCachedCatalogVersion()
 	{
 		return cachedCatalogVersion;
 	}
 
+	/** {@code GET /health} (unauthenticated). Blocking call. */
 	public JsonObject getHealth() throws CloudApiException, IOException
 	{
 		JsonObject json = request("GET", "/health", null, false);
@@ -129,6 +142,7 @@ public final class CloudApiClient
 		return json;
 	}
 
+	/** {@code GET /packs}. Blocking call. */
 	public JsonObject getPacks() throws CloudApiException, IOException
 	{
 		JsonObject json = requestAuthed("GET", "/packs", null);
@@ -136,6 +150,10 @@ public final class CloudApiClient
 		return json;
 	}
 
+	/**
+	 * {@code GET /catalog/cards/live}, sending {@code cachedCatalogVersion} as an If-None-Match
+	 * ETag so the server can respond 304. Blocking call.
+	 */
 	public LiveCardsResponse getLiveCards(String cachedCatalogVersion) throws CloudApiException, IOException
 	{
 		try (Response response = getWithOptionalEtag("/catalog/cards/live", cachedCatalogVersion))
@@ -165,6 +183,7 @@ public final class CloudApiClient
 		}
 	}
 
+	/** {@code GET /players/{name}/stats} (unauthenticated, name URL-encoded with spaces as underscores). Blocking call. */
 	public JsonObject getPublicPlayerStats(String displayName) throws CloudApiException, IOException
 	{
 		String name = displayName == null ? "" : displayName.trim();
@@ -173,6 +192,7 @@ public final class CloudApiClient
 		return request("GET", "/players/" + encoded + "/stats", null, false);
 	}
 
+	/** Updates {@link #cachedCatalogVersion} if non-blank; no-op otherwise. */
 	private void setCachedCatalogVersion(String catalogVersion)
 	{
 		if (catalogVersion != null && !catalogVersion.isBlank())
@@ -181,11 +201,13 @@ public final class CloudApiClient
 		}
 	}
 
+	/** Extracts and caches the {@code catalogVersion} field from a JSON body, if present. */
 	private void cacheCatalogVersionFrom(JsonObject json)
 	{
 		setCachedCatalogVersion(textTrimmed(json, "catalogVersion"));
 	}
 
+	/** {@code POST /auth/pair/start} (unauthenticated). Blocking call. */
 	public JsonObject pairStart(String displayName, String profileKeyHash, long accountHash)
 		throws CloudApiException, IOException
 	{
@@ -196,6 +218,7 @@ public final class CloudApiClient
 		return request("POST", "/auth/pair/start", body, false);
 	}
 
+	/** {@code POST /auth/refresh} (unauthenticated). Blocking call. */
 	public JsonObject refresh(String refreshToken, String profileKeyHash) throws CloudApiException, IOException
 	{
 		JsonObject body = new JsonObject();
@@ -204,6 +227,7 @@ public final class CloudApiClient
 		return request("POST", "/auth/refresh", body, false);
 	}
 
+	/** {@code POST /auth/web-code}, requesting a one-time code to sign into the web app. Blocking call. */
 	public JsonObject webCode(String next) throws CloudApiException, IOException
 	{
 		JsonObject body = new JsonObject();
@@ -214,16 +238,19 @@ public final class CloudApiClient
 		return requestAuthed("POST", "/auth/web-code", body);
 	}
 
+	/** {@code GET /me/stats}. Blocking call. */
 	public JsonObject getStats() throws CloudApiException, IOException
 	{
 		return requestAuthed("GET", "/me/stats", null);
 	}
 
+	/** {@code GET /me/state}. Blocking call. */
 	public JsonObject getState() throws CloudApiException, IOException
 	{
 		return requestAuthed("GET", "/me/state", null);
 	}
 
+	/** {@code GET /me/cards}, paginated (limit clamped to 1-500). Blocking call. */
 	public JsonObject getCardsPage(int limit, String cursor) throws CloudApiException, IOException
 	{
 		int pageLimit = Math.max(1, Math.min(limit, 500));
@@ -235,11 +262,13 @@ public final class CloudApiClient
 		return requestAuthed("GET", path.toString(), null);
 	}
 
+	/** {@code POST /credits/attest}. Blocking call. */
 	public JsonObject attest(JsonObject body) throws CloudApiException, IOException
 	{
 		return requestAuthed("POST", "/credits/attest", body);
 	}
 
+	/** {@code POST /credits/settle-hiscores}. Blocking call. */
 	public JsonObject settleHiscores(String displayName, long accountHash, boolean snapshot)
 		throws CloudApiException, IOException
 	{
@@ -253,17 +282,23 @@ public final class CloudApiClient
 		return requestAuthed("POST", "/credits/settle-hiscores", body);
 	}
 
+	/** {@link #settleHiscores(String, long, boolean)} without requesting a snapshot. */
 	public JsonObject settleHiscores(String displayName, long accountHash) throws CloudApiException, IOException
 	{
 		return settleHiscores(displayName, accountHash, false);
 	}
 
+	/** {@code GET /config/activities/version} (unauthenticated). Blocking call. */
 	public String getActivitiesVersion() throws CloudApiException, IOException
 	{
 		String version = text(request("GET", "/config/activities/version", null, false), "version");
 		return version == null ? "" : version;
 	}
 
+	/**
+	 * {@code GET /config/activities}, sending {@code cachedVersion} as an If-None-Match ETag so
+	 * the server can respond 304. Blocking call.
+	 */
 	public ActivitiesConfigResponse getActivities(String cachedVersion) throws CloudApiException, IOException
 	{
 		try (Response response = getWithOptionalEtag("/config/activities", cachedVersion))
@@ -292,11 +327,13 @@ public final class CloudApiClient
 		}
 	}
 
+	/** {@code POST /packs/open}. Blocking call. */
 	public JsonObject openPack(JsonObject body) throws CloudApiException, IOException
 	{
 		return requestAuthed("POST", "/packs/open", body);
 	}
 
+	/** Adds the required {@code accountHash} field to a trade mutator request body. */
 	public static JsonObject withPluginAccountHash(JsonObject body, long accountHash)
 	{
 		if (accountHash == -1L)
@@ -308,6 +345,7 @@ public final class CloudApiClient
 		return out;
 	}
 
+	/** {@code POST /trades}. Blocking call. */
 	public JsonObject createTrade(String partnerDisplayName, long accountHash) throws CloudApiException, IOException
 	{
 		JsonObject body = withPluginAccountHash(new JsonObject(), accountHash);
@@ -315,6 +353,7 @@ public final class CloudApiClient
 		return requestAuthed("POST", "/trades", body);
 	}
 
+	/** {@code GET /me/trades/inbox}, optionally filtered to entries since {@code sinceRevision}. Blocking call. */
 	public JsonObject getTradeInbox(long accountHash, Long sinceRevision) throws CloudApiException, IOException
 	{
 		String path = "/me/trades/inbox?accountHash=" + accountHash;
@@ -325,12 +364,14 @@ public final class CloudApiClient
 		return requestAuthed("GET", path, null);
 	}
 
+	/** {@code POST /me/trades/{tradeId}/ack-notify}. Blocking call. */
 	public JsonObject ackTradeNotify(String tradeId, long accountHash) throws CloudApiException, IOException
 	{
 		JsonObject body = withPluginAccountHash(new JsonObject(), accountHash);
 		return requestAuthed("POST", "/me/trades/" + tradeId + "/ack-notify", body);
 	}
 
+	/** Parses the {@code inbox} array of a trade-inbox response, skipping malformed entries. */
 	public List<TradeInboxItem> parseInbox(JsonObject response)
 	{
 		List<TradeInboxItem> out = new ArrayList<>();
@@ -356,6 +397,7 @@ public final class CloudApiClient
 		return out;
 	}
 
+	/** Persists {@code accessToken}/{@code refreshToken}/{@code accountId}/{@code status} from an auth response, and marks migrated if indicated. */
 	public void applyTokenResponse(JsonObject tokens)
 	{
 		if (tokens == null)
@@ -373,6 +415,10 @@ public final class CloudApiClient
 		}
 	}
 
+	/**
+	 * Issues an authenticated request; on a 401 makes one attempt to refresh the access token and
+	 * retries once before giving up.
+	 */
 	private JsonObject requestAuthed(String method, String pathAndQuery, JsonObject body)
 		throws CloudApiException, IOException
 	{
@@ -390,6 +436,13 @@ public final class CloudApiClient
 		}
 	}
 
+	/**
+	 * Attempts a synchronous token refresh using the stored refresh token and current profile
+	 * key hash. Clears stored credentials and invokes the stale-refresh handler if the refresh
+	 * token itself is rejected as stale.
+	 *
+	 * @return true if the refresh succeeded and new tokens were applied.
+	 */
 	private boolean tryRefresh()
 	{
 		String refresh = tokenStore.getRefreshToken();
@@ -428,6 +481,11 @@ public final class CloudApiClient
 		}
 	}
 
+	/**
+	 * Builds and executes a single HTTP request against the cloud API. Enforces the consent gate,
+	 * attaches the bearer token when {@code authed}, serializes {@code body} as the JSON payload
+	 * for non-GET methods, and throws {@link CloudApiException} on a non-2xx response.
+	 */
 	private JsonObject request(String method, String pathAndQuery, JsonObject body, boolean authed)
 		throws CloudApiException, IOException
 	{
@@ -465,6 +523,7 @@ public final class CloudApiClient
 		}
 	}
 
+	/** Builds a {@link CloudApiException} from an error response and notifies the account-lock handler if applicable. */
 	private CloudApiException httpError(int status, String body)
 	{
 		CloudApiException ex = exceptionFromHttpBody(status, body);
@@ -486,6 +545,7 @@ public final class CloudApiClient
 		return ex;
 	}
 
+	/** Parses an error response body's {@code error.code}/{@code error.message}/{@code credits} fields into an exception. */
 	private static CloudApiException exceptionFromHttpBody(int status, String body)
 	{
 		String code = "http_error";
@@ -511,6 +571,7 @@ public final class CloudApiClient
 		return new CloudApiException(status, code, CloudHttpErrorMapper.humanize(status, code, message), serverCredits);
 	}
 
+	/** Forwards a non-blank {@code X-Activities-Version} header value to the registered listener, swallowing its errors. */
 	private void notifyActivitiesVersion(String headerValue)
 	{
 		if (headerValue == null || headerValue.isBlank())
@@ -531,6 +592,7 @@ public final class CloudApiClient
 		}
 	}
 
+	/** Removes the surrounding quotes from a raw ETag header value, if present. */
 	private static String stripQuotes(String etag)
 	{
 		if (etag == null)
@@ -545,6 +607,7 @@ public final class CloudApiClient
 		return t;
 	}
 
+	/** Resolves and parses the API URL for {@code pathAndQuery}, throwing if the configured base URL is invalid. */
 	private HttpUrl requireApiUrl(String pathAndQuery) throws CloudApiException
 	{
 		HttpUrl url = HttpUrl.parse(CloudEndpoints.apiUrl(pathAndQuery));
@@ -555,6 +618,7 @@ public final class CloudApiClient
 		return url;
 	}
 
+	/** Issues a GET, enforcing the consent gate and attaching an If-None-Match header when {@code cachedVersion} is set. */
 	private Response getWithOptionalEtag(String path, String cachedVersion) throws CloudApiException, IOException
 	{
 		requireCloudConsentAllowed();
@@ -571,6 +635,7 @@ public final class CloudApiClient
 		return http.newCall(b.build()).execute();
 	}
 
+	/** Reads the response body, throwing {@link CloudApiException} if the response was not successful. */
 	private String readSuccessfulBody(Response response) throws CloudApiException, IOException
 	{
 		String text = readBody(response);
@@ -581,12 +646,14 @@ public final class CloudApiClient
 		return text;
 	}
 
+	/** Reads the response body as UTF-8 text, or {@code ""} if there is none. */
 	private static String readBody(Response response) throws IOException
 	{
 		ResponseBody body = response.body();
 		return body == null ? "" : new String(body.bytes(), StandardCharsets.UTF_8);
 	}
 
+	/** Parses {@code text} as a JSON object; returns an empty object for blank/invalid/non-object input. */
 	private static JsonObject parseObject(String text)
 	{
 		if (text == null || text.isEmpty())

--- a/src/main/java/com/osrstcg/cloud/api/CloudApiException.java
+++ b/src/main/java/com/osrstcg/cloud/api/CloudApiException.java
@@ -1,5 +1,6 @@
 package com.osrstcg.cloud.api;
 
+/** Thrown by {@link CloudApiClient} for any failed cloud HTTP call (non-2xx response or transport-level rejection). */
 public final class CloudApiException extends Exception
 {
 	private final int status;
@@ -7,11 +8,17 @@ public final class CloudApiException extends Exception
 	/** Optional server credits from an error body (e.g. insufficient funds on pack open). */
 	private final Long serverCredits;
 
+	/** Creates an exception with no server-reported credits balance. */
 	public CloudApiException(int status, String code, String message)
 	{
 		this(status, code, message, null);
 	}
 
+	/**
+	 * @param status HTTP status code, or 0 for a non-HTTP failure (e.g. invalid base URL).
+	 * @param code server error code, defaulted to {@code "error"} when null.
+	 * @param message human-facing message; falls back to {@code code} when null.
+	 */
 	public CloudApiException(int status, String code, String message, Long serverCredits)
 	{
 		super(message == null ? code : message);
@@ -20,11 +27,13 @@ public final class CloudApiException extends Exception
 		this.serverCredits = serverCredits;
 	}
 
+	/** HTTP status code, or 0 for a non-HTTP failure. */
 	public int getStatus()
 	{
 		return status;
 	}
 
+	/** Server error code (never null; defaults to {@code "error"}). */
 	public String getCode()
 	{
 		return code;
@@ -36,41 +45,49 @@ public final class CloudApiException extends Exception
 		return serverCredits;
 	}
 
+	/** True for HTTP 401 (not signed in / expired token). */
 	public boolean isUnauthorized()
 	{
 		return status == 401;
 	}
 
+	/** True for HTTP 429 (client should back off and retry later). */
 	public boolean isRateLimited()
 	{
 		return status == 429;
 	}
 
+	/** True for any 5xx response. */
 	public boolean isServerError()
 	{
 		return status >= 500 && status < 600;
 	}
 
+	/** True when the server rejected the request due to a stale local catalog version. */
 	public boolean isCatalogMismatch()
 	{
 		return "catalog_mismatch".equals(code);
 	}
 
+	/** True when the account is permanently banned. */
 	public boolean isAccountBanned()
 	{
 		return "banned".equalsIgnoreCase(code) || "account_banned".equalsIgnoreCase(code);
 	}
 
+	/** True when the account is temporarily quarantined. */
 	public boolean isAccountQuarantined()
 	{
 		return "quarantined".equalsIgnoreCase(code);
 	}
 
+	/** True when the refresh token itself is invalid/stale, meaning stored credentials should be cleared. */
 	public boolean isStaleRefreshToken()
 	{
 		return "invalid_refresh_token".equals(code) || "profile_mismatch".equals(code);
 	}
 
+	/** True when the failure is due to the account not having enough credits, inferred from code or message. */
 	public boolean isInsufficientCredits()
 	{
 		String normalizedCode = code == null ? "" : code.trim().toLowerCase();

--- a/src/main/java/com/osrstcg/cloud/api/CloudConnectionState.java
+++ b/src/main/java/com/osrstcg/cloud/api/CloudConnectionState.java
@@ -1,9 +1,14 @@
 package com.osrstcg.cloud.api;
 
+/** High-level cloud connectivity state for UI display. */
 public enum CloudConnectionState
 {
+	/** No active session with the cloud backend. */
 	DISCONNECTED,
+	/** A connection attempt (pairing / token refresh) is in progress. */
 	CONNECTING,
+	/** Authenticated and able to reach the cloud backend. */
 	CONNECTED,
+	/** Last attempt failed. */
 	ERROR
 }

--- a/src/main/java/com/osrstcg/cloud/api/CloudEndpoints.java
+++ b/src/main/java/com/osrstcg/cloud/api/CloudEndpoints.java
@@ -1,5 +1,6 @@
 package com.osrstcg.cloud.api;
 
+/** Base URLs for the cloud API/web backend and helpers for building/rewriting URLs against them. */
 public final class CloudEndpoints
 {
 	public static final String API_BASE_URL = "https://api.osrs-tcg.net/api/v1";
@@ -9,6 +10,7 @@ public final class CloudEndpoints
 	{
 	}
 
+	/** Resolves a path (or already-absolute {@code https://} URL) against {@link #API_BASE_URL}. */
 	public static String apiUrl(String pathAndQuery)
 	{
 		if (pathAndQuery == null || pathAndQuery.isBlank())
@@ -19,11 +21,17 @@ public final class CloudEndpoints
 		return joined.isEmpty() ? API_BASE_URL : joined;
 	}
 
+	/** Resolves a path (or already-absolute {@code https://} URL) against {@link #WEB_BASE_URL}. */
 	public static String webUrl(String pathOrUrl)
 	{
 		return joinHttps(WEB_BASE_URL, pathOrUrl);
 	}
 
+	/**
+	 * Resolves a value that may be an absolute URL, an {@code /api/v1/...} path, another
+	 * {@code /api/...} path, or a bare web path, into an absolute {@code https://} URL.
+	 * Returns {@code ""} for null/blank input.
+	 */
 	public static String resolvePublicUrl(String pathOrUrl)
 	{
 		if (pathOrUrl == null)
@@ -50,6 +58,10 @@ public final class CloudEndpoints
 		return webUrl(raw);
 	}
 
+	/**
+	 * Rewrites a server-provided URL (any host) or path onto {@link #WEB_BASE_URL}, keeping only
+	 * the path/query. Returns null for null/blank input.
+	 */
 	public static String rewriteToWebBase(String serverUrl)
 	{
 		if (serverUrl == null || serverUrl.isBlank())
@@ -69,6 +81,7 @@ public final class CloudEndpoints
 		return WEB_BASE_URL + (raw.startsWith("/") ? raw : "/" + raw);
 	}
 
+	/** Joins {@code pathOrUrl} onto {@code httpsBase} unless it is already an absolute {@code https://} URL. */
 	private static String joinHttps(String httpsBase, String pathOrUrl)
 	{
 		if (pathOrUrl == null)

--- a/src/main/java/com/osrstcg/cloud/api/CloudHttpErrorMapper.java
+++ b/src/main/java/com/osrstcg/cloud/api/CloudHttpErrorMapper.java
@@ -7,6 +7,11 @@ final class CloudHttpErrorMapper
 	{
 	}
 
+	/**
+	 * Produces a short player-facing message: a canned message for rate limiting or an
+	 * HTML/gateway body, the trimmed/truncated server message otherwise, or a status-based
+	 * default when the message is blank.
+	 */
 	static String humanize(int status, String code, String message)
 	{
 		if (status == 429 || "rate_limited".equals(code))
@@ -26,6 +31,7 @@ final class CloudHttpErrorMapper
 		return cleaned;
 	}
 
+	/** True when {@code text} looks like an HTML error page (e.g. from an nginx gateway) rather than API JSON. */
 	static boolean looksLikeHtmlOrGatewayPage(String text)
 	{
 		String lower = text.toLowerCase(java.util.Locale.ROOT);
@@ -36,6 +42,7 @@ final class CloudHttpErrorMapper
 			|| lower.contains("nginx/");
 	}
 
+	/** Generic player-facing message for an HTTP status when no usable server message is available. */
 	static String defaultMessageForHttpStatus(int status)
 	{
 		if (status == 401 || status == 403)

--- a/src/main/java/com/osrstcg/cloud/api/CloudResponseSync.java
+++ b/src/main/java/com/osrstcg/cloud/api/CloudResponseSync.java
@@ -4,12 +4,14 @@ import com.google.gson.JsonObject;
 import com.osrstcg.cloud.trade.TradeCloudService;
 import com.osrstcg.state.TcgStateService;
 
+/** Applies the {@code revision}/{@code stateHash} fields present on many cloud API responses to local sync state. */
 public final class CloudResponseSync
 {
 	private CloudResponseSync()
 	{
 	}
 
+	/** No-op when {@code response} lacks a {@code revision} field; otherwise records it on both services. */
 	public static void applyRevision(JsonObject response, TcgStateService stateService, TradeCloudService tradeCloud)
 	{
 		if (response == null || !response.has("revision") || response.get("revision").isJsonNull())

--- a/src/main/java/com/osrstcg/cloud/api/JsonObjects.java
+++ b/src/main/java/com/osrstcg/cloud/api/JsonObjects.java
@@ -2,12 +2,14 @@ package com.osrstcg.cloud.api;
 
 import com.google.gson.JsonObject;
 
+/** Null-safe accessors for reading fields out of cloud API {@link JsonObject} responses. */
 public final class JsonObjects
 {
 	private JsonObjects()
 	{
 	}
 
+	/** Trims {@code value}; returns null if it was null or blank. */
 	public static String blankToNull(String value)
 	{
 		if (value == null || value.isBlank())
@@ -17,6 +19,7 @@ public final class JsonObjects
 		return value.trim();
 	}
 
+	/** Returns {@code root.get(key)} as an object, or an empty {@link JsonObject} if absent/null/not an object. */
 	public static JsonObject objectOrEmpty(JsonObject root, String key)
 	{
 		if (root != null && key != null && root.has(key) && root.get(key).isJsonObject())
@@ -26,6 +29,7 @@ public final class JsonObjects
 		return new JsonObject();
 	}
 
+	/** Reads a boolean field, defaulting to false when absent, null, or not boolean-typed. */
 	public static boolean readBoolean(JsonObject o, String key)
 	{
 		if (o == null || key == null || !o.has(key) || o.get(key).isJsonNull())
@@ -42,17 +46,20 @@ public final class JsonObjects
 		}
 	}
 
+	/** Reads a numeric field as a nullable {@link Double}; null when absent, null, or not numeric. */
 	public static Double readNullableDouble(JsonObject o, String key)
 	{
 		return readNumberKey(o, key);
 	}
 
+	/** Reads a numeric field rounded to a long, or {@code fallback} when absent/null/not numeric. */
 	public static long readLong(JsonObject o, String key, long fallback)
 	{
 		Double value = readNumberKey(o, key);
 		return value == null ? fallback : Math.round(value);
 	}
 
+	/** Reads a string field, or null when absent, null, or not string-typed. */
 	public static String text(JsonObject o, String key)
 	{
 		if (o == null || key == null || !o.has(key) || o.get(key).isJsonNull())
@@ -69,6 +76,7 @@ public final class JsonObjects
 		}
 	}
 
+	/** Like {@link #text(JsonObject, String)}, but trims and returns null for an empty result. */
 	public static String textTrimmed(JsonObject o, String key)
 	{
 		String value = text(o, key);
@@ -80,22 +88,26 @@ public final class JsonObjects
 		return trimmed.isEmpty() ? null : trimmed;
 	}
 
+	/** Reads a numeric field rounded to an int, or 0 when absent/null/not numeric. */
 	public static int readInt(JsonObject o, String key)
 	{
 		return (int) Math.round(readDouble(o, key));
 	}
 
+	/** Reads a numeric field rounded to a long, or 0 when absent/null/not numeric. */
 	public static long readLong(JsonObject o, String key)
 	{
 		return Math.round(readDouble(o, key));
 	}
 
+	/** Reads a numeric field as a primitive double, or 0.0 when absent/null/not numeric. */
 	public static double readDouble(JsonObject o, String key)
 	{
 		Double value = readNumber(o, key);
 		return value == null ? 0.0d : value;
 	}
 
+	/** Reads a numeric field by {@code primary} key, falling back through {@code aliases} in order; null if none match. */
 	public static Double readNumber(JsonObject o, String primary, String... aliases)
 	{
 		Double value = readNumberKey(o, primary);
@@ -118,6 +130,7 @@ public final class JsonObjects
 		return null;
 	}
 
+	/** Reads a numeric field as a nullable {@link Double}; null when absent, null, or not numeric. */
 	private static Double readNumberKey(JsonObject o, String key)
 	{
 		if (o == null || key == null || !o.has(key) || o.get(key).isJsonNull())

--- a/src/main/java/com/osrstcg/cloud/attest/AttestRateCapNotifier.java
+++ b/src/main/java/com/osrstcg/cloud/attest/AttestRateCapNotifier.java
@@ -16,6 +16,10 @@ import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.chat.ChatMessageManager;
 
+/**
+ * Watches credit attest responses for {@code rate_cap} rejection reasons and posts a throttled,
+ * player-facing chat warning. Safe to call from any thread; internal state is a single atomic timestamp.
+ */
 @Slf4j
 @Singleton
 public final class AttestRateCapNotifier
@@ -27,27 +31,35 @@ public final class AttestRateCapNotifier
 	private final Consumer<String> chatSink;
 	private final AtomicLong lastRateCapWarnAtMs = new AtomicLong(0L);
 
+	/** Injected constructor: routes warnings to the prefixed game chat. */
 	@Inject
 	AttestRateCapNotifier(ChatMessageManager chatMessageManager)
 	{
 		this(body -> TcgPluginGameMessages.queuePrefixedGameMessage(chatMessageManager, body));
 	}
 
+	/** Test/internal constructor with a pluggable chat sink; a null sink is replaced with a no-op. */
 	AttestRateCapNotifier(Consumer<String> chatSink)
 	{
 		this.chatSink = chatSink == null ? body -> { } : chatSink;
 	}
 
+	/** Clears the throttle so the next rate-cap rejection warns immediately. Called on session reset. */
 	public void reset()
 	{
 		lastRateCapWarnAtMs.set(0L);
 	}
 
+	/** Inspects an attest response for rate-cap rejections and quarantine, using the current time. */
 	public void onAttestResponse(JsonObject response)
 	{
 		onAttestResponse(response, System.currentTimeMillis());
 	}
 
+	/**
+	 * Logs any rate-cap rejection reasons found in {@code response} and, subject to throttling, warns
+	 * the player in chat. Also logs a warning if the response is marked quarantined.
+	 */
 	void onAttestResponse(JsonObject response, long nowMs)
 	{
 		if (response == null)
@@ -76,6 +88,7 @@ public final class AttestRateCapNotifier
 		}
 	}
 
+	/** Extracts distinct {@code reason} values from {@code response.rejected} that start with {@code rate_cap}. */
 	static List<String> collectRateCapReasons(JsonObject response)
 	{
 		Set<String> reasons = new LinkedHashSet<>();
@@ -112,6 +125,7 @@ public final class AttestRateCapNotifier
 		return List.copyOf(reasons);
 	}
 
+	/** True if {@code reason}, case-insensitively, starts with the {@code rate_cap} prefix. */
 	static boolean isRateCapReason(String reason)
 	{
 		if (reason == null || reason.isBlank())
@@ -121,6 +135,7 @@ public final class AttestRateCapNotifier
 		return reason.trim().toLowerCase(Locale.ROOT).startsWith(RATE_CAP_PREFIX);
 	}
 
+	/** Builds the chat message for a rate-cap warning, preferring a category-specific message when one applies. */
 	static String playerFacingRateCapMessage(List<String> reasons)
 	{
 		String specific = mapSpecificMessage(reasons);
@@ -131,6 +146,10 @@ public final class AttestRateCapNotifier
 		return "Credit rate limit hit - some XP/kills were not credited this hour. Try again later.";
 	}
 
+	/**
+	 * Returns a message naming the single credit category (skill/level/kills/activity/global) hit by the
+	 * rate cap, or {@code null} if the reasons are empty or span more than one category.
+	 */
 	private static String mapSpecificMessage(List<String> reasons)
 	{
 		if (reasons == null || reasons.isEmpty())
@@ -194,6 +213,7 @@ public final class AttestRateCapNotifier
 		return null;
 	}
 
+	/** Posts the rate-cap chat warning unless one was already sent within {@link #RATE_CAP_THROTTLE_MS}. */
 	private void maybeWarnRateCap(List<String> reasons, long nowMs)
 	{
 		while (true)
@@ -212,6 +232,7 @@ public final class AttestRateCapNotifier
 		}
 	}
 
+	/** Formats every {@code reason} found in {@code response.rejected} as a bracketed list, for debug logging. */
 	private static String formatAllRejectReasons(JsonObject response)
 	{
 		if (response == null || !response.has("rejected") || !response.get("rejected").isJsonArray())

--- a/src/main/java/com/osrstcg/cloud/attest/AttestRejectRequeuer.java
+++ b/src/main/java/com/osrstcg/cloud/attest/AttestRejectRequeuer.java
@@ -7,6 +7,12 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Reinterprets rejected events from an attest response and re-queues fixed-up versions of them onto
+ * {@link CreditAttestQueue}. Handles two known reject reasons: {@code settle_cooldown} (retry unchanged)
+ * and {@code kill_amount_too_large} (split an oversized npc_kill into {@link CreditAttestCoalescer#MAX_KILL_AMOUNT}
+ * chunks). Runs on the flush thread, as part of {@link CreditAttestPoster#postAttestBatch}.
+ */
 @Slf4j
 final class AttestRejectRequeuer
 {
@@ -20,6 +26,13 @@ final class AttestRejectRequeuer
 		this.queue = queue;
 	}
 
+	/**
+	 * Walks {@code response.rejected}, matching each rejection's {@code index} back to the sent
+	 * {@code batch}, and re-queues a corrected event for the reasons this class knows how to fix.
+	 * Any events produced are prepended to the queue's pending list and an early flush is scheduled.
+	 *
+	 * @return the reject reasons seen and the indexes into {@code batch} that were requeued
+	 */
 	AttestRejectRequeuer.RequeueResult requeueRejectedEvents(JsonObject response, List<JsonObject> batch)
 	{
 		RequeueResult result = new RequeueResult();
@@ -127,6 +140,7 @@ final class AttestRejectRequeuer
 		return result;
 	}
 
+	/** Reasons seen and batch indexes requeued for a single {@link #requeueRejectedEvents} call. */
 	static final class RequeueResult
 	{
 		final List<Integer> requeuedIndexes = new ArrayList<>();

--- a/src/main/java/com/osrstcg/cloud/attest/CreditAttestCoalescer.java
+++ b/src/main/java/com/osrstcg/cloud/attest/CreditAttestCoalescer.java
@@ -16,6 +16,12 @@ import static com.osrstcg.cloud.attest.CreditAttestQueue.evidenceLong;
 import static com.osrstcg.cloud.attest.CreditAttestQueue.evidenceObject;
 import static com.osrstcg.cloud.attest.CreditAttestQueue.evidenceString;
 
+/**
+ * Stateless helper that merges raw credit-attest events (xp/level-up/npc-kill/activity) into fewer,
+ * aggregated wire events, and picks which of those to send first when there are too many for one batch.
+ * All methods are static and side-effect free (aside from mutating the {@code coalesced} list passed to
+ * {@link #takePriorityBatch}); safe to call from any thread.
+ */
 public final class CreditAttestCoalescer
 {
 	public static final int MAX_BATCH = 100;
@@ -38,6 +44,12 @@ public final class CreditAttestCoalescer
 	{
 	}
 
+	/**
+	 * Aggregates raw events: xp_chunk merges by skill+hour, level_up merges by skill (widening the
+	 * from/to range), npc_kill merges by npc+combat level+hour then splits back into
+	 * {@link #MAX_KILL_AMOUNT}-sized chunks, and activity (and any unrecognized type) passes through
+	 * unmerged. Combat-skill xp is dropped (see {@link #isCombatSkillName}), as are zero-progress events.
+	 */
 	public static List<JsonObject> coalesce(List<JsonObject> rawEvents)
 	{
 		if (rawEvents == null || rawEvents.isEmpty())
@@ -124,11 +136,17 @@ public final class CreditAttestCoalescer
 		return out;
 	}
 
+	/** Convenience for checking the early-flush threshold without keeping the coalesced result. */
 	public static int estimateCoalescedCount(List<JsonObject> rawEvents)
 	{
 		return coalesce(rawEvents).size();
 	}
 
+	/**
+	 * Removes up to {@code max} events from {@code coalesced} (mutating it) and returns them as a batch,
+	 * highest {@link #priorityScore} first, so the most valuable credits are sent when a flush can't fit
+	 * everything in one request.
+	 */
 	public static List<JsonObject> takePriorityBatch(List<JsonObject> coalesced, int max)
 	{
 		if (coalesced == null || coalesced.isEmpty() || max <= 0)
@@ -172,17 +190,24 @@ public final class CreditAttestCoalescer
 		return batch;
 	}
 
+	/** True for the melee/ranged/magic/defence skills whose xp is never attested directly (kills are instead). */
 	public static boolean isCombatSkillName(String skill)
 	{
 		return COMBAT_SKILLS_BLOCK_XP.contains(normalizeSkillKey(skill));
 	}
 
+	/** True for "HITPOINTS" or any skill name prefixed with it (e.g. boss-specific hitpoints variants). */
 	public static boolean isHitpointsSkillName(String skill)
 	{
 		String key = normalizeSkillKey(skill);
 		return key.equals(HITPOINTS_SKILL_KEY) || key.startsWith(HITPOINTS_SKILL_KEY + " ");
 	}
 
+	/**
+	 * True if every event in {@code events} is a hitpoints xp_chunk. Used to hold back a batch that
+	 * carries no real credit value (hitpoints xp is never awarded optimistic credits) rather than
+	 * spending a flush cycle on it.
+	 */
 	public static boolean isHitpointsXpOnly(List<JsonObject> events)
 	{
 		if (events == null || events.isEmpty())
@@ -204,6 +229,7 @@ public final class CreditAttestCoalescer
 		return true;
 	}
 
+	/** Trims and upper-cases a skill name for use as a stable grouping/comparison key; null becomes "". */
 	public static String normalizeSkillKey(String skill)
 	{
 		if (skill == null)
@@ -213,6 +239,7 @@ public final class CreditAttestCoalescer
 		return skill.trim().toUpperCase(Locale.ROOT);
 	}
 
+	/** Floors an epoch-millis timestamp to its hour bucket, clamping negative input to 0. */
 	public static long epochHour(long atMs)
 	{
 		long t = atMs;
@@ -223,6 +250,7 @@ public final class CreditAttestCoalescer
 		return t / HOUR_MS;
 	}
 
+	/** Adds one xp_chunk's delta into its skill+hour bucket; skips combat skills and non-positive deltas. */
 	private static void mergeXp(Map<String, XpAgg> xpBySkillHour, JsonObject evidence, long at, long optimistic)
 	{
 		String skill = evidenceString(evidence, "skill", "");
@@ -253,6 +281,7 @@ public final class CreditAttestCoalescer
 		agg.lastAt = Math.max(agg.lastAt, at);
 	}
 
+	/** Widens a skill's level-up bucket to cover [min fromLevel, max toLevel]; skips non-progressing entries. */
 	private static void mergeLevelUp(Map<String, LevelAgg> levelBySkill, JsonObject evidence, long at, long optimistic)
 	{
 		String skill = evidenceString(evidence, "skill", "");
@@ -291,6 +320,7 @@ public final class CreditAttestCoalescer
 		agg.lastAt = Math.max(agg.lastAt, at);
 	}
 
+	/** Adds one npc_kill's amount into its npc+combat-level+hour bucket. */
 	private static void mergeKill(Map<KillKey, KillAgg> kills, JsonObject evidence, long at, long optimistic)
 	{
 		String npcName = evidenceString(evidence, "npcName", "");
@@ -309,6 +339,7 @@ public final class CreditAttestCoalescer
 		agg.lastAt = Math.max(agg.lastAt, at);
 	}
 
+	/** Ranks events for {@link #takePriorityBatch}: level_up highest, then xp_chunk, npc_kill, activity. */
 	private static long priorityScore(JsonObject event)
 	{
 		String type = JsonObjects.text(event, "type");
@@ -333,6 +364,7 @@ public final class CreditAttestCoalescer
 		return 1_000L;
 	}
 
+	/** Builds a wire-shaped xp_chunk event from aggregated values. */
 	private static JsonObject buildXp(String skill, long xpDelta, long at, long optimisticCredits)
 	{
 		JsonObject evidence = new JsonObject();
@@ -341,6 +373,7 @@ public final class CreditAttestCoalescer
 		return copyEvent(TYPE_XP_CHUNK, evidence, at, optimisticCredits);
 	}
 
+	/** Builds a wire-shaped level_up event from aggregated values. */
 	private static JsonObject buildLevelUp(String skill, int fromLevel, int toLevel, long at, long optimisticCredits)
 	{
 		JsonObject evidence = new JsonObject();
@@ -350,6 +383,7 @@ public final class CreditAttestCoalescer
 		return copyEvent(TYPE_LEVEL_UP, evidence, at, optimisticCredits);
 	}
 
+	/** Builds a wire-shaped npc_kill event from aggregated values; omits npcId/npcName when unset. */
 	private static JsonObject buildKill(int npcId, String npcName, int combatLevel, int amount, long at, long optimisticCredits)
 	{
 		JsonObject evidence = new JsonObject();
@@ -366,6 +400,7 @@ public final class CreditAttestCoalescer
 		return copyEvent(TYPE_NPC_KILL, evidence, at, optimisticCredits);
 	}
 
+	/** Assembles a {type, evidence, at, [optimisticCredits]} event, deep-copying the evidence object. */
 	private static JsonObject copyEvent(String type, JsonObject evidence, long at, long optimisticCredits)
 	{
 		JsonObject event = new JsonObject();
@@ -379,6 +414,7 @@ public final class CreditAttestCoalescer
 		return event;
 	}
 
+	/** Reads the client-side optimistic credit estimate stashed on an event, or 0 if absent/invalid. */
 	public static long optimisticOf(JsonObject event)
 	{
 		if (event == null || !event.has(CLIENT_OPTIMISTIC_CREDITS) || event.get(CLIENT_OPTIMISTIC_CREDITS).isJsonNull())
@@ -395,6 +431,7 @@ public final class CreditAttestCoalescer
 		}
 	}
 
+	/** Returns a copy of {@code event} with the client-only optimistic-credits field stripped for sending. */
 	public static JsonObject forWire(JsonObject event)
 	{
 		if (event == null)
@@ -406,6 +443,7 @@ public final class CreditAttestCoalescer
 		return copy;
 	}
 
+	/** Reads an event's {@code at} timestamp, defaulting to now if missing/null. */
 	private static long atOf(JsonObject event)
 	{
 		if (event != null && event.has("at") && !event.get("at").isJsonNull())
@@ -415,6 +453,7 @@ public final class CreditAttestCoalescer
 		return System.currentTimeMillis();
 	}
 
+	/** Running total for one skill+hour xp_chunk bucket. */
 	private static final class XpAgg
 	{
 		private String emitSkill;
@@ -423,6 +462,7 @@ public final class CreditAttestCoalescer
 		private long optimisticCredits;
 	}
 
+	/** Widening from/to level range for one skill's level_up bucket. */
 	private static final class LevelAgg
 	{
 		private String emitSkill;
@@ -432,6 +472,7 @@ public final class CreditAttestCoalescer
 		private long optimisticCredits;
 	}
 
+	/** Running total for one npc+combat-level+hour npc_kill bucket. */
 	private static final class KillAgg
 	{
 		private int amount;
@@ -439,6 +480,7 @@ public final class CreditAttestCoalescer
 		private long optimisticCredits;
 	}
 
+	/** Grouping key for npc_kill aggregation: npc identity, combat level, and hour bucket. */
 	private static final class KillKey
 	{
 		private final int npcId;
@@ -454,6 +496,7 @@ public final class CreditAttestCoalescer
 			this.epochHour = epochHour;
 		}
 
+		/** {@inheritDoc} */
 		@Override
 		public boolean equals(Object o)
 		{
@@ -472,6 +515,7 @@ public final class CreditAttestCoalescer
 				&& Objects.equals(npcName, that.npcName);
 		}
 
+		/** {@inheritDoc} */
 		@Override
 		public int hashCode()
 		{
@@ -479,6 +523,7 @@ public final class CreditAttestCoalescer
 		}
 	}
 
+	/** An event paired with its index in the source list and its {@link #priorityScore}, for sorting. */
 	private static final class Scored
 	{
 		private final int index;

--- a/src/main/java/com/osrstcg/cloud/attest/CreditAttestPoster.java
+++ b/src/main/java/com/osrstcg/cloud/attest/CreditAttestPoster.java
@@ -9,6 +9,11 @@ import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Sends one coalesced batch of credit events to the cloud attest endpoint and applies the response:
+ * clears optimistic credits, requeues fixable rejects, updates sidebar economy stats, and forces a
+ * refresh when server state changed. Must run on a background/flush thread, never the client thread.
+ */
 @Slf4j
 final class CreditAttestPoster
 {
@@ -23,6 +28,12 @@ final class CreditAttestPoster
 		this.requeuer = requeuer;
 	}
 
+	/**
+	 * Posts {@code batch} to the attest API, requeues any rejected-but-fixable events, clears optimistic
+	 * credits for what the server accepted, and applies any economy/revision changes from the response.
+	 *
+	 * @return true if applying the response changed local credits or the trade revision
+	 */
 	boolean postAttestBatch(List<JsonObject> batch) throws Exception
 	{
 		long accountHash = queue.resolveAccountHash();
@@ -117,6 +128,7 @@ final class CreditAttestPoster
 		return changed;
 	}
 
+	/** True for transient I/O failures, server errors (5xx), or rate limiting — worth a retry flush. */
 	static boolean isRetryableAttestFailure(Throwable ex)
 	{
 		if (ex instanceof IOException && !(ex instanceof CloudApiException))

--- a/src/main/java/com/osrstcg/cloud/attest/CreditAttestQueue.java
+++ b/src/main/java/com/osrstcg/cloud/attest/CreditAttestQueue.java
@@ -26,6 +26,14 @@ import com.osrstcg.util.TcgPluginGameMessages;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * In-memory + disk-spilled queue of raw credit-earning events (xp, level-ups, npc kills, activities)
+ * awaiting attestation to the cloud. Buffers events as they occur, coalesces and prioritizes them at
+ * flush time via {@link CreditAttestCoalescer}, posts batches through {@link CreditAttestPoster}, and
+ * requeues fixable rejects via {@link AttestRejectRequeuer}. {@link #enqueue} is called from the client
+ * thread as gameplay events happen; flushes run on the injected {@link ScheduledExecutorService}, guarded
+ * by internal locks, so callers never need external synchronization.
+ */
 @Slf4j
 @Singleton
 public final class CreditAttestQueue
@@ -58,6 +66,7 @@ public final class CreditAttestQueue
 	private volatile String lastDisplayName;
 	private volatile long spillLoadedAccountHash = -1L;
 
+	/** Injected constructor; wires up the sub-scheduler with a flush callback and initial default interval. */
 	@Inject
 	CreditAttestQueue(
 		CloudApiClient api,
@@ -85,17 +94,20 @@ public final class CreditAttestQueue
 			() -> flushSafe(false), running::get);
 	}
 
+	/** Registers a callback invoked whenever attest processing changes credits/pending totals; replaces any prior listener. */
 	public void setEconomyListener(Runnable listener)
 	{
 		economyListener.set(listener);
 	}
 
+	/** Starts periodic flushing and loads any spilled events for the current account. */
 	public void start()
 	{
 		attestScheduler.start();
 		ensureSpillLoaded();
 	}
 
+	/** Stops periodic flushing and resets retry/spill/rate-cap state for the next session. */
 	public void stop()
 	{
 		attestScheduler.stop();
@@ -104,6 +116,7 @@ public final class CreditAttestQueue
 		rateCapNotifier.reset();
 	}
 
+	/** Clamps a server-provided attest interval to at least {@link #DEFAULT_ATTEST_AFTER_MS}, falling back when unset. */
 	private static long resolveAttestAfterMs(long ms, long fallbackMs)
 	{
 		if (ms <= 0L)
@@ -114,6 +127,7 @@ public final class CreditAttestQueue
 		return ms;
 	}
 
+	/** Updates the periodic flush interval from the server's {@code attestAfterMs}/{@code pollAfterMs} hint, if present. */
 	void noteAttestAfterMs(JsonObject response)
 	{
 		long fallback = lastGoodAttestAfterMs.get();
@@ -122,6 +136,7 @@ public final class CreditAttestQueue
 		lastGoodAttestAfterMs.set(resolveAttestAfterMs(ms, fallback));
 	}
 
+	/** Drops all in-memory pending events and deletes the on-disk spill for the current account, without flushing. */
 	public void discardPending()
 	{
 		long hash;
@@ -140,6 +155,12 @@ public final class CreditAttestQueue
 		}
 	}
 
+	/**
+	 * Records one raw credit-earning event for later attestation. Filters out combat-skill xp and
+	 * non-progressing level-ups, applies the optimistic credit estimate to local state immediately,
+	 * persists the pending list to disk, and triggers an early flush on a coalesced-count or xp-spike
+	 * threshold. No-op if the session can't currently collect attests. Expected to run on the client thread.
+	 */
 	public void enqueue(String type, JsonObject evidence, long optimisticCredits)
 	{
 		if (!session.canCollectAttests())
@@ -212,16 +233,24 @@ public final class CreditAttestQueue
 		}
 	}
 
+	/** Schedules an immediate, non-blocking flush on the executor. */
 	public void flushNow()
 	{
 		scheduler.execute(() -> flushSafe(false));
 	}
 
+	/**
+	 * Runs a teardown flush synchronously on the calling thread (used on shutdown/logout). Must not be
+	 * called from the client thread.
+	 *
+	 * @return true if the flush changed local credits or the trade revision
+	 */
 	public boolean flushBlocking()
 	{
 		return flushSafe(true);
 	}
 
+	/** Reads the current account hash from the client, caching it and invalidating spill-loaded state on account change. */
 	long resolveAccountHash()
 	{
 		long hash = client.getAccountHash();
@@ -237,6 +266,7 @@ public final class CreditAttestQueue
 		return lastAccountHash;
 	}
 
+	/** Reads and sanitizes the local player's RSN, caching the last known value for use when unavailable. */
 	String resolveDisplayName()
 	{
 		if (client.getLocalPlayer() != null && client.getLocalPlayer().getName() != null)
@@ -251,6 +281,7 @@ public final class CreditAttestQueue
 		return lastDisplayName;
 	}
 
+	/** Loads any spilled pending events for the current account into memory, once per account hash. */
 	private void ensureSpillLoaded()
 	{
 		long hash = resolveAccountHash();
@@ -295,6 +326,7 @@ public final class CreditAttestQueue
 		}
 	}
 
+	/** Writes a snapshot of the current pending list to disk for the current account. */
 	private void persistSpillFromPending()
 	{
 		long hash;
@@ -311,6 +343,7 @@ public final class CreditAttestQueue
 		spillStore.save(hash, snapshot);
 	}
 
+	/** Adds an optimistic credit estimate to local state and notifies the economy listener, if positive. */
 	private void applyOptimistic(long optimisticCredits)
 	{
 		if (optimisticCredits > 0)
@@ -320,11 +353,16 @@ public final class CreditAttestQueue
 		}
 	}
 
+	/** Delegates to {@link CreditAttestScheduler#scheduleEarlyFlush()}. */
 	void scheduleEarlyFlush()
 	{
 		attestScheduler.scheduleEarlyFlush();
 	}
 
+	/**
+	 * On a retryable failure (and not during teardown), schedules a backing-off retry flush up to
+	 * {@link #ATTEST_RETRY_ATTEMPTS} times; otherwise resets the failure counter.
+	 */
 	private void maybeScheduleRetryFlush(boolean teardown, Exception ex)
 	{
 		if (teardown || !CreditAttestPoster.isRetryableAttestFailure(ex))
@@ -344,6 +382,7 @@ public final class CreditAttestQueue
 		attestScheduler.scheduleRetryFlush(delayMs);
 	}
 
+	/** Inserts events at the front of the pending list, so they're the next candidates for flushing. */
 	void prependPending(List<JsonObject> events)
 	{
 		synchronized (lock)
@@ -352,6 +391,7 @@ public final class CreditAttestQueue
 		}
 	}
 
+	/** Runs {@link #flush} and swallows/logs any exception so scheduler callbacks never throw. */
 	private boolean flushSafe(boolean teardown)
 	{
 		try
@@ -370,6 +410,15 @@ public final class CreditAttestQueue
 		}
 	}
 
+	/**
+	 * Drains and posts all pending events, one coalesced+prioritized batch at a time, until the pending
+	 * list is empty. Serialized via {@link #flushGate} so only one flush runs at a time. A batch that's
+	 * only hitpoints xp is held back rather than sent. On a post failure, the batch (and any remaining
+	 * coalesced events) are put back on the front of the pending list and the exception propagates.
+	 *
+	 * @param teardown true for a shutdown flush, which uses a looser readiness check than a normal flush
+	 * @return true if any posted batch changed local credits or the trade revision
+	 */
 	private boolean flush(boolean teardown) throws Exception
 	{
 		if (teardown)
@@ -456,6 +505,11 @@ public final class CreditAttestQueue
 		}
 	}
 
+	/**
+	 * Determines how many optimistic credits to clear after a batch is posted: prefers the server's
+	 * accepted-credits sum when present, otherwise falls back to the batch's optimistic estimate minus
+	 * whatever was held back for requeued (not yet resolved) events.
+	 */
 	static long resolveOptimisticClearAmount(
 		JsonObject response,
 		List<JsonObject> batch,
@@ -481,6 +535,7 @@ public final class CreditAttestQueue
 		return Math.max(0L, batchOptimisticEstimate - holdBack);
 	}
 
+	/** Sums the credit amounts of {@code response.accepted}, or -1 if the field is absent/malformed. */
 	private static long sumAcceptedCredits(JsonObject response)
 	{
 		if (response == null || !response.has("accepted") || !response.get("accepted").isJsonArray())
@@ -511,6 +566,7 @@ public final class CreditAttestQueue
 		return sawAmount ? sum : -1L;
 	}
 
+	/** Posts a debug-chat summary of an outgoing attest batch (event type counts, optimistic estimate), if debug chat is on. */
 	void debugCreditAttestSend(List<JsonObject> batch, long optimisticEstimate)
 	{
 		if (!stateService.isDebugChatEnabled() || batch == null || batch.isEmpty())
@@ -544,6 +600,7 @@ public final class CreditAttestQueue
 		TcgPluginGameMessages.queueDebugGameMessage(chatMessageManager, message);
 	}
 
+	/** Posts a debug-chat summary of an attest response (credits, cleared/pending optimistic, rejects), if debug chat is on. */
 	void debugCreditAttestResponse(JsonObject response, long clearOptimistic, long pendingBefore)
 	{
 		if (!stateService.isDebugChatEnabled() || response == null)
@@ -572,6 +629,7 @@ public final class CreditAttestQueue
 		TcgPluginGameMessages.queueDebugGameMessage(chatMessageManager, message.toString());
 	}
 
+	/** Formats {@code response.rejected} reasons as a bracketed, comma-separated list for logging/chat. */
 	static String formatRejectedReasons(JsonObject response)
 	{
 		if (response == null || !response.has("rejected") || !response.get("rejected").isJsonArray())
@@ -602,6 +660,7 @@ public final class CreditAttestQueue
 		return sb.toString();
 	}
 
+	/** Invokes the registered economy listener, if any. */
 	void notifyEconomyListener()
 	{
 		Runnable listener = economyListener.get();
@@ -611,6 +670,7 @@ public final class CreditAttestQueue
 		}
 	}
 
+	/** Returns an event's {@code evidence} object, or an empty object if missing/not an object. */
 	static JsonObject evidenceObject(JsonObject event)
 	{
 		if (event != null && event.has("evidence") && event.get("evidence").isJsonObject())
@@ -620,6 +680,7 @@ public final class CreditAttestQueue
 		return new JsonObject();
 	}
 
+	/** Reads a string field from an evidence object, returning {@code defaultValue} if missing/null. */
 	static String evidenceString(JsonObject evidence, String key, String defaultValue)
 	{
 		if (evidence == null || !evidence.has(key) || evidence.get(key).isJsonNull())
@@ -630,6 +691,7 @@ public final class CreditAttestQueue
 		return value == null ? defaultValue : value;
 	}
 
+	/** Reads an int field from an evidence object, returning {@code defaultValue} if missing/null. */
 	static int evidenceInt(JsonObject evidence, String key, int defaultValue)
 	{
 		if (evidence == null || !evidence.has(key) || evidence.get(key).isJsonNull())
@@ -639,6 +701,7 @@ public final class CreditAttestQueue
 		return evidence.get(key).getAsInt();
 	}
 
+	/** Reads a long field from an evidence object, returning {@code defaultValue} if missing/null. */
 	static long evidenceLong(JsonObject evidence, String key, long defaultValue)
 	{
 		if (evidence == null || !evidence.has(key) || evidence.get(key).isJsonNull())

--- a/src/main/java/com/osrstcg/cloud/attest/CreditAttestScheduler.java
+++ b/src/main/java/com/osrstcg/cloud/attest/CreditAttestScheduler.java
@@ -22,6 +22,7 @@ final class CreditAttestScheduler
 	private ScheduledFuture<?> flushFuture;
 	private ScheduledFuture<?> retryFlushFuture;
 
+	/** @param flushSafeFalse invoked to run a non-teardown flush; {@code stillRunning} checked after each tick to decide whether to reschedule */
 	CreditAttestScheduler(
 		ScheduledExecutorService scheduler,
 		AtomicBoolean running,
@@ -40,6 +41,7 @@ final class CreditAttestScheduler
 		this.stillRunning = stillRunning;
 	}
 
+	/** Starts the periodic flush timer at the default interval, if not already running. Idempotent. */
 	void start()
 	{
 		synchronized (scheduleLock)
@@ -54,6 +56,7 @@ final class CreditAttestScheduler
 		}
 	}
 
+	/** Stops the scheduler and cancels any pending periodic or retry flush. */
 	void stop()
 	{
 		synchronized (scheduleLock)
@@ -64,6 +67,7 @@ final class CreditAttestScheduler
 		}
 	}
 
+	/** Runs a flush immediately on the executor, coalescing concurrent requests via {@code earlyFlushScheduled}. */
 	void scheduleEarlyFlush()
 	{
 		if (!earlyFlushScheduled.compareAndSet(false, true))
@@ -83,6 +87,10 @@ final class CreditAttestScheduler
 		});
 	}
 
+	/**
+	 * Schedules a single flush retry after {@code delayMs}, unless the scheduler is stopped or a retry
+	 * is already pending (only one retry flush may be in flight at a time).
+	 */
 	void scheduleRetryFlush(long delayMs)
 	{
 		if (!running.get())
@@ -118,6 +126,7 @@ final class CreditAttestScheduler
 		}
 	}
 
+	/** Periodic timer callback: runs a flush, then reschedules itself using the latest attest-after interval. */
 	void flushTick()
 	{
 		try
@@ -136,6 +145,7 @@ final class CreditAttestScheduler
 		}
 	}
 
+	/** Schedules the next periodic {@link #flushTick()}; must be called while holding {@link #scheduleLock}. */
 	private void scheduleNextLocked(long delayMs)
 	{
 		if (!running.get())
@@ -145,6 +155,7 @@ final class CreditAttestScheduler
 		flushFuture = scheduler.schedule(this::flushTick, Math.max(0L, delayMs), TimeUnit.MILLISECONDS);
 	}
 
+	/** Cancels the pending periodic flush, if any; must be called while holding {@link #scheduleLock}. */
 	private void cancelScheduledLocked()
 	{
 		if (flushFuture != null)
@@ -154,6 +165,7 @@ final class CreditAttestScheduler
 		}
 	}
 
+	/** Cancels the pending retry flush, if any, and clears its scheduled flag; must hold {@link #scheduleLock}. */
 	private void cancelRetryFlushLocked()
 	{
 		if (retryFlushFuture != null)

--- a/src/main/java/com/osrstcg/cloud/attest/CreditAttestSpillStore.java
+++ b/src/main/java/com/osrstcg/cloud/attest/CreditAttestSpillStore.java
@@ -16,6 +16,10 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Persists pending credit-attest events to a per-account JSON file so they survive a client restart
+ * before being flushed to the cloud. Reads/writes are file I/O and should not run on the client thread.
+ */
 @Slf4j
 @Singleton
 public final class CreditAttestSpillStore
@@ -35,12 +39,14 @@ public final class CreditAttestSpillStore
 		this.profilesRoot = profilesRoot;
 	}
 
+	/** Resolves the spill file path for an account, or {@code null} if the account can't be hashed to a dir name. */
 	Path spillFile(long accountHash)
 	{
 		String id = ProfileKeyHasher.accountDirName(accountHash);
 		return id == null ? null : profilesRoot.resolve(id).resolve(SPILL_FILENAME);
 	}
 
+	/** Loads the spilled pending events for an account, or an empty list if none/unreadable/invalid. */
 	public List<JsonObject> load(long accountHash)
 	{
 		if (accountHash == -1L)
@@ -50,6 +56,7 @@ public final class CreditAttestSpillStore
 		return readSpillFile(spillFile(accountHash));
 	}
 
+	/** Reads and parses a spill file as a JSON array of objects; returns an empty list on any failure. */
 	private List<JsonObject> readSpillFile(Path file)
 	{
 		if (file == null || !Files.isRegularFile(file))
@@ -86,6 +93,7 @@ public final class CreditAttestSpillStore
 		}
 	}
 
+	/** Atomically writes {@code events} as the spill file for an account, or deletes it if the list is empty. */
 	public void save(long accountHash, List<JsonObject> events)
 	{
 		if (accountHash == -1L)
@@ -122,6 +130,7 @@ public final class CreditAttestSpillStore
 		}
 	}
 
+	/** Deletes the spill file for an account, if any. Failures are logged and swallowed. */
 	public void delete(long accountHash)
 	{
 		if (accountHash == -1L)
@@ -142,6 +151,7 @@ public final class CreditAttestSpillStore
 		}
 	}
 
+	/** Deep-copies a list of events so a snapshot can be persisted without aliasing live queue state. */
 	static List<JsonObject> copyEvents(List<JsonObject> events)
 	{
 		if (events == null || events.isEmpty())

--- a/src/main/java/com/osrstcg/cloud/catalog/CardCatalogService.java
+++ b/src/main/java/com/osrstcg/cloud/catalog/CardCatalogService.java
@@ -26,6 +26,12 @@ import net.runelite.client.RuneLite;
 import com.osrstcg.cloud.api.CloudApiClient;
 import com.osrstcg.cloud.api.CloudApiException;
 
+/**
+ * Loads the card catalog from disk cache on startup and keeps it fresh from the cloud
+ * {@code catalog/cards/live} endpoint, updating {@link CardDatabase} in place and persisting
+ * the raw response to disk for the next launch. Fetches run on the injected scheduler and make
+ * a blocking network call, so they must not run on the client thread.
+ */
 @Slf4j
 @Singleton
 public final class CardCatalogService
@@ -58,11 +64,17 @@ public final class CardCatalogService
 		this.scheduler = scheduler;
 	}
 
+	/** Registers a callback invoked (not necessarily on the client thread) whenever the catalog changes. */
 	public void setChangeListener(Runnable listener)
 	{
 		changeListener.set(listener);
 	}
 
+	/**
+	 * Populates {@link CardDatabase} synchronously from the on-disk cache, preferring the live
+	 * cache format and falling back to the legacy {@code Card.json} format. No-op if neither
+	 * file is present or parseable. Also deletes the now-obsolete card-art overlay cache files.
+	 */
 	public void loadDiskCacheIfPresent()
 	{
 		deleteStaleCardArtCache();
@@ -106,11 +118,13 @@ public final class CardCatalogService
 		}
 	}
 
+	/** Kicks off an async catalog fetch on the scheduler; does not gate on the login-fetch flag. */
 	public CompletableFuture<Void> prefetchAsync()
 	{
 		return CompletableFuture.runAsync(this::fetchAndApply, scheduler);
 	}
 
+	/** Fetches the catalog once per login: no-op if already attempted since the last {@link #resetLoginFetchGate()}. */
 	public CompletableFuture<Void> refreshOnLogin()
 	{
 		if (!loginFetchAttempted.compareAndSet(false, true))
@@ -120,17 +134,25 @@ public final class CardCatalogService
 		return CompletableFuture.runAsync(this::fetchAndApply, scheduler);
 	}
 
+	/** Allows {@link #refreshOnLogin()} to fetch again (e.g. after logout/login). */
 	public void resetLoginFetchGate()
 	{
 		loginFetchAttempted.set(false);
 	}
 
+	/** Forces an async catalog fetch regardless of the login-fetch gate, and marks that gate as satisfied. */
 	public CompletableFuture<Void> refreshNow()
 	{
 		loginFetchAttempted.set(true);
 		return CompletableFuture.runAsync(this::fetchAndApply, scheduler);
 	}
 
+	/**
+	 * Blocking fetch-and-apply cycle: sends the cached catalog version as an ETag, and on a 304
+	 * loads the disk cache if the in-memory database is still empty; on 200 parses and applies
+	 * the new catalog, persisting it to disk. Swallows all exceptions (logging them), except a
+	 * consent-required error which is logged at debug and otherwise ignored.
+	 */
 	private void fetchAndApply()
 	{
 		try
@@ -185,6 +207,7 @@ public final class CardCatalogService
 		}
 	}
 
+	/** Best-effort removal of the obsolete card-art overlay cache files, ignoring failures. */
 	private void deleteStaleCardArtCache()
 	{
 		Path dir = diskCacheDir();
@@ -199,12 +222,14 @@ public final class CardCatalogService
 		}
 	}
 
+	/** Parses a raw live-catalog JSON string (as stored on disk) into card definitions. */
 	private static List<CardDefinition> parseLiveJson(String json)
 	{
 		JsonObject obj = new JsonParser().parse(json).getAsJsonObject();
 		return LiveCardsCatalogParser.parse(obj);
 	}
 
+	/** Invokes the registered change listener, if any, swallowing its exceptions. */
 	private void notifyChanged()
 	{
 		Runnable listener = changeListener.get();
@@ -221,6 +246,7 @@ public final class CardCatalogService
 		}
 	}
 
+	/** Writes the raw catalog JSON and version to disk atomically; failures are logged and ignored. */
 	private void persistDiskCache(String json, String version)
 	{
 		Path dir = diskCacheDir();
@@ -239,6 +265,7 @@ public final class CardCatalogService
 		}
 	}
 
+	/** Reads the last persisted catalog version from disk, or null if absent/unreadable. */
 	private static String readDiskVersion()
 	{
 		Path file = diskCacheDir().resolve(LIVE_VERSION_FILE);
@@ -257,17 +284,20 @@ public final class CardCatalogService
 		}
 	}
 
+	/** Directory under the RuneLite home folder used for the card catalog disk cache. */
 	private static Path diskCacheDir()
 	{
 		return Path.of(RuneLite.RUNELITE_DIR.getAbsolutePath(), "OSRS-TCG", "catalog");
 	}
 
+	/** Clears the cached catalog version and deletes the entire disk cache directory. */
 	public void deleteDiskCache()
 	{
 		cachedCatalogVersion.set(null);
 		deleteDirectoryQuietly(diskCacheDir());
 	}
 
+	/** Recursively deletes a directory, best-effort, logging but not throwing on failure. */
 	private static void deleteDirectoryQuietly(Path dir)
 	{
 		if (dir == null || !Files.isDirectory(dir))

--- a/src/main/java/com/osrstcg/cloud/catalog/LiveCardsCatalogParser.java
+++ b/src/main/java/com/osrstcg/cloud/catalog/LiveCardsCatalogParser.java
@@ -20,6 +20,11 @@ public final class LiveCardsCatalogParser
 	{
 	}
 
+	/**
+	 * Converts the {@code items} and {@code npcs} arrays of a live-catalog response into
+	 * {@link CardDefinition}s, deduplicated by name (items take priority over NPCs). Returns an
+	 * empty list for null input.
+	 */
 	public static List<CardDefinition> parse(JsonObject liveJson)
 	{
 		if (liveJson == null)
@@ -78,6 +83,11 @@ public final class LiveCardsCatalogParser
 		return cards;
 	}
 
+	/**
+	 * Builds a {@link CardDefinition} from one raw item/NPC entry. When an NPC shares its name
+	 * with an item, it is renamed to {@code "npc:<id>"} to keep it distinct (or dropped if it
+	 * has no id). Returns null when the entry has no name.
+	 */
 	private static CardDefinition normalizeParent(JsonObject raw, boolean npc, Set<String> itemNames)
 	{
 		String name = JsonObjects.textTrimmed(raw, "name");
@@ -216,6 +226,7 @@ public final class LiveCardsCatalogParser
 		return out;
 	}
 
+	/** Reads a JSON array of strings at {@code key}, trimming and dropping blanks; empty list if absent/not an array. */
 	private static List<String> parseStringList(JsonObject o, String key)
 	{
 		if (o == null || !o.has(key) || !o.get(key).isJsonArray())

--- a/src/main/java/com/osrstcg/cloud/catalog/LiveCardsResponse.java
+++ b/src/main/java/com/osrstcg/cloud/catalog/LiveCardsResponse.java
@@ -18,31 +18,37 @@ public final class LiveCardsResponse
 		this.catalogVersion = catalogVersion == null ? "" : catalogVersion;
 	}
 
+	/** Builds a result for a 304 response; the caller should keep using its previously cached catalog. */
 	public static LiveCardsResponse notModified(String catalogVersion)
 	{
 		return new LiveCardsResponse(true, null, null, catalogVersion);
 	}
 
+	/** Builds a result for a 200 response carrying a fresh catalog body. */
 	public static LiveCardsResponse ok(JsonObject body, String rawJson, String catalogVersion)
 	{
 		return new LiveCardsResponse(false, body, rawJson, catalogVersion);
 	}
 
+	/** True when the server returned 304 (client's cached version is still current). */
 	public boolean isNotModified()
 	{
 		return notModified;
 	}
 
+	/** Parsed response body; null when {@link #isNotModified()}. */
 	public JsonObject getBody()
 	{
 		return body;
 	}
 
+	/** Raw response text as received, for disk caching; null when {@link #isNotModified()}. */
 	public String getRawJson()
 	{
 		return rawJson;
 	}
 
+	/** Catalog version from the response headers/body; never null (may be empty). */
 	public String getCatalogVersion()
 	{
 		return catalogVersion;

--- a/src/main/java/com/osrstcg/cloud/catalog/PackCatalogCache.java
+++ b/src/main/java/com/osrstcg/cloud/catalog/PackCatalogCache.java
@@ -15,6 +15,11 @@ public final class PackCatalogCache
 	private final List<BoosterPackDefinition> packs;
 	private final boolean fromServer;
 
+	/**
+	 * @param packSize clamped to a minimum of 0.
+	 * @param packs defensively copied into an unmodifiable list; null treated as empty.
+	 * @param fromServer whether this cache reflects an actual server fetch, vs. the empty placeholder.
+	 */
 	public PackCatalogCache(
 		String catalogVersion,
 		int packSize,
@@ -29,31 +34,37 @@ public final class PackCatalogCache
 		this.fromServer = fromServer;
 	}
 
+	/** Server-reported catalog version, or {@code ""} if unknown. */
 	public String getCatalogVersion()
 	{
 		return catalogVersion;
 	}
 
+	/** Number of cards in a booster pack per this catalog. */
 	public int getPackSize()
 	{
 		return packSize;
 	}
 
+	/** Unmodifiable list of packs in this catalog. */
 	public List<BoosterPackDefinition> getPacks()
 	{
 		return packs;
 	}
 
+	/** True when this cache was populated from an actual server response, as opposed to the empty placeholder. */
 	public boolean isFromServer()
 	{
 		return fromServer;
 	}
 
+	/** True when this catalog has no packs. */
 	public boolean isEmpty()
 	{
 		return packs.isEmpty();
 	}
 
+	/** Builds a lookup map keyed by trimmed pack id, keeping the first pack seen for any duplicate id. */
 	public Map<String, BoosterPackDefinition> byId()
 	{
 		Map<String, BoosterPackDefinition> map = new LinkedHashMap<>();
@@ -68,6 +79,7 @@ public final class PackCatalogCache
 		return Collections.unmodifiableMap(map);
 	}
 
+	/** Looks up a pack by id (via {@link #byId()}); empty when {@code packId} is null/blank or not found. */
 	public Optional<BoosterPackDefinition> get(String packId)
 	{
 		if (packId == null || packId.isBlank())

--- a/src/main/java/com/osrstcg/cloud/catalog/PackCatalogService.java
+++ b/src/main/java/com/osrstcg/cloud/catalog/PackCatalogService.java
@@ -16,6 +16,11 @@ import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import com.osrstcg.cloud.api.CloudApiClient;
 
+/**
+ * Holds the in-memory {@link PackCatalogCache} for the shop, fetching it from {@code GET /packs}
+ * on login or after a catalog-mismatch error and preloading pack images. Fetches run on the
+ * injected scheduler and make a blocking network call, so they must not run on the client thread.
+ */
 @Slf4j
 @Singleton
 public final class PackCatalogService
@@ -42,16 +47,19 @@ public final class PackCatalogService
 		this.cache.set(emptyCache());
 	}
 
+	/** Registers a callback invoked (not necessarily on the client thread) whenever the pack catalog changes. */
 	public void setChangeListener(Runnable listener)
 	{
 		changeListener.set(listener);
 	}
 
+	/** Current catalog snapshot; never null (an empty placeholder before the first successful fetch). */
 	public PackCatalogCache getCache()
 	{
 		return cache.get();
 	}
 
+	/** Packs to show in the shop: empty until a real server catalog has been loaded. */
 	public List<BoosterPackDefinition> getVisibleBoosters()
 	{
 		PackCatalogCache current = getCache();
@@ -62,6 +70,7 @@ public final class PackCatalogService
 		return current.getPacks();
 	}
 
+	/** Finds a pack by collection key or id; returns null if not found or if either argument is unusable. */
 	public static BoosterPackDefinition findById(List<BoosterPackDefinition> packs, String packId)
 	{
 		if (packId == null || packId.isBlank() || packs == null)
@@ -82,6 +91,7 @@ public final class PackCatalogService
 		return null;
 	}
 
+	/** Current catalog version, preferring the cache's, falling back to the API client's last-seen value. */
 	public String requireCatalogVersion()
 	{
 		String version = getCache().getCatalogVersion();
@@ -93,6 +103,7 @@ public final class PackCatalogService
 		return fromApi == null ? "" : fromApi.trim();
 	}
 
+	/** Fetches the pack catalog once per login: no-op if already attempted since the last {@link #clear()}. */
 	public CompletableFuture<Void> refreshOnLogin()
 	{
 		if (!loginFetchAttempted.compareAndSet(false, true))
@@ -102,11 +113,13 @@ public final class PackCatalogService
 		return CompletableFuture.runAsync(this::fetchAndApplyLogin, scheduler);
 	}
 
+	/** Forces an async refetch after the server reports a {@code catalog_mismatch} error. */
 	public CompletableFuture<Void> refreshAfterCatalogMismatch()
 	{
 		return CompletableFuture.runAsync(this::fetchAndApplyMismatch, scheduler);
 	}
 
+	/** Resets to the empty catalog and allows {@link #refreshOnLogin()} to fetch again (e.g. on logout). */
 	public void clear()
 	{
 		loginFetchAttempted.set(false);
@@ -114,6 +127,11 @@ public final class PackCatalogService
 		notifyChanged();
 	}
 
+	/**
+	 * Blocking login fetch-and-apply cycle. Leaves the previous cache in place (shop stays empty
+	 * or unchanged) if the fetch fails or the server returns no packs. Kicks off image preload
+	 * on success.
+	 */
 	private void fetchAndApplyLogin()
 	{
 		try
@@ -137,6 +155,11 @@ public final class PackCatalogService
 		}
 	}
 
+	/**
+	 * Blocking refetch after a {@code catalog_mismatch} error. Keeps the previous cache if the
+	 * fetch fails or the server returns no packs; otherwise applies it and marks the login-fetch
+	 * gate satisfied.
+	 */
 	private void fetchAndApplyMismatch()
 	{
 		try
@@ -161,6 +184,7 @@ public final class PackCatalogService
 		}
 	}
 
+	/** Kicks off async preloading of every hosted thumbnail/image URL referenced by the catalog. */
 	private CompletableFuture<Void> preloadPackImages(PackCatalogCache catalog)
 	{
 		if (catalog == null || imageCacheService == null)
@@ -190,6 +214,7 @@ public final class PackCatalogService
 		return imageCacheService.preloadAsync(urls);
 	}
 
+	/** Parses a {@code GET /packs} response body into a {@link PackCatalogCache}, tolerating missing/null fields. */
 	static PackCatalogCache parseServerCatalog(JsonObject json)
 	{
 		String version = "";
@@ -222,6 +247,7 @@ public final class PackCatalogService
 		return new PackCatalogCache(version, packSize, packs, true);
 	}
 
+	/** Parses one {@code packs[]} entry; returns null when {@code id} is missing/blank. */
 	private static BoosterPackDefinition parsePackEntry(JsonObject o)
 	{
 		if (o == null || !o.has("id") || o.get("id").isJsonNull())
@@ -284,11 +310,13 @@ public final class PackCatalogService
 		return pack;
 	}
 
+	/** The placeholder cache used before any successful server fetch, or after {@link #clear()}. */
 	private static PackCatalogCache emptyCache()
 	{
 		return new PackCatalogCache("", 0, List.of(), false);
 	}
 
+	/** Invokes the registered change listener, if any. */
 	private void notifyChanged()
 	{
 		Runnable listener = changeListener.get();

--- a/src/main/java/com/osrstcg/cloud/catalog/PackPullParser.java
+++ b/src/main/java/com/osrstcg/cloud/catalog/PackPullParser.java
@@ -12,6 +12,11 @@ public final class PackPullParser
 	{
 	}
 
+	/**
+	 * Parses one {@code cards[]} element into a {@link PackCardResult}. Returns null when the
+	 * element is null or missing {@code cardName}. Generates a random {@code instanceId} when
+	 * the server didn't supply one.
+	 */
 	public static PackCardResult parseCard(JsonObject c)
 	{
 		if (c == null)

--- a/src/main/java/com/osrstcg/cloud/session/CloudCollectionPager.java
+++ b/src/main/java/com/osrstcg/cloud/session/CloudCollectionPager.java
@@ -8,6 +8,12 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import com.osrstcg.cloud.api.CloudApiClient;
 
+/**
+ * Fetches the full owned-card collection from {@code /me/cards} in pages when the player state
+ * response indicates cards are paginated, and retries the whole state pull once if the server
+ * revision drifts mid-paging. Blocking: every method here issues synchronous HTTP calls via
+ * {@link CloudApiClient} and must be called off the client/EDT thread.
+ */
 @Slf4j
 final class CloudCollectionPager
 {
@@ -16,11 +22,16 @@ final class CloudCollectionPager
 
 	private final CloudApiClient api;
 
+	/** Wires the API client; no side effects. */
 	CloudCollectionPager(CloudApiClient api)
 	{
 		this.api = api;
 	}
 
+	/**
+	 * Parses {@code stateJson} and, if cards are paginated, fetches all pages from {@code /me/cards}.
+	 * On a revision drift mid-paging, re-fetches the full state once and pages again against the new revision.
+	 */
 	CloudPlayerStateParser.ParsedCloudPlayerState loadCloudPlayerStateWithCards(JsonObject stateJson)
 		throws Exception
 	{
@@ -41,6 +52,7 @@ final class CloudCollectionPager
 		}
 	}
 
+	/** Returns {@code parsed} unchanged if cards aren't paginated, otherwise fills in cards fetched by page. */
 	CloudPlayerStateParser.ParsedCloudPlayerState resolveCardsForState(
 		CloudPlayerStateParser.ParsedCloudPlayerState parsed) throws Exception
 	{
@@ -52,6 +64,12 @@ final class CloudCollectionPager
 		return parsed.withCards(cards);
 	}
 
+	/**
+	 * Pages through {@code /me/cards} until {@code hasMore} is false, verifying each page reports
+	 * {@code expectedRevision}. Throws if a page's revision doesn't match (caller should retry from
+	 * fresh state), if paging exceeds {@link #ME_CARDS_MAX_PAGES}, or if a page claims more results
+	 * without a cursor.
+	 */
 	List<OwnedCardInstance> fetchAllOwnedCards(long expectedRevision) throws Exception
 	{
 		List<OwnedCardInstance> all = new ArrayList<>();

--- a/src/main/java/com/osrstcg/cloud/session/CloudCollectionSyncService.java
+++ b/src/main/java/com/osrstcg/cloud/session/CloudCollectionSyncService.java
@@ -10,6 +10,12 @@ import lombok.extern.slf4j.Slf4j;
 import com.osrstcg.cloud.api.CloudApiClient;
 import com.osrstcg.cloud.attest.CreditAttestQueue;
 
+/**
+ * Pulls cloud economy/collection state and reconciles it into local {@link TcgStateService}.
+ * Compares local vs server revisions and collection hashes to decide whether a full {@code /me/cards}
+ * pull is needed. Blocking: the {@code refresh*}/{@code reconcile*} methods issue synchronous HTTP
+ * calls and must not run on the client/EDT thread.
+ */
 @Slf4j
 final class CloudCollectionSyncService
 {
@@ -21,6 +27,7 @@ final class CloudCollectionSyncService
 	private final TcgPublicStatsCalculator publicStatsCalculator;
 	private final CloudCollectionPager pager;
 
+	/** Wires collaborators; no side effects. */
 	CloudCollectionSyncService(
 		CloudSessionService session,
 		CloudApiClient api,
@@ -39,6 +46,11 @@ final class CloudCollectionSyncService
 		this.pager = pager;
 	}
 
+	/**
+	 * Updates cached economy (credits/opened packs/total gained) and collection sidebar stats from a
+	 * {@code stats}-shaped response, and applies any account status it carries. No-op if {@code stats}
+	 * is null.
+	 */
 	void applySidebarStats(JsonObject stats)
 	{
 		if (stats == null)
@@ -69,6 +81,12 @@ final class CloudCollectionSyncService
 		}
 	}
 
+	/**
+	 * Reacts to a push/inbox stats update: logs (does not itself resolve) a mismatch between server
+	 * and locally-computed sidebar counts, then delegates to {@link #reconcileCollectionWithCloud}
+	 * to pull a fresh collection if needed. No-op while cloud consent is pending, or if {@code stats}
+	 * is null. Reconcile failures are swallowed and logged at debug level.
+	 */
 	void reconcileCollectionFromInbox(JsonObject stats)
 	{
 		if (stats == null || session.needsCloudConsent())
@@ -111,6 +129,11 @@ final class CloudCollectionSyncService
 		}
 	}
 
+	/**
+	 * Flushes any pending credit attests, then re-fetches and applies server stats, clearing the
+	 * local optimistic credit adjustment. No-op if there's no access token, consent is pending, or
+	 * the account is locked.
+	 */
 	void refreshCreditsFromServer() throws Exception
 	{
 		if (tokens.getAccessToken() == null || session.needsCloudConsent() || session.isAccountLocked())
@@ -130,6 +153,7 @@ final class CloudCollectionSyncService
 		stateService.clearOptimisticCredits();
 	}
 
+	/** Fetches server stats, applies them, and reconciles the local collection against the cloud copy. */
 	void refreshLocalCacheFromCloud() throws Exception
 	{
 		JsonObject stats = api.getStats();
@@ -137,6 +161,13 @@ final class CloudCollectionSyncService
 		reconcileCollectionWithCloud(stats);
 	}
 
+	/**
+	 * Compares local sync markers against {@code stats} and, if the collection hash differs (or the
+	 * legacy revision is behind with no hash to compare), pulls the full player state and cards from
+	 * {@code /me/state} via {@link CloudCollectionPager} and replaces local collection/economy state.
+	 * If unchanged but the revision/hash advanced, only updates the local sync markers. No-op while
+	 * cloud consent is pending.
+	 */
 	void reconcileCollectionWithCloud(JsonObject stats) throws Exception
 	{
 		if (session.needsCloudConsent())
@@ -199,6 +230,7 @@ final class CloudCollectionSyncService
 			parsed.revision, parsed.cards.size(), parsed.migrated);
 	}
 
+	/** Delegates to {@link CloudCollectionPager#loadCloudPlayerStateWithCards}. */
 	CloudPlayerStateParser.ParsedCloudPlayerState loadCloudPlayerStateWithCards(JsonObject stateJson) throws Exception
 	{
 		return pager.loadCloudPlayerStateWithCards(stateJson);

--- a/src/main/java/com/osrstcg/cloud/session/CloudPlayerStateParser.java
+++ b/src/main/java/com/osrstcg/cloud/session/CloudPlayerStateParser.java
@@ -10,12 +10,23 @@ import com.osrstcg.state.OwnedCardInstance;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Stateless parser for the JSON payloads returned by the cloud {@code /me/state} and related
+ * endpoints. Converts raw {@link JsonObject}s into typed, defensively-normalized value objects
+ * ({@link ParsedCloudPlayerState}, {@link SyncMarkers}).
+ */
 public final class CloudPlayerStateParser
 {
 	private CloudPlayerStateParser()
 	{
 	}
 
+	/**
+	 * Parses a full {@code /me/state}-shaped root object (account/economy/stats/cards sections)
+	 * into a {@link ParsedCloudPlayerState}. Returns {@link ParsedCloudPlayerState#empty()} if
+	 * {@code root} is null. Cards are read from the top-level {@code cards} field, falling back to
+	 * {@code collection.cards} for older payload shapes.
+	 */
 	public static ParsedCloudPlayerState parse(JsonObject root)
 	{
 		if (root == null)
@@ -89,6 +100,11 @@ public final class CloudPlayerStateParser
 			groupKey);
 	}
 
+	/**
+	 * Converts a {@code cards} JSON array into {@link OwnedCardInstance}s, skipping any element that
+	 * isn't an object or is missing a usable card name. Returns an empty list if {@code cardsEl} is
+	 * null or not an array.
+	 */
 	public static List<OwnedCardInstance> parseCards(JsonElement cardsEl)
 	{
 		List<OwnedCardInstance> out = new ArrayList<>();
@@ -124,6 +140,11 @@ public final class CloudPlayerStateParser
 		return out;
 	}
 
+	/**
+	 * Reads revision/stateHash/collectionHash sync markers from either a stats payload with a nested
+	 * {@code economy} object or an economy object directly, falling back to top-level fields when the
+	 * nested ones are absent. Returns zero/blank markers if {@code statsOrEconomy} is null.
+	 */
 	public static SyncMarkers readSyncMarkers(JsonObject statsOrEconomy)
 	{
 		if (statsOrEconomy == null)
@@ -147,12 +168,14 @@ public final class CloudPlayerStateParser
 		return new SyncMarkers(revision, hash == null ? "" : hash, collectionHash == null ? "" : collectionHash);
 	}
 
+	/** Revision/hash markers used to detect whether local state is behind the cloud copy. */
 	public static final class SyncMarkers
 	{
 		public final long revision;
 		public final String stateHash;
 		public final String collectionHash;
 
+		/** Normalizes revision to non-negative and hashes to trimmed, non-null strings. */
 		public SyncMarkers(long revision, String stateHash, String collectionHash)
 		{
 			this.revision = Math.max(0L, revision);
@@ -161,6 +184,11 @@ public final class CloudPlayerStateParser
 		}
 	}
 
+	/**
+	 * Normalized, immutable snapshot of a cloud player-state response: migration/account status,
+	 * economy totals, sync markers, and the owned card collection (which may be a placeholder when
+	 * {@link #cardsPaged} is true, pending a follow-up page fetch via {@link CloudCollectionPager}).
+	 */
 	public static final class ParsedCloudPlayerState
 	{
 		public final boolean migrated;
@@ -176,6 +204,7 @@ public final class CloudPlayerStateParser
 		public final boolean cardsPaged;
 		public final String groupKey;
 
+		/** Normalizes all fields (non-negative numbers, non-null/trimmed strings, immutable card list). */
 		ParsedCloudPlayerState(
 			boolean migrated,
 			String migratedAt,
@@ -204,6 +233,7 @@ public final class CloudPlayerStateParser
 			this.groupKey = groupKey == null || groupKey.isBlank() ? null : groupKey.trim();
 		}
 
+		/** Returns a copy with {@code nextCards} substituted and {@code cardsPaged} cleared. */
 		public ParsedCloudPlayerState withCards(List<OwnedCardInstance> nextCards)
 		{
 			return new ParsedCloudPlayerState(
@@ -221,6 +251,7 @@ public final class CloudPlayerStateParser
 				groupKey);
 		}
 
+		/** An unmigrated, zeroed-out state used when there is no cloud payload to parse. */
 		static ParsedCloudPlayerState empty()
 		{
 			return new ParsedCloudPlayerState(false, null, null, EconomyState.empty(), 0L, 0L, "", "",

--- a/src/main/java/com/osrstcg/cloud/session/CloudProfileConsentService.java
+++ b/src/main/java/com/osrstcg/cloud/session/CloudProfileConsentService.java
@@ -13,6 +13,12 @@ import com.osrstcg.cloud.catalog.CardCatalogService;
 import com.osrstcg.cloud.catalog.PackCatalogService;
 import com.osrstcg.state.TcgStateService;
 
+/**
+ * Handles the one-time cloud profile creation/consent flow: pairing or refreshing a session,
+ * marking the profile migrated, and adopting an already-migrated server collection when local
+ * progress exists but this profile hasn't consented yet. Blocking: methods issue synchronous HTTP
+ * calls and must not run on the client/EDT thread.
+ */
 @Slf4j
 final class CloudProfileConsentService
 {
@@ -29,6 +35,7 @@ final class CloudProfileConsentService
 	private final CardCatalogService cardCatalogService;
 	private final ActivityConfigService activityConfigService;
 
+	/** Wires collaborators; no side effects. */
 	CloudProfileConsentService(
 		CloudSessionService session,
 		CloudCollectionSyncService collectionSync,
@@ -57,6 +64,12 @@ final class CloudProfileConsentService
 		this.activityConfigService = activityConfigService;
 	}
 
+	/**
+	 * Creates (or completes consent for) the cloud profile for the current RuneScape account: requires
+	 * being logged in with a known account hash, display name, and RuneLite profile key. Runs the
+	 * pairing/migration flow inside {@link CloudApiClient#openConsentTraffic()} so consent-gated
+	 * traffic is permitted for its duration.
+	 */
 	void createProfile() throws Exception
 	{
 		if (client.getGameState() != GameState.LOGGED_IN)
@@ -85,6 +98,11 @@ final class CloudProfileConsentService
 		}
 	}
 
+	/**
+	 * Ensures a session is active (refreshing or pairing as needed), adopts an already-migrated
+	 * server collection if applicable, then marks the profile migrated and finishes consent if it
+	 * wasn't already.
+	 */
 	private void createProfileAllowed(
 		long accountHash,
 		String displayName,
@@ -119,6 +137,11 @@ final class CloudProfileConsentService
 		finishConsentSuccess();
 	}
 
+	/**
+	 * Post-consent bring-up: refreshes local cache from cloud, settles offline hiscores, marks the
+	 * session connected, clears obsolete local caches, and refreshes pack/card catalogs and activity
+	 * config. Bails out early if the account becomes locked (banned/quarantined) partway through.
+	 */
 	void finishConsentSuccess() throws Exception
 	{
 		collectionSync.refreshLocalCacheFromCloud();
@@ -139,6 +162,12 @@ final class CloudProfileConsentService
 		activityConfigService.refreshOnLogin();
 	}
 
+	/**
+	 * If this profile hasn't recorded migration locally but has local progress (credits/packs/cards)
+	 * and has an access token, checks the server state: if the server shows the account already
+	 * migrated (has a migration timestamp or cards), adopts that server collection/economy locally
+	 * and marks migrated, skipping the consent prompt. No-op otherwise.
+	 */
 	void adoptServerMigrationIfNeeded() throws Exception
 	{
 		if (tokens.isMigrated() || tokens.getAccessToken() == null)

--- a/src/main/java/com/osrstcg/cloud/session/CloudSessionCoordinator.java
+++ b/src/main/java/com/osrstcg/cloud/session/CloudSessionCoordinator.java
@@ -19,6 +19,14 @@ import net.runelite.api.GameState;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.WorldChanged;
 
+/**
+ * Wires {@link CloudSessionService} connection lifecycle to RuneLite client events: connects on
+ * login/world change, disconnects on logout, and schedules randomized-delay reconnect attempts
+ * while cloud is reachable-but-not-ready. Starts/stops the credit attest queue and trade sync
+ * alongside session readiness, and pauses all cloud traffic on restricted world types. Connection
+ * attempts run on the injected {@link ScheduledExecutorService}; UI refresh callbacks are marshalled
+ * onto the EDT via {@link SwingUtilities#invokeLater}.
+ */
 @Slf4j
 @Singleton
 public class CloudSessionCoordinator
@@ -39,6 +47,7 @@ public class CloudSessionCoordinator
 	private ScheduledFuture<?> cloudReconnectFuture;
 	private GameState lastObservedGameState;
 
+	/** Wires collaborators; no side effects. */
 	@Inject
 	public CloudSessionCoordinator(
 		Client client,
@@ -58,6 +67,11 @@ public class CloudSessionCoordinator
 		this.scheduler = scheduler;
 	}
 
+	/**
+	 * Registers a listener on {@link CloudSessionService} that starts/stops the attest queue and
+	 * trade sync in response to readiness changes, manages reconnect scheduling, and refreshes the
+	 * sidebar on every status change.
+	 */
 	public void installStatusListener()
 	{
 		cloudSessionService.setStatusListener(() ->
@@ -81,11 +95,18 @@ public class CloudSessionCoordinator
 		});
 	}
 
+	/** Removes the status listener installed by {@link #installStatusListener()}. */
 	public void clearStatusListener()
 	{
 		cloudSessionService.setStatusListener(null);
 	}
 
+	/**
+	 * Kicks off (or no-ops if already in flight) an async attempt to establish/verify the cloud
+	 * session on {@link #scheduler}. Short-circuits if the account is locked or the world is
+	 * restricted. On success, cancels any pending reconnect and starts the attest queue and trade
+	 * sync; on failure, schedules a reconnect.
+	 */
 	public void connect()
 	{
 		if (cloudSessionService.isAccountLocked())
@@ -138,6 +159,7 @@ public class CloudSessionCoordinator
 		});
 	}
 
+	/** Cancels reconnect, stops attest/trade traffic, and marks the session as restricted-world-paused. */
 	public void pauseForRestrictedWorld()
 	{
 		cancelReconnect();
@@ -147,6 +169,11 @@ public class CloudSessionCoordinator
 		SwingUtilities.invokeLater(sidebarRefresh::refresh);
 	}
 
+	/**
+	 * Tears down the cloud session on logout. If the account is locked, discards pending attests
+	 * without flushing; otherwise blocks flushing pending attests and snapshotting hiscores before
+	 * disconnecting.
+	 */
 	public void disconnect()
 	{
 		cancelReconnect();
@@ -165,6 +192,12 @@ public class CloudSessionCoordinator
 		cloudSessionService.disconnectQuietly();
 	}
 
+	/**
+	 * Schedules a single reconnect attempt with a random delay between {@link #CLOUD_RECONNECT_MIN_MS}
+	 * and {@link #CLOUD_RECONNECT_MAX_MS}, unless one is already pending, reconnect isn't applicable
+	 * (not logged in, can't collect attests, already ready, or waiting on game identity), or the
+	 * current connection state isn't {@code ERROR}/{@code DISCONNECTED}.
+	 */
 	public void scheduleReconnectIfNeeded()
 	{
 		if (client.getGameState() != GameState.LOGGED_IN
@@ -197,6 +230,7 @@ public class CloudSessionCoordinator
 		cloudSessionService.noteOfflineReconnectScheduled();
 	}
 
+	/** Fires when a scheduled reconnect delay elapses; re-attempts {@link #connect()} if still needed. */
 	private void onReconnectTimer()
 	{
 		synchronized (cloudReconnectLock)
@@ -212,6 +246,7 @@ public class CloudSessionCoordinator
 		connect();
 	}
 
+	/** Cancels any pending scheduled reconnect, if one exists. */
 	public void cancelReconnect()
 	{
 		synchronized (cloudReconnectLock)
@@ -224,6 +259,10 @@ public class CloudSessionCoordinator
 		}
 	}
 
+	/**
+	 * Per-tick hook: if logged in, not locked, not already connecting/active, and still waiting for
+	 * game identity (display name/account hash) to become available, retries {@link #connect()}.
+	 */
 	public void onLoggedInGameTick()
 	{
 		if (client.getGameState() != GameState.LOGGED_IN)
@@ -244,6 +283,11 @@ public class CloudSessionCoordinator
 		}
 	}
 
+	/**
+	 * Reacts to RuneLite game state transitions: flushes pending attests on leaving a logged-in
+	 * session (excluding hop/loading transitions), disconnects on reaching the login screen, and
+	 * connects (or resumes a restricted-world pause) on reaching logged-in.
+	 */
 	public void onGameStateChanged(GameStateChanged event)
 	{
 		GameState gs = event.getGameState();
@@ -278,6 +322,7 @@ public class CloudSessionCoordinator
 		}
 	}
 
+	/** Re-attempts connect on world hop (world type may have changed) and refreshes the sidebar. */
 	public void onWorldChanged(WorldChanged event)
 	{
 		if (client.getGameState() == GameState.LOGGED_IN)
@@ -287,6 +332,11 @@ public class CloudSessionCoordinator
 		SwingUtilities.invokeLater(sidebarRefresh::refresh);
 	}
 
+	/**
+	 * Client-shutdown hook: blocking-flushes pending attests and snapshots hiscores (unless the
+	 * account is locked), logging rather than throwing on failure, then always stops attest/trade
+	 * traffic and disconnects.
+	 */
 	public void flushAttestsForShutdown()
 	{
 		try

--- a/src/main/java/com/osrstcg/cloud/session/CloudSessionService.java
+++ b/src/main/java/com/osrstcg/cloud/session/CloudSessionService.java
@@ -30,6 +30,14 @@ import com.osrstcg.cloud.catalog.CardCatalogService;
 import com.osrstcg.cloud.catalog.PackCatalogService;
 import com.osrstcg.cloud.trade.TradeCloudService;
 
+/**
+ * Owns the cloud connection lifecycle and account-lock state for the plugin: authenticates/pairs
+ * the RuneLite profile with the cloud backend, tracks connection state and status messages, gates
+ * traffic behind consent/lock/restricted-world checks, and delegates collection sync, hiscores
+ * settling, and profile-consent work to {@link CloudCollectionSyncService}, {@link HiscoresSettleService},
+ * and {@link CloudProfileConsentService} respectively. {@link #ensureSession()} is synchronized and
+ * blocking (issues synchronous HTTP calls) and must not run on the client/EDT thread.
+ */
 @Slf4j
 @Singleton
 public final class CloudSessionService
@@ -71,6 +79,11 @@ public final class CloudSessionService
 	public static final String ACCOUNT_QUARANTINED_STATUS =
 		"Your account is quarantined. Check the account panel for more information.";
 
+	/**
+	 * Wires collaborators, constructs the internal {@link CloudCollectionPager}/{@link CloudCollectionSyncService}/
+	 * {@link HiscoresSettleService}/{@link CloudProfileConsentService} helpers, and registers this
+	 * service's stale-refresh and account-lock handlers with {@code api}.
+	 */
 	@Inject
 	CloudSessionService(
 		Client client,
@@ -117,6 +130,7 @@ public final class CloudSessionService
 		api.setAccountLockHandler(this::noteLockFromApiException);
 	}
 
+	/** Invoked by {@link CloudApiClient} when a refresh token is rejected as stale: clears login gates and disconnects. */
 	private void handleStaleRefresh()
 	{
 		clearLoginFetchGates();
@@ -124,42 +138,53 @@ public final class CloudSessionService
 			needsCloudConsent() ? CONSENT_WAITING_STATUS : "Disconnected");
 	}
 
+	/** Current cloud connection state. */
 	public CloudConnectionState getConnectionState()
 	{
 		return connectionState.get();
 	}
 
+	/** Human-readable status message associated with the current connection state. */
 	public String getStatusMessage()
 	{
 		return statusMessage.get();
 	}
 
+	/** Whether the player needs to log into RuneScape before cloud session setup can proceed. */
 	public boolean isRunescapeLoginRequired()
 	{
 		return client.getGameState() != GameState.LOGGED_IN;
 	}
 
+	/** Whether the connection state is CONNECTED and an access token is present. */
 	public boolean isSessionActive()
 	{
 		return connectionState.get() == CloudConnectionState.CONNECTED && tokens.getAccessToken() != null;
 	}
 
+	/** Whether the session is active and no gate (consent/lock/restricted world) is blocking traffic. */
 	public boolean isReady()
 	{
 		return isSessionActive() && cloudGatesOpen();
 	}
 
+	/** Whether credit attests may currently be collected, regardless of session state. */
 	public boolean canCollectAttests()
 	{
 		return cloudGatesOpen();
 	}
 
+	/** True unless cloud consent is pending, the account is locked, or the world is restricted. */
 	private boolean cloudGatesOpen()
 	{
 		return !needsCloudConsent() && !isAccountLocked()
 			&& !isRestrictedWorld();
 	}
 
+	/**
+	 * Updates the status message to indicate an offline reconnect was scheduled, if a reconnect is
+	 * applicable and the current state is ERROR/DISCONNECTED. No-op otherwise.
+	 */
 	public void noteOfflineReconnectScheduled()
 	{
 		if (!canCollectAttests() || isReady())
@@ -174,26 +199,31 @@ public final class CloudSessionService
 		setState(state, "Cloud unreachable - retrying in 5-15m");
 	}
 
+	/** Whether the current world type is one where cloud credits are disabled. */
 	public boolean isRestrictedWorld()
 	{
 		return restrictedWorldGuard.isRestricted();
 	}
 
+	/** Whether the account is currently flagged banned. */
 	public boolean isAccountBanned()
 	{
 		return accountBanned.get();
 	}
 
+	/** Whether the account is currently flagged quarantined. */
 	public boolean isAccountQuarantined()
 	{
 		return accountQuarantined.get();
 	}
 
+	/** Whether the account is banned or quarantined. */
 	public boolean isAccountLocked()
 	{
 		return isAccountBanned() || isAccountQuarantined();
 	}
 
+	/** Whether the account panel may be opened: requires a token, consent, an unrestricted world, and (active or locked) session. */
 	public boolean canOpenAccountPanel()
 	{
 		if (tokens.getAccessToken() == null || needsCloudConsent() || isRestrictedWorld())
@@ -203,6 +233,7 @@ public final class CloudSessionService
 		return isSessionActive() || isAccountLocked();
 	}
 
+	/** Stops hiscores/activity polling and moves the connection to DISCONNECTED with a restricted-world message. */
 	public void enterRestrictedWorld()
 	{
 		hiscoresSettle.clearGate();
@@ -214,11 +245,13 @@ public final class CloudSessionService
 		setState(CloudConnectionState.DISCONNECTED, message);
 	}
 
+	/** Flags the account as banned and pauses all cloud traffic. */
 	public void enterAccountBanned()
 	{
 		enterAccountLock(accountBanned, ACCOUNT_BANNED_STATUS, "banned");
 	}
 
+	/** Flags the account as quarantined and pauses all cloud traffic, unless already banned. */
 	public void enterAccountQuarantined()
 	{
 		if (isAccountBanned())
@@ -228,6 +261,7 @@ public final class CloudSessionService
 		enterAccountLock(accountQuarantined, ACCOUNT_QUARANTINED_STATUS, "quarantined");
 	}
 
+	/** Sets {@code flag}, pauses cloud traffic, updates status, and logs once on first transition into the lock. */
 	private void enterAccountLock(AtomicBoolean flag, String statusMessage, String kind)
 	{
 		boolean already = flag.getAndSet(true);
@@ -239,6 +273,7 @@ public final class CloudSessionService
 		}
 	}
 
+	/** Persists {@code status} and, if it's "banned"/"quarantined", enters the corresponding lock. No-op if blank. */
 	void applyAccountStatus(String status)
 	{
 		if (status == null || status.isBlank())
@@ -257,6 +292,7 @@ public final class CloudSessionService
 		}
 	}
 
+	/** Registers a callback to run when the account transitions into a locked (banned/quarantined) state. */
 	public void registerAccountLockCleanup(Runnable cleanup)
 	{
 		if (cleanup != null)
@@ -265,6 +301,11 @@ public final class CloudSessionService
 		}
 	}
 
+	/**
+	 * Stops and discards pending attests, runs registered lock cleanups (catching and logging any
+	 * failure so one bad cleanup doesn't block the rest), and stops trade sync, activity polling,
+	 * hiscores gating, and the pack catalog.
+	 */
 	private void pauseCloudTrafficOnLock()
 	{
 		CreditAttestQueue attestQueue = attestQueueProvider.get();
@@ -288,6 +329,7 @@ public final class CloudSessionService
 		packCatalogService.clear();
 	}
 
+	/** Applies banned/quarantined flags read from an attest response, if present. No-op if {@code response} is null. */
 	public void noteAttestBanFlags(JsonObject response)
 	{
 		if (response == null)
@@ -299,6 +341,7 @@ public final class CloudSessionService
 			JsonObjects.readBoolean(response, "quarantined"));
 	}
 
+	/** Applies banned/quarantined flags carried on a {@link CloudApiException}, if present. No-op if null. */
 	public void noteLockFromApiException(CloudApiException ex)
 	{
 		if (ex == null)
@@ -308,6 +351,7 @@ public final class CloudSessionService
 		applyAccountLockFlags(ex.isAccountBanned(), ex.isAccountQuarantined());
 	}
 
+	/** Enters the banned lock if {@code banned}, else the quarantined lock if {@code quarantined}. */
 	private void applyAccountLockFlags(boolean banned, boolean quarantined)
 	{
 		if (banned)
@@ -321,27 +365,40 @@ public final class CloudSessionService
 		}
 	}
 
+	/** Whether pending credit attests may be flushed to the server right now. */
 	public boolean canAttestFlush()
 	{
 		return tokens.getAccessToken() != null && !needsCloudConsent() && !isAccountLocked();
 	}
 
+	/** Whether this profile still needs to complete the cloud consent/migration flow. */
 	public boolean needsCloudConsent()
 	{
 		return !tokens.isMigrated();
 	}
 
+	/** Replaces the connection-status change listener (single slot; pass {@code null} to clear). */
 	public void setStatusListener(Runnable listener)
 	{
 		statusListener.set(listener);
 	}
 
+	/** Whether the status message indicates we're blocked waiting for account hash or display name. */
 	public boolean isWaitingForGameIdentity()
 	{
 		String message = statusMessage.get();
 		return WAITING_FOR_DISPLAY_NAME.equals(message) || WAITING_FOR_ACCOUNT.equals(message);
 	}
 
+	/**
+	 * Synchronously drives the cloud session state machine to completion: validates preconditions
+	 * (not locked, not restricted world, logged in, has account hash, consent granted, has display
+	 * name/profile key), refreshes or pairs credentials, adopts server migration if needed, syncs
+	 * collection state, settles hiscores, and refreshes catalogs — moving through CONNECTING to
+	 * CONNECTED, or to ERROR/DISCONNECTED with an explanatory status message on failure. Blocking:
+	 * issues synchronous HTTP calls; callers must invoke off the client/EDT thread. Synchronized so
+	 * concurrent callers serialize rather than racing the connection state machine.
+	 */
 	public synchronized void ensureSession()
 	{
 		if (isAccountLocked())
@@ -452,6 +509,7 @@ public final class CloudSessionService
 		}
 	}
 
+	/** Sanitized local player display name, or {@code null} if the player/name isn't available yet. */
 	String resolveDisplayName()
 	{
 		if (client.getLocalPlayer() == null || client.getLocalPlayer().getName() == null)
@@ -462,17 +520,20 @@ public final class CloudSessionService
 		return name == null || name.isEmpty() ? null : name;
 	}
 
+	/** Delegates to {@link CloudProfileConsentService#createProfile()}. Blocking; synchronized. */
 	public synchronized void createProfile() throws Exception
 	{
 		profileConsent.createProfile();
 	}
 
+	/** Deletes on-disk card catalog and image caches left over from before this profile migrated. */
 	void deleteObsoleteLocalCaches()
 	{
 		cardCatalogService.deleteDiskCache();
 		cardImageCacheService.deleteObsoleteImageCacheDirs();
 	}
 
+	/** Clears lock flags, login gates, and cloud-derived local caches, then moves to DISCONNECTED. */
 	public void disconnectQuietly()
 	{
 		accountBanned.set(false);
@@ -483,26 +544,31 @@ public final class CloudSessionService
 		setState(CloudConnectionState.DISCONNECTED, "Disconnected");
 	}
 
+	/** Delegates to {@link HiscoresSettleService#snapshotOnLogout()}. Blocking. */
 	public void snapshotHiscoresOnLogout()
 	{
 		hiscoresSettle.snapshotOnLogout();
 	}
 
+	/** Delegates to {@link CloudCollectionSyncService#applySidebarStats(JsonObject)}. */
 	public void applySidebarStats(JsonObject stats)
 	{
 		collectionSync.applySidebarStats(stats);
 	}
 
+	/** Delegates to {@link CloudCollectionSyncService#reconcileCollectionFromInbox(JsonObject)}. */
 	public void reconcileCollectionFromInbox(JsonObject stats)
 	{
 		collectionSync.reconcileCollectionFromInbox(stats);
 	}
 
+	/** Delegates to {@link CloudCollectionSyncService#refreshCreditsFromServer()}. Blocking. */
 	public void refreshCreditsFromServer() throws Exception
 	{
 		collectionSync.refreshCreditsFromServer();
 	}
 
+	/** Pairs a new session for this profile/account and applies the returned token response. Blocking. */
 	void pairSession(String displayName, String profileHash, long accountHash)
 		throws CloudApiException, IOException
 	{
@@ -510,6 +576,7 @@ public final class CloudSessionService
 		api.applyTokenResponse(start);
 	}
 
+	/** Whether the local state has any credits, opened packs, or owned cards worth migrating. */
 	boolean hasLocalProgress()
 	{
 		TcgState local = stateService.getState();
@@ -518,6 +585,7 @@ public final class CloudSessionService
 			|| !local.getCollectionState().getOwnedInstances().isEmpty();
 	}
 
+	/** Updates connection state and status message, then notifies the registered status listener, if any. */
 	void setState(CloudConnectionState state, String message)
 	{
 		connectionState.set(state);
@@ -529,6 +597,7 @@ public final class CloudSessionService
 		}
 	}
 
+	/** Resets per-login one-shot gates (catalog fetch, activity polling, hiscores settle) so they re-run on next login. */
 	private void clearLoginFetchGates()
 	{
 		packCatalogService.clear();
@@ -537,6 +606,7 @@ public final class CloudSessionService
 		hiscoresSettle.clearGate();
 	}
 
+	/** Whether {@code displayName} is null or empty. */
 	private static boolean displayNameMissing(String displayName)
 	{
 		return displayName == null || displayName.isEmpty();

--- a/src/main/java/com/osrstcg/cloud/session/CloudTokenStore.java
+++ b/src/main/java/com/osrstcg/cloud/session/CloudTokenStore.java
@@ -24,21 +24,28 @@ public final class CloudTokenStore
 		this.configManager = configManager;
 	}
 
+	/** Returns the stored access token, or {@code null} if none is set. */
 	public String getAccessToken()
 	{
 		return JsonObjects.blankToNull(configManager.getRSProfileConfiguration(GROUP, ACCESS));
 	}
 
+	/** Returns the stored refresh token, or {@code null} if none is set. */
 	public String getRefreshToken()
 	{
 		return JsonObjects.blankToNull(configManager.getRSProfileConfiguration(GROUP, REFRESH));
 	}
 
+	/** Whether this profile has completed the one-time cloud migration/consent flow. */
 	public boolean isMigrated()
 	{
 		return "true".equalsIgnoreCase(configManager.getRSProfileConfiguration(GROUP, MIGRATED));
 	}
 
+	/**
+	 * Persists the access/refresh token pair, and optionally the account id and status.
+	 * No-op if either token is null/empty.
+	 */
 	public void saveTokens(String accessToken, String refreshToken, String accountId, String status)
 	{
 		if (accessToken == null || accessToken.isEmpty() || refreshToken == null || refreshToken.isEmpty())
@@ -57,11 +64,13 @@ public final class CloudTokenStore
 		}
 	}
 
+	/** Marks (or unmarks) this profile as having completed cloud migration/consent. */
 	public void setMigrated(boolean migrated)
 	{
 		configManager.setRSProfileConfiguration(GROUP, MIGRATED, migrated ? "true" : "false");
 	}
 
+	/** Persists the account status (e.g. banned/quarantined). No-op if {@code status} is null/empty. */
 	public void setAccountStatus(String status)
 	{
 		if (status == null || status.isEmpty())
@@ -71,6 +80,7 @@ public final class CloudTokenStore
 		configManager.setRSProfileConfiguration(GROUP, STATUS, status);
 	}
 
+	/** Removes stored access/refresh tokens, account id, and status (does not clear the migrated flag). */
 	public void clear()
 	{
 		configManager.unsetRSProfileConfiguration(GROUP, ACCESS);
@@ -79,6 +89,7 @@ public final class CloudTokenStore
 		configManager.unsetRSProfileConfiguration(GROUP, STATUS);
 	}
 
+	/** Whether a refresh token is currently stored. */
 	public boolean hasRefreshToken()
 	{
 		return getRefreshToken() != null;

--- a/src/main/java/com/osrstcg/cloud/session/HiscoresSettleService.java
+++ b/src/main/java/com/osrstcg/cloud/session/HiscoresSettleService.java
@@ -17,6 +17,13 @@ import com.osrstcg.cloud.api.JsonObjects;
 import com.osrstcg.cloud.trade.TradeCloudService;
 import javax.inject.Provider;
 
+/**
+ * Settles offline hiscores gains into cloud credits once per login, and snapshots hiscores on
+ * logout so offline progress since the snapshot can be settled next login. Handles transient
+ * {@code hiscores_unavailable} failures with a single delayed retry. Blocking: methods issue
+ * synchronous HTTP calls via {@link CloudApiClient} and must not run on the client/EDT thread,
+ * except the scheduled retry body which runs on {@link #scheduler}.
+ */
 @Slf4j
 final class HiscoresSettleService
 {
@@ -37,6 +44,7 @@ final class HiscoresSettleService
 	private final java.util.function.BooleanSupplier needsCloudConsent;
 	private final java.util.function.BooleanSupplier isAccountLocked;
 
+	/** Wires collaborators and the shared login/retry flags owned by {@link CloudSessionService}. */
 	HiscoresSettleService(
 		Client client,
 		CloudApiClient api,
@@ -65,6 +73,11 @@ final class HiscoresSettleService
 		this.isAccountLocked = isAccountLocked;
 	}
 
+	/**
+	 * Records a hiscores snapshot at logout so future gains can be settled next login. No-op if the
+	 * account is locked, consent is pending, no access token, the world is restricted, or the account
+	 * hash/display name aren't known. Failures are logged at debug level and swallowed.
+	 */
 	void snapshotOnLogout()
 	{
 		if (isAccountLocked.getAsBoolean()
@@ -109,6 +122,12 @@ final class HiscoresSettleService
 		}
 	}
 
+	/**
+	 * Settles offline hiscores gains since the last snapshot into credits, once per login (guarded by
+	 * {@link #hiscoresSettledThisLogin}). No-op if already settled this login, the account is locked,
+	 * consent is pending, no access token, the world is restricted, or the account hash/display name
+	 * aren't known yet. On error, delegates to {@link #handleSettleError}.
+	 */
 	void settleAfterCloudLogin()
 	{
 		if (hiscoresSettledThisLogin.get())
@@ -151,12 +170,18 @@ final class HiscoresSettleService
 		}
 	}
 
+	/** Resets the once-per-login settle gate and retry-scheduled flag (e.g. on logout or lock). */
 	void clearGate()
 	{
 		hiscoresSettledThisLogin.set(false);
 		hiscoresRetryScheduled.set(false);
 	}
 
+	/**
+	 * Classifies a settle failure: "not found"/forbidden/locked codes are treated as terminal for
+	 * this login (marks settled, no retry); {@code hiscores_unavailable}/503 schedules one retry;
+	 * anything else is just logged.
+	 */
 	private void handleSettleError(CloudApiException ex, long accountHash, String displayName)
 	{
 		String code = ex.getCode() == null ? "" : ex.getCode();
@@ -187,6 +212,11 @@ final class HiscoresSettleService
 		log.warn("Hiscores settle failed: {} {}", code, ex.getMessage());
 	}
 
+	/**
+	 * Schedules a single delayed settle retry (guarded by {@link #hiscoresRetryScheduled} so only one
+	 * retry is ever pending). The retry re-checks preconditions (not already settled, has token,
+	 * consent granted, still the same account) before calling settle again.
+	 */
 	private void scheduleRetry(long accountHash, String displayName)
 	{
 		if (!hiscoresRetryScheduled.compareAndSet(false, true))
@@ -226,6 +256,7 @@ final class HiscoresSettleService
 		}, HISCORES_RETRY_DELAY_SEC, TimeUnit.SECONDS);
 	}
 
+	/** Current local player's sanitized name, falling back to the last known name if unavailable. */
 	private String resolveDisplayName()
 	{
 		if (client.getLocalPlayer() != null && client.getLocalPlayer().getName() != null)
@@ -240,6 +271,10 @@ final class HiscoresSettleService
 		return lastDisplayName;
 	}
 
+	/**
+	 * Applies a settle response's sidebar stats and revision, and posts a chat toast when credits
+	 * were accepted. No-op if the response is null or marked skipped/throttled.
+	 */
 	private void applySettleResponse(JsonObject response)
 	{
 		if (response == null)
@@ -272,6 +307,7 @@ final class HiscoresSettleService
 		}
 	}
 
+	/** Formats the "Offline settle: +N credits (XP x, levels y, activities z)." chat toast text. */
 	private static String buildToast(long accepted, JsonObject response)
 	{
 		StringBuilder sb = new StringBuilder("Offline settle: +");

--- a/src/main/java/com/osrstcg/cloud/session/ProfileKeyHasher.java
+++ b/src/main/java/com/osrstcg/cloud/session/ProfileKeyHasher.java
@@ -7,6 +7,10 @@ import javax.inject.Singleton;
 import net.runelite.client.RuneLite;
 import net.runelite.client.config.ConfigManager;
 
+/**
+ * Derives stable, hashed identifiers used for cloud pairing and local cache directory naming:
+ * a hash of the current RuneLite profile key, and hashes of account hashes for per-account dirs.
+ */
 @Singleton
 public final class ProfileKeyHasher
 {
@@ -18,6 +22,7 @@ public final class ProfileKeyHasher
 		this.configManager = configManager;
 	}
 
+	/** Hex hash of the active RuneLite profile key, or {@code null} if no profile key is set. */
 	public String currentProfileKeyHash()
 	{
 		String key = configManager.getRSProfileKey();
@@ -28,6 +33,7 @@ public final class ProfileKeyHasher
 		return TcgStateHash.hexOfUtf8(key);
 	}
 
+	/** Hex hash of {@code accountHash} used as the local cache directory name, or {@code null} if unset (-1). */
 	public static String accountDirName(long accountHash)
 	{
 		if (accountHash == -1L)
@@ -37,11 +43,13 @@ public final class ProfileKeyHasher
 		return TcgStateHash.hexOfUtf8(Long.toString(accountHash));
 	}
 
+	/** Root directory under the RuneLite home where this plugin stores local data. */
 	public static Path tcgRoot()
 	{
 		return Path.of(RuneLite.RUNELITE_DIR.getAbsolutePath(), "OSRS-TCG");
 	}
 
+	/** Directory holding per-profile local caches, under {@link #tcgRoot()}. */
 	public static Path profilesRoot()
 	{
 		return tcgRoot().resolve("profiles");

--- a/src/main/java/com/osrstcg/cloud/session/RestrictedWorldGuard.java
+++ b/src/main/java/com/osrstcg/cloud/session/RestrictedWorldGuard.java
@@ -8,6 +8,10 @@ import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.api.WorldType;
 
+/**
+ * Detects world types (PvP arena, Deadman, seasonal, etc.) where cloud credits/attests must be
+ * disabled, and describes which blocked types are active on the current world.
+ */
 @Singleton
 public final class RestrictedWorldGuard
 {
@@ -30,11 +34,13 @@ public final class RestrictedWorldGuard
 		this.client = client;
 	}
 
+	/** Whether the current world (per the client) has a blocked world type. */
 	public boolean isRestricted()
 	{
 		return isRestricted(client == null ? null : client.getWorldType());
 	}
 
+	/** Whether any of {@code types} is a blocked world type. */
 	public static boolean isRestricted(EnumSet<WorldType> types)
 	{
 		if (types == null || types.isEmpty())
@@ -51,6 +57,7 @@ public final class RestrictedWorldGuard
 		return false;
 	}
 
+	/** Comma-joined names of the blocked world types present on the current world, or {@code ""} if none. */
 	public String describeBlockedTypes()
 	{
 		EnumSet<WorldType> types = client == null ? null : client.getWorldType();

--- a/src/main/java/com/osrstcg/cloud/shop/CloudPackService.java
+++ b/src/main/java/com/osrstcg/cloud/shop/CloudPackService.java
@@ -34,6 +34,12 @@ import com.osrstcg.cloud.catalog.PackPullParser;
 import com.osrstcg.cloud.session.CloudSessionService;
 import com.osrstcg.cloud.trade.TradeCloudService;
 
+/**
+ * Buys a booster pack through the cloud API and applies the resulting pulls, credits and ranks to local state.
+ * {@link #buyAndOpenPack(BoosterPackDefinition)} makes a blocking network call and updates shared
+ * {@link TcgStateService} state, so callers must invoke it off the client thread and marshal any UI work
+ * back onto the client thread themselves.
+ */
 @Slf4j
 @Singleton
 public final class CloudPackService
@@ -48,6 +54,7 @@ public final class CloudPackService
 	private final Client client;
 	private final TcgPartyAnnouncer partyAnnouncer;
 
+	/** Wires cloud/session/state collaborators used to buy and resolve a pack open. */
 	@Inject
 	CloudPackService(
 		CloudApiClient api,
@@ -71,11 +78,22 @@ public final class CloudPackService
 		this.partyAnnouncer = partyAnnouncer;
 	}
 
+	/**
+	 * Buys and opens {@code booster} via the cloud API. Makes a blocking network call - run off the client
+	 * thread. Never throws; failures are reported through the returned {@link PackOpenResult}.
+	 */
 	public PackOpenResult buyAndOpenPack(BoosterPackDefinition booster)
 	{
 		return buyAndOpenPack(booster, true);
 	}
 
+	/**
+	 * Core buy-and-open flow: validates session/credits/catalog, calls the open-pack endpoint, then updates
+	 * owned cards, credits, sidebar ranks and collection stats from the response.
+	 *
+	 * @param allowCatalogRetry whether a {@code catalog_mismatch} error should trigger one catalog refresh
+	 *                          and a single retry with the refreshed pack definition
+	 */
 	private PackOpenResult buyAndOpenPack(BoosterPackDefinition booster, boolean allowCatalogRetry)
 	{
 		long creditsBefore = stateService.getCredits();
@@ -264,6 +282,7 @@ public final class CloudPackService
 		}
 	}
 
+	/** Reconciles local credits with the server's reported balance after an insufficient-credits failure. */
 	private void applyInsufficientCreditsFix(CloudApiException ex)
 	{
 		Long serverCredits = ex == null ? null : ex.getServerCredits();
@@ -277,6 +296,7 @@ public final class CloudPackService
 		refreshCreditsQuietly();
 	}
 
+	/** Refreshes credits from the server, swallowing and logging any failure. */
 	private void refreshCreditsQuietly()
 	{
 		try
@@ -289,6 +309,7 @@ public final class CloudPackService
 		}
 	}
 
+	/** Applies the optional 6-element {@code ranks} array from a pack-open response to sidebar state, if present and valid. */
 	private void absorbRanksFromPackOpen(JsonObject response)
 	{
 		if (response == null || !response.has("ranks") || !response.get("ranks").isJsonArray())

--- a/src/main/java/com/osrstcg/cloud/trade/TcgTradeMenuHandler.java
+++ b/src/main/java/com/osrstcg/cloud/trade/TcgTradeMenuHandler.java
@@ -14,6 +14,7 @@ import net.runelite.client.util.Text;
 @Singleton
 public class TcgTradeMenuHandler
 {
+	/** Menu option text injected on message rows and matched back on click. */
 	static final String TRADE_REQ_MENU_OPTION = "TCG trade request";
 
 	private final Client client;
@@ -26,6 +27,10 @@ public class TcgTradeMenuHandler
 		this.tradeCloudService = tradeCloudService;
 	}
 
+	/**
+	 * Injects a "TCG trade request" entry onto "Message" menu rows (friends / friends chat / clan). Must run
+	 * on the client thread, as {@link MenuEntryAdded} handlers do.
+	 */
 	public void onMenuEntryAdded(MenuEntryAdded event)
 	{
 		if (event == null || !"Message".equals(event.getOption()))
@@ -49,6 +54,11 @@ public class TcgTradeMenuHandler
 			.onClick(e -> tradeCloudService.sendTradeRequest(playerName));
 	}
 
+	/**
+	 * Handles clicks on the injected "TCG trade request" entry, sending the trade request for the clicked
+	 * player. Must run on the client thread, as {@link MenuOptionClicked} handlers do; the actual request is
+	 * dispatched asynchronously by {@link TradeCloudService#sendTradeRequest(String)}.
+	 */
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
 		if (event == null || !TRADE_REQ_MENU_OPTION.equals(event.getMenuOption()))

--- a/src/main/java/com/osrstcg/cloud/trade/TradeCloudService.java
+++ b/src/main/java/com/osrstcg/cloud/trade/TradeCloudService.java
@@ -20,6 +20,13 @@ import com.osrstcg.cloud.api.CloudApiException;
 import com.osrstcg.cloud.api.CloudEndpoints;
 import com.osrstcg.cloud.session.CloudSessionService;
 
+/**
+ * Manages player-to-player trading against the cloud API: sending trade requests and self-rescheduling
+ * polling of the trade inbox, with backoff on errors. {@link #start()}/{@link #stop()} control the poll
+ * loop's lifecycle (e.g. on login/logout); {@link #sendTradeRequest(String)} and the poll loop both run
+ * their network calls on the injected {@link ScheduledExecutorService}, never on the client thread, and
+ * notify the registered inbox listener afterward so the caller can hop back to the client thread.
+ */
 @Slf4j
 @Singleton
 public final class TradeCloudService
@@ -46,6 +53,7 @@ public final class TradeCloudService
 	private final Object scheduleLock = new Object();
 	private ScheduledFuture<?> pollFuture;
 
+	/** Wires cloud/session collaborators and the executor used for network calls and polling. */
 	@Inject
 	TradeCloudService(
 		CloudApiClient api,
@@ -61,6 +69,7 @@ public final class TradeCloudService
 		this.scheduler = scheduler;
 	}
 
+	/** Starts the inbox poll loop (idempotent) and resets revision/backoff state, forcing a login broadcast. */
 	public void start()
 	{
 		synchronized (scheduleLock)
@@ -78,6 +87,7 @@ public final class TradeCloudService
 		}
 	}
 
+	/** Stops the inbox poll loop and cancels any scheduled poll. */
 	public void stop()
 	{
 		synchronized (scheduleLock)
@@ -91,6 +101,10 @@ public final class TradeCloudService
 		}
 	}
 
+	/**
+	 * Requests an immediate inbox poll, bypassing the current backoff/interval. If a poll is already in
+	 * flight, defers the extra poll until it finishes rather than running two concurrently.
+	 */
 	public void requestForcedRefresh()
 	{
 		synchronized (scheduleLock)
@@ -109,6 +123,7 @@ public final class TradeCloudService
 		}
 	}
 
+	/** Records the latest known trade-inbox revision, ignoring negative (unknown) values. */
 	public void noteRevision(long revision)
 	{
 		if (revision >= 0L)
@@ -117,21 +132,29 @@ public final class TradeCloudService
 		}
 	}
 
+	/** @return the last known trade-inbox revision, or -1 if none has been observed yet */
 	public long getLastRevision()
 	{
 		return lastRevision.get();
 	}
 
+	/** Registers the callback invoked after each poll/mutation that may have changed inbox state. */
 	public void setInboxListener(Runnable listener)
 	{
 		inboxListener.set(listener);
 	}
 
+	/** @return the most recent unresolved incoming trade from the last poll, or null if none */
 	public TradeInboxItem getPendingAccept()
 	{
 		return pendingAccept.get();
 	}
 
+	/**
+	 * Creates a trade request to {@code partnerDisplayName} via the cloud API. Dispatches the (blocking)
+	 * network call on the executor, so this method returns immediately; chat feedback, opening the trade
+	 * web page and a forced inbox refresh happen asynchronously once the call completes.
+	 */
 	public void sendTradeRequest(String partnerDisplayName)
 	{
 		if (!session.isReady())
@@ -190,6 +213,7 @@ public final class TradeCloudService
 		});
 	}
 
+	/** Chats a mapped failure message for a failed trade mutation, unless the account is locked/banned/quarantined. */
 	private void queueTradeFailure(CloudApiException ex)
 	{
 		if (ex != null && (ex.isAccountBanned() || ex.isAccountQuarantined() || session.isAccountLocked()))
@@ -201,6 +225,7 @@ public final class TradeCloudService
 			mapped == null ? "Trade failed." : mapped);
 	}
 
+	/** Schedules the next poll after {@code delayMs}; no-op if stopped. Caller must hold {@link #scheduleLock}. */
 	private void scheduleNextLocked(long delayMs)
 	{
 		if (!running.get())
@@ -210,6 +235,7 @@ public final class TradeCloudService
 		pollFuture = scheduler.schedule(this::pollSafe, Math.max(0L, delayMs), TimeUnit.MILLISECONDS);
 	}
 
+	/** Cancels any pending scheduled poll. Caller must hold {@link #scheduleLock}. */
 	private void cancelScheduledLocked()
 	{
 		if (pollFuture != null)
@@ -219,6 +245,11 @@ public final class TradeCloudService
 		}
 	}
 
+	/**
+	 * Poll-loop entry point: runs {@link #poll()}, computes the next delay (honoring server-suggested
+	 * interval, error backoff, or a queued forced refresh), and reschedules itself. Never throws - all
+	 * poll failures are caught, logged and turned into a backoff delay.
+	 */
 	private void pollSafe()
 	{
 		polling.set(true);
@@ -261,6 +292,13 @@ public final class TradeCloudService
 		}
 	}
 
+	/**
+	 * Makes one blocking call to the trade-inbox endpoint, applies any changed sidebar stats/revision, chats
+	 * a ping for newly-notified (or, on first poll after login, all) pending trades, acks notified items,
+	 * and updates {@link #pendingAccept}.
+	 *
+	 * @return the server-suggested delay in ms before the next poll
+	 */
 	private long poll() throws Exception
 	{
 		if (!session.isReady() || client.getAccountHash() == -1L)
@@ -324,6 +362,7 @@ public final class TradeCloudService
 		return pollAfterMs;
 	}
 
+	/** Applies any credits/openedPacks/totalCreditsGained/revision fields present on a trade RPC response to session state. */
 	private void applyEconomyFieldsFromRpc(JsonObject response)
 	{
 		if (response == null)
@@ -353,6 +392,7 @@ public final class TradeCloudService
 		}
 	}
 
+	/** Invokes the registered inbox listener, if any. */
 	private void notifyListener()
 	{
 		Runnable listener = inboxListener.get();
@@ -362,6 +402,11 @@ public final class TradeCloudService
 		}
 	}
 
+	/**
+	 * Chooses the next poll delay for a failed poll based on the error type: re-establishes the session and
+	 * waits {@link #AUTH_RETRY_MS} on 401, exponential backoff on rate limit/server error, otherwise falls
+	 * back to the last known good interval.
+	 */
 	private long delayForApiError(CloudApiException ex)
 	{
 		if (ex.isUnauthorized())
@@ -382,6 +427,7 @@ public final class TradeCloudService
 		return Math.max(DEFAULT_POLL_MS, lastGoodPollAfterMs.get());
 	}
 
+	/** Doubles the current backoff (starting from {@link #DEFAULT_POLL_MS}), capped at {@link #BACKOFF_MAX_MS}. */
 	private long nextBackoffDelayMs()
 	{
 		long next = backoffMs.get();

--- a/src/main/java/com/osrstcg/cloud/trade/TradeInboxItem.java
+++ b/src/main/java/com/osrstcg/cloud/trade/TradeInboxItem.java
@@ -9,6 +9,7 @@ public final class TradeInboxItem
 	private final String fromDisplayName;
 	private final boolean notified;
 
+	/** @param fromDisplayName null is normalized to an empty string */
 	public TradeInboxItem(String tradeId, String fromDisplayName, boolean notified)
 	{
 		this.tradeId = tradeId;
@@ -16,16 +17,19 @@ public final class TradeInboxItem
 		this.notified = notified;
 	}
 
+	/** Server-assigned id of the pending trade. */
 	public String getTradeId()
 	{
 		return tradeId;
 	}
 
+	/** Display name of the player who sent the trade request; never null. */
 	public String getFromDisplayName()
 	{
 		return fromDisplayName;
 	}
 
+	/** Whether the chat ping for this trade has already been shown. */
 	public boolean isNotified()
 	{
 		return notified;

--- a/src/main/java/com/osrstcg/cloud/trade/TradeMutationErrors.java
+++ b/src/main/java/com/osrstcg/cloud/trade/TradeMutationErrors.java
@@ -6,6 +6,7 @@ import com.osrstcg.cloud.api.CloudApiException;
  */
 final class TradeMutationErrors
 {
+	/** Static-only utility class; not instantiable. */
 	private TradeMutationErrors()
 	{
 	}

--- a/src/main/java/com/osrstcg/command/TcgResetCommand.java
+++ b/src/main/java/com/osrstcg/command/TcgResetCommand.java
@@ -14,6 +14,10 @@ import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 
+/**
+ * Implements the {@code ::tcg-reset} chat command: clears all plugin config keys, restores defaults,
+ * and reconnects the cloud session.
+ */
 @Singleton
 public class TcgResetCommand
 {
@@ -25,6 +29,7 @@ public class TcgResetCommand
 	private final SidebarRefresh sidebarRefresh;
 	private final ConfigManager configManager;
 
+	/** Stores the collaborators used to clear config, reconnect the cloud session, and refresh the UI. */
 	@Inject
 	public TcgResetCommand(
 		Client client,
@@ -44,6 +49,7 @@ public class TcgResetCommand
 		this.configManager = configManager;
 	}
 
+	/** Dispatches {@code ::tcg-reset} to {@link #handleResetConfigCommand()}; ignores every other command. */
 	public void onCommandExecuted(CommandExecuted event)
 	{
 		if (event == null || event.getCommand() == null)
@@ -57,6 +63,10 @@ public class TcgResetCommand
 		handleResetConfigCommand();
 	}
 
+	/**
+	 * Unsets every {@code osrstcg.*} config key (global and RS-profile-scoped), restores config defaults,
+	 * reconnects the cloud session if logged in, refreshes the sidebar on the EDT, and chats a summary.
+	 */
 	private void handleResetConfigCommand()
 	{
 		final String group = "osrstcg";

--- a/src/main/java/com/osrstcg/config/CreditsPerHourWindow.java
+++ b/src/main/java/com/osrstcg/config/CreditsPerHourWindow.java
@@ -1,5 +1,6 @@
 package com.osrstcg.config;
 
+/** Config option choices for the rolling window used to compute a credits-per-hour rate. */
 public enum CreditsPerHourWindow
 {
 	MINUTES_15("15 min", 15L * 60L * 1000L),
@@ -11,17 +12,23 @@ public enum CreditsPerHourWindow
 	/** {@code null} when history never auto-expires. */
 	private final Long windowMs;
 
+	/**
+	 * @param label display label shown in config UI.
+	 * @param windowMs window length in ms, or {@code null} for persistent (never expires).
+	 */
 	CreditsPerHourWindow(String label, Long windowMs)
 	{
 		this.label = label;
 		this.windowMs = windowMs;
 	}
 
+	/** @return window length in ms, or {@code null} when history never auto-expires. */
 	public Long getWindowMs()
 	{
 		return windowMs;
 	}
 
+	/** @return display label shown in config UI. */
 	@Override
 	public String toString()
 	{

--- a/src/main/java/com/osrstcg/config/PullNotificationTrigger.java
+++ b/src/main/java/com/osrstcg/config/PullNotificationTrigger.java
@@ -1,5 +1,6 @@
 package com.osrstcg.config;
 
+/** Config option choices for when pack-pull notifications are fired: per card or once at the end of the pack. */
 public enum PullNotificationTrigger
 {
 	EVERY_CARD("Every card"),
@@ -7,11 +8,13 @@ public enum PullNotificationTrigger
 
 	private final String label;
 
+	/** @param label display label shown in config UI. */
 	PullNotificationTrigger(String label)
 	{
 		this.label = label;
 	}
 
+	/** @return display label shown in config UI. */
 	@Override
 	public String toString()
 	{

--- a/src/main/java/com/osrstcg/config/PullNotifyTier.java
+++ b/src/main/java/com/osrstcg/config/PullNotifyTier.java
@@ -2,6 +2,7 @@ package com.osrstcg.config;
 
 import com.osrstcg.catalog.RarityMath;
 
+/** Config option mirror of {@link RarityMath.Tier}, used as the "notify at or above this rarity" threshold setting. */
 public enum PullNotifyTier
 {
 	COMMON(RarityMath.Tier.COMMON),
@@ -14,21 +15,25 @@ public enum PullNotifyTier
 
 	private final RarityMath.Tier tier;
 
+	/** @param tier corresponding {@link RarityMath.Tier}. */
 	PullNotifyTier(RarityMath.Tier tier)
 	{
 		this.tier = tier;
 	}
 
+	/** @return the corresponding {@link RarityMath.Tier}. */
 	public RarityMath.Tier toRarityTier()
 	{
 		return tier;
 	}
 
+	/** @return true if {@code value} is this tier or rarer (higher ordinal). */
 	public boolean meetsOrExceeds(RarityMath.Tier value)
 	{
 		return value != null && value.ordinal() >= tier.ordinal();
 	}
 
+	/** @return display label from the underlying {@link RarityMath.Tier}. */
 	public String displayLabel()
 	{
 		return tier.getLabel();

--- a/src/main/java/com/osrstcg/credit/CreditAwardService.java
+++ b/src/main/java/com/osrstcg/credit/CreditAwardService.java
@@ -24,14 +24,24 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.eventbus.Subscribe;
 import com.osrstcg.state.TcgStateService;
 
+/**
+ * Central coordinator for awarding credits from XP gains and level-ups. Tracks per-skill XP/level baselines,
+ * converts XP into credit chunks (with a separate, cheaper Slayer conversion), and enqueues optimistic
+ * credit attest events via {@link CreditAttestQueue}. Also enforces a short cooldown after login/world-hop
+ * so transient stat resyncs (e.g. temporary boosts settling) don't get credited as real gains. Most XP/level
+ * entry points ({@link #onStatChanged}, {@link #onFakeXpDrop}) are called directly from the plugin's event
+ * handlers; {@link #onGameTick} is the only RuneLite-subscribed method here.
+ */
 @Singleton
 @Slf4j
 public class CreditAwardService
 {
 	private static final int FAKE_XP_DROP_SANITY_CAP = 20_000_000;
+	/** Default credit-award cooldown, in game ticks, after login/world-hop before live XP gains are credited. */
 	static final int CREDIT_COOLDOWN_TICKS = 3;
 	/** Extra settle window when hopping off a restricted/event world (temp max stats). */
 	static final int RESTRICTED_WORLD_EXIT_SETTLE_TICKS = 15;
+	/** Combat skills excluded from XP-based credit awards (XP here comes from combat, not standalone training). */
 	private static final Set<Skill> COMBAT_SKILLS = EnumSet.of(
 		Skill.ATTACK,
 		Skill.DEFENCE,
@@ -63,6 +73,7 @@ public class CreditAwardService
 		this.chatMessageManager = chatMessageManager;
 	}
 
+	/** Resets in-memory tracking and restores the uncredited XP pool from the persisted baseline, if any. */
 	public void resetExperienceCreditBaseline()
 	{
 		skills.resetTracking();
@@ -78,6 +89,7 @@ public class CreditAwardService
 		}
 	}
 
+	/** Snapshots current skill baselines (if logged in) and persists them, when credit tracking is allowed. */
 	public void flushSkillBaselineForPersist()
 	{
 		if (!isCreditTrackingAllowed())
@@ -88,11 +100,13 @@ public class CreditAwardService
 		persistSkillBaselineToState();
 	}
 
+	/** Whether credit tracking is currently allowed (false while the cloud account is locked). */
 	public boolean isCreditTrackingAllowed()
 	{
 		return !session.isAccountLocked();
 	}
 
+	/** Stops tracking on an account lock: clears uncredited XP and resets in-memory baselines to zero. */
 	public void stopCreditTrackingOnLock()
 	{
 		clearUncreditedXpPool("account locked");
@@ -105,6 +119,12 @@ public class CreditAwardService
 		}
 	}
 
+	/**
+	 * Handles a {@code StatChanged} event: tracks XP gain for credit chunks and, outside cooldown, checks
+	 * for a level-up to award level-up credit.
+	 *
+	 * @return true if this call caused an XP chunk to be credited
+	 */
 	public boolean onStatChanged(StatChanged event)
 	{
 		if (!isCreditTrackingAllowed())
@@ -150,6 +170,13 @@ public class CreditAwardService
 		return xpChunkAwarded;
 	}
 
+	/**
+	 * Handles a {@code FakeXpDrop} event (XP that doesn't reach {@code StatChanged}, e.g. once a skill is
+	 * maxed). Ignores combat-skill drops and drops for skills not already at max XP; Hitpoints XP is attested
+	 * without going into the creditable XP bucket.
+	 *
+	 * @return true if this call caused credit to be awarded
+	 */
 	public boolean onFakeXpDrop(FakeXpDrop event)
 	{
 		if (!isCreditTrackingAllowed())
@@ -198,6 +225,7 @@ public class CreditAwardService
 		return applyXpGain(xp, skill);
 	}
 
+	/** Arms the settle cooldown appropriate to the client's current game state when the plugin starts up. */
 	public void onPluginStarted()
 	{
 		if (client == null)
@@ -216,6 +244,10 @@ public class CreditAwardService
 		}
 	}
 
+	/**
+	 * Handles a {@code GameStateChanged} event: persists baselines and arms a settle cooldown on logout or
+	 * world hop, and begins the credit cooldown once logged back in if a settle was pending.
+	 */
 	public void onGameStateChanged(GameStateChanged event)
 	{
 		GameState next = event.getGameState();
@@ -245,6 +277,10 @@ public class CreditAwardService
 		}
 	}
 
+	/**
+	 * Drives the credit-award cooldown and baseline initialization each tick: ends an expired cooldown and
+	 * re-captures baselines after settling, or performs first-time baseline capture if not yet initialized.
+	 */
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
@@ -279,6 +315,7 @@ public class CreditAwardService
 		}
 	}
 
+	/** Restores any persisted uncredited XP (if pending) and (re-)captures live skill baselines after settling. */
 	private void captureBaselinesAfterSettle()
 	{
 		if (restoreXpFromPersistedBaseline)
@@ -295,6 +332,12 @@ public class CreditAwardService
 		debugAward("Live skill baselines captured after settle");
 	}
 
+	/**
+	 * Sums the level-up reward (credits) for each level from {@code previousLevel+1} to {@code currentLevel}
+	 * and enqueues an attest event for the total, if the cloud session can currently collect attests.
+	 *
+	 * @return the total credits enqueued (0 if none, or if attests can't be collected right now)
+	 */
 	private long awardLevelUps(Skill skill, int previousLevel, int currentLevel)
 	{
 		if (currentLevel <= previousLevel)
@@ -333,6 +376,13 @@ public class CreditAwardService
 		return totalReward;
 	}
 
+	/**
+	 * Updates the previous-XP baseline for {@code skill} and, if XP increased while not on cooldown, routes
+	 * the gain to the appropriate credit path (ignored for combat skills, Hitpoints attested without credit
+	 * bucketing, others accumulated toward an XP chunk). XP drops (e.g. from a stat reset) are ignored.
+	 *
+	 * @return true if this call caused an XP chunk to be credited
+	 */
 	private boolean trackXpGainFromStatChanged(Skill skill, int currentXp)
 	{
 		if (isOverallSkill(skill))
@@ -386,6 +436,12 @@ public class CreditAwardService
 		return xpChunkAwarded;
 	}
 
+	/**
+	 * Applies a positive XP gain (xp) for {@code skill}: routes Slayer XP through its own chunk conversion,
+	 * otherwise pools the XP into the skill's uncredited bucket and awards any completed chunks.
+	 *
+	 * @return true if this call caused an XP chunk to be credited
+	 */
 	private boolean applyXpGain(long xpGained, Skill skill)
 	{
 		if (xpGained <= 0L || skill == null)
@@ -407,6 +463,7 @@ public class CreditAwardService
 		return awarded;
 	}
 
+	/** Attests {@code xpGained} (xp) as an XP chunk with zero optimistic credits (e.g. Hitpoints XP). */
 	private void attestXpWithoutCreditBucket(long xpGained, String source)
 	{
 		if (xpGained <= 0L)
@@ -425,6 +482,13 @@ public class CreditAwardService
 			NumberFormatting.format(xpGained), safeName(source)));
 	}
 
+	/**
+	 * Accumulates Slayer XP (xp) and, if attests can currently be collected, converts completed
+	 * {@link XpCreditMath#SLAYER_XP_PER_CHUNK} chunks to credits and attests the pending amount. If the
+	 * cloud session is offline, the XP stays pending and nothing is attested yet.
+	 *
+	 * @return true if this call caused credit to be awarded
+	 */
 	private boolean attestSlayerXp(long xpGained, String source)
 	{
 		if (xpGained <= 0L)
@@ -461,6 +525,12 @@ public class CreditAwardService
 		return credits > 0L;
 	}
 
+	/**
+	 * Converts completed XP chunks from the skill's uncredited pool into credits, attests them, and
+	 * subtracts the credited XP from the pool, if attests can currently be collected.
+	 *
+	 * @return true if this call caused credit to be awarded
+	 */
 	private boolean awardCreditsFromUncreditedXp(Skill skill)
 	{
 		if (skill == null)
@@ -494,6 +564,7 @@ public class CreditAwardService
 		return credits > 0L;
 	}
 
+	/** Enqueues an {@code xp_chunk} attest event with {@code xpDelta} xp and its optimistic credits. */
 	private void enqueueXpChunk(String skill, long xpDelta, long optimisticCredits)
 	{
 		JsonObject evidence = new JsonObject();
@@ -502,12 +573,14 @@ public class CreditAwardService
 		attestQueue.enqueue("xp_chunk", evidence, optimisticCredits);
 	}
 
+	/** Persisted skill credit baseline, if one exists and is non-empty; {@code null} otherwise. */
 	private SkillCreditBaseline presentBaseline()
 	{
 		SkillCreditBaseline saved = stateService.getState().getSkillCreditBaseline();
 		return saved != null && saved.isPresent() ? saved : null;
 	}
 
+	/** Arms a settle cooldown for returning to the login screen, restoring the persisted uncredited XP after. */
 	private void armStatsSettleForLoginScreen()
 	{
 		pendingStatsSettle = true;
@@ -515,6 +588,7 @@ public class CreditAwardService
 		suppressAwardsUntilSettle(true, CREDIT_COOLDOWN_TICKS);
 	}
 
+	/** Arms a settle cooldown for a world hop or re-login, keeping the uncredited XP pool intact. */
 	private void armStatsSettleForHopOrLogin()
 	{
 		pendingStatsSettle = true;
@@ -522,11 +596,13 @@ public class CreditAwardService
 		suppressAwardsUntilSettle(false, resolveHopSettleCooldownTicks(session.isRestrictedWorld()));
 	}
 
+	/** Cooldown duration (ticks) to use after a world hop: longer when leaving a restricted/event world. */
 	static int resolveHopSettleCooldownTicks(boolean restrictedWorld)
 	{
 		return restrictedWorld ? RESTRICTED_WORLD_EXIT_SETTLE_TICKS : CREDIT_COOLDOWN_TICKS;
 	}
 
+	/** Persists the current skill baselines to plugin state, if tracking is allowed and XP is initialized. */
 	private void persistSkillBaselineToState()
 	{
 		if (!isCreditTrackingAllowed() || !skills.skillXpInitialized)
@@ -538,6 +614,7 @@ public class CreditAwardService
 		stateService.replaceSkillCreditBaseline(baseline);
 	}
 
+	/** Begins the credit cooldown and resets live tracking, optionally also clearing uncredited XP. */
 	private void suppressAwardsUntilSettle(boolean clearUncreditedXpPool, int cooldownTicks)
 	{
 		beginCreditAwardCooldown(cooldownTicks);
@@ -548,6 +625,7 @@ public class CreditAwardService
 		}
 	}
 
+	/** Starts (or restarts) the credit-award cooldown for {@code durationTicks} game ticks (min 1). */
 	private void beginCreditAwardCooldown(int durationTicks)
 	{
 		int duration = Math.max(1, durationTicks);
@@ -562,6 +640,7 @@ public class CreditAwardService
 		creditCooldownUntilTick = client.getTickCount() + duration;
 	}
 
+	/** Whether the credit-award cooldown is currently active (also guards against tick-count rollover). */
 	public boolean isCreditAwardOnCooldown()
 	{
 		if (!creditCooldownActive || client == null)
@@ -583,6 +662,7 @@ public class CreditAwardService
 		return true;
 	}
 
+	/** Clears the uncredited XP pool, logging a debug message with {@code reason} if XP was actually lost. */
 	private void clearUncreditedXpPool(String reason)
 	{
 		long totalRemainder = skills.totalUncreditedXp();
@@ -595,11 +675,13 @@ public class CreditAwardService
 		skills.clearUncreditedXpPool();
 	}
 
+	/** Non-null NPC/source name for logging, defaulting to "Unknown NPC". */
 	private String safeName(String name)
 	{
 		return name == null || name.isEmpty() ? "Unknown NPC" : name;
 	}
 
+	/** Logs and chats {@code message} as a debug game message, when debug chat is enabled. */
 	private void debugAward(String message)
 	{
 		if (!stateService.isDebugChatEnabled())
@@ -610,16 +692,19 @@ public class CreditAwardService
 		TcgPluginGameMessages.queueDebugGameMessage(chatMessageManager, message);
 	}
 
+	/** Whether {@code skill} is the "Overall" pseudo-skill (excluded from XP/level credit tracking). */
 	static boolean isOverallSkill(Skill skill)
 	{
 		return skill != null && "Overall".equalsIgnoreCase(skill.getName());
 	}
 
+	/** Whether {@code skill} is one of {@link #COMBAT_SKILLS}. */
 	private boolean isCombatSkill(Skill skill)
 	{
 		return skill != null && COMBAT_SKILLS.contains(skill);
 	}
 
+	/** Whether {@code skill} is genuinely at max XP client-side, so a fake XP drop for it can be trusted. */
 	private boolean isGenuineMaxedSkillFakeXpDrop(Skill skill)
 	{
 		if (client == null || isOverallSkill(skill))

--- a/src/main/java/com/osrstcg/credit/CreditsRateTracker.java
+++ b/src/main/java/com/osrstcg/credit/CreditsRateTracker.java
@@ -9,6 +9,11 @@ import net.runelite.api.GameState;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.client.eventbus.Subscribe;
 
+/**
+ * Tracks recent credit gains and derives a rolling credits-per-hour rate for the sidebar. Subscribes to
+ * {@link GameStateChanged} to reset on logout. All public methods are synchronized since drops can be
+ * recorded from background threads while the UI reads the rate on the client/EDT thread.
+ */
 @Singleton
 public class CreditsRateTracker
 {
@@ -25,6 +30,7 @@ public class CreditsRateTracker
 		this.config = config;
 	}
 
+	/** Records a credit gain (credits) at the current time, pruning old drops and recomputing the cached rate. */
 	public synchronized void recordCreditGain(long amount)
 	{
 		if (amount <= 0L)
@@ -38,6 +44,7 @@ public class CreditsRateTracker
 		recomputeCachedRate(now);
 	}
 
+	/** Current credits/hour rate, or {@code null} if too few recent drops or the window has gone stale. */
 	public synchronized Long creditsPerHourOrNull()
 	{
 		if (cachedCreditsPerHour == null || drops.isEmpty())
@@ -60,12 +67,14 @@ public class CreditsRateTracker
 		return cachedCreditsPerHour;
 	}
 
+	/** Discards all tracked drops and the cached rate. */
 	public synchronized void clear()
 	{
 		drops.clear();
 		cachedCreditsPerHour = null;
 	}
 
+	/** Resets tracking when the player returns to the login screen. */
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged event)
 	{
@@ -75,6 +84,7 @@ public class CreditsRateTracker
 		}
 	}
 
+	/** Recomputes {@link #cachedCreditsPerHour} from the current drop window, or clears it if below the minimum. */
 	private void recomputeCachedRate(long nowMs)
 	{
 		if (drops.size() < MIN_DROPS_TO_SHOW)
@@ -94,6 +104,7 @@ public class CreditsRateTracker
 		cachedCreditsPerHour = Math.round(total * 3_600_000.0d / (double) elapsedMs);
 	}
 
+	/** Removes drops older than the configured rate window (no-op if the window is unbounded). */
 	private void prune(long nowMs)
 	{
 		Long windowMs = windowMsOrNull();
@@ -109,6 +120,7 @@ public class CreditsRateTracker
 		}
 	}
 
+	/** Configured rate window in ms, or {@code null} for the persistent (unbounded) window. */
 	private Long windowMsOrNull()
 	{
 		CreditsPerHourWindow window = config.creditsPerHourWindow();
@@ -119,6 +131,7 @@ public class CreditsRateTracker
 		return window.getWindowMs();
 	}
 
+	/** A single recorded credit gain: {@code amount} credits at {@code timeMs}. */
 	private static final class CreditDrop
 	{
 		private final long timeMs;

--- a/src/main/java/com/osrstcg/credit/GameMessageCreditTracker.java
+++ b/src/main/java/com/osrstcg/credit/GameMessageCreditTracker.java
@@ -21,6 +21,10 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.util.Text;
 
+/**
+ * Awards credits for configured chat "activities" (game messages matching a rule from
+ * {@link ActivityConfigService}) by enqueueing an attest event. Subscribes to {@link ChatMessage}.
+ */
 @Slf4j
 @Singleton
 public final class GameMessageCreditTracker
@@ -53,6 +57,7 @@ public final class GameMessageCreditTracker
 		this.sidebarRefresh = sidebarRefresh;
 	}
 
+	/** Matches game/spam chat messages against configured activity rules and enqueues a credit attest on a hit. */
 	@Subscribe
 	public void onChatMessage(ChatMessage event)
 	{
@@ -78,6 +83,7 @@ public final class GameMessageCreditTracker
 		sidebarRefresh.refreshCredits();
 	}
 
+	/** Logs and chats a debug message for a matched activity rule, when debug chat is enabled. */
 	private void debugActivityQueued(CompiledActivityConfig.CompiledChatRule matched)
 	{
 		if (!stateService.isDebugChatEnabled())
@@ -96,6 +102,7 @@ public final class GameMessageCreditTracker
 		TcgPluginGameMessages.queueDebugGameMessage(chatMessageManager, body);
 	}
 
+	/** First configured chat rule whose pattern matches {@code messageWithoutTags}, if any. */
 	private Optional<CompiledActivityConfig.CompiledChatRule> firstMatchingRule(String messageWithoutTags)
 	{
 		List<CompiledActivityConfig.CompiledChatRule> rules = activityConfigService.getChatRules();

--- a/src/main/java/com/osrstcg/credit/LevelUpCreditMath.java
+++ b/src/main/java/com/osrstcg/credit/LevelUpCreditMath.java
@@ -5,15 +5,20 @@ import net.runelite.api.Experience;
 /** Level-up credit curve used by {@link CreditAwardService}. */
 final class LevelUpCreditMath
 {
+	/** Credits awarded for reaching level 1-2 (curve floor). */
 	static final int LEVEL_UP_REWARD_FLOOR = 1_250;
+	/** Credits awarded for reaching {@link net.runelite.api.Experience#MAX_REAL_LEVEL} (curve cap). */
 	static final int LEVEL_UP_REWARD_CAP = 25_000;
+	/** Number of levels the curve ramps over, from level 2 to {@link net.runelite.api.Experience#MAX_REAL_LEVEL}. */
 	static final int LEVEL_UP_PROGRESS_LEVELS = 97;
+	/** Exponent shaping the reward curve; higher values back-load rewards toward higher levels. */
 	static final double LEVEL_UP_CURVE_STEEPNESS = 2.5d;
 
 	private LevelUpCreditMath()
 	{
 	}
 
+	/** Credit reward (credits) for reaching {@code level}, clamped and interpolated along the reward curve. */
 	static int levelUpReward(int level)
 	{
 		int clamped = clampLevel(level);
@@ -32,11 +37,13 @@ final class LevelUpCreditMath
 		return (int) Math.round(LEVEL_UP_REWARD_FLOOR * multiplier);
 	}
 
+	/** Level for a given xp amount, clamped to the valid level range. */
 	static int levelForXp(int xp)
 	{
 		return clampLevel(Experience.getLevelForXp(Math.max(0, xp)));
 	}
 
+	/** Clamps a level to {@code [1, Experience.MAX_VIRT_LEVEL]}. */
 	static int clampLevel(int level)
 	{
 		if (level < 1)

--- a/src/main/java/com/osrstcg/credit/NpcKillCreditTracker.java
+++ b/src/main/java/com/osrstcg/credit/NpcKillCreditTracker.java
@@ -20,9 +20,15 @@ import net.runelite.api.events.InteractingChanged;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.Subscribe;
 
+/**
+ * Awards credits for player-caused NPC kills. Tracks which NPCs the player has recently interacted with or
+ * hit so a death is only credited when it was actually caused by the player within a short timeout.
+ * Subscribes to {@link InteractingChanged}, {@link HitsplatApplied}, {@link ActorDeath}, and {@link GameTick}.
+ */
 @Singleton
 public final class NpcKillCreditTracker
 {
+	/** Ticks after the last player interaction/hit on an NPC before it's no longer considered engaged. */
 	private static final int INTERACT_TIMEOUT_TICKS = 12;
 
 	private final Client client;
@@ -32,8 +38,11 @@ public final class NpcKillCreditTracker
 	private final ActivityConfigService activityConfigService;
 	private final SidebarRefresh sidebarRefresh;
 
+	/** Last known display name per NPC index. */
 	private final Map<Integer, String> lastKnownNpcName = new ConcurrentHashMap<>();
+	/** Tick of the last player interaction/hit per NPC index, for the engagement timeout. */
 	private final Map<Integer, Integer> lastInteractionTicks = new ConcurrentHashMap<>();
+	/** Whether the player has interacted with or hit the NPC at this index recently enough to credit its death. */
 	private final Map<Integer, Boolean> wasNpcEngaged = new ConcurrentHashMap<>();
 
 	@Inject
@@ -53,6 +62,7 @@ public final class NpcKillCreditTracker
 		this.sidebarRefresh = sidebarRefresh;
 	}
 
+	/** Clears all tracked NPC interaction state. */
 	public void shutdown()
 	{
 		lastKnownNpcName.clear();
@@ -60,6 +70,7 @@ public final class NpcKillCreditTracker
 		wasNpcEngaged.clear();
 	}
 
+	/** Marks an NPC the player has just targeted as engaged, so a fast/one-hit kill still qualifies. */
 	@Subscribe
 	public void onInteractingChanged(InteractingChanged event)
 	{
@@ -84,6 +95,7 @@ public final class NpcKillCreditTracker
 		}
 	}
 
+	/** Marks an NPC hit by the player's own hitsplat as engaged and refreshes its interaction timeout. */
 	@Subscribe
 	public void onHitsplatApplied(HitsplatApplied event)
 	{
@@ -107,6 +119,10 @@ public final class NpcKillCreditTracker
 		}
 	}
 
+	/**
+	 * On an NPC death, awards npc-kill credit if the player was recently engaged with it. Deferred to the
+	 * client thread since engagement state can be checked/cleared from event handlers on the same tick.
+	 */
 	@Subscribe
 	public void onActorDeath(ActorDeath event)
 	{
@@ -154,6 +170,7 @@ public final class NpcKillCreditTracker
 		});
 	}
 
+	/** Expires stale interaction timestamps once past {@link #INTERACT_TIMEOUT_TICKS}. */
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
@@ -193,6 +210,7 @@ public final class NpcKillCreditTracker
 		attestQueue.enqueue("npc_kill", evidence, optimisticCredits);
 	}
 
+	/** Strips RuneLite formatting tags from an NPC name, defaulting to "Unnamed NPC" for {@code null}. */
 	private static String normalizeName(String npcName)
 	{
 		if (npcName == null)
@@ -202,17 +220,20 @@ public final class NpcKillCreditTracker
 		return npcName.replaceAll("<.*?>", "").trim();
 	}
 
+	/** Whether {@code npcId} is excluded from kill credit by activity config. */
 	private boolean isExcludedNpc(int npcId)
 	{
 		return activityConfigService.getCompiled().isExcludedNpc(npcId);
 	}
 
+	/** Whether the NPC at {@code npcIndex} was interacted with/hit within {@link #INTERACT_TIMEOUT_TICKS}. */
 	private boolean isInteractionValid(int npcIndex)
 	{
 		Integer lastTick = lastInteractionTicks.get(npcIndex);
 		return lastTick != null && (client.getTickCount() - lastTick) <= INTERACT_TIMEOUT_TICKS;
 	}
 
+	/** Removes tracked interaction state for an NPC index after its death has been handled. */
 	private void cleanupAfterLogging(int npcIndex)
 	{
 		lastKnownNpcName.remove(npcIndex);

--- a/src/main/java/com/osrstcg/credit/SkillCreditSession.java
+++ b/src/main/java/com/osrstcg/credit/SkillCreditSession.java
@@ -12,14 +12,22 @@ import net.runelite.api.Skill;
 /** Live skill XP / level baselines and uncredited XP pools for {@link CreditAwardService}. */
 final class SkillCreditSession
 {
+	/** Highest level observed per skill so far this session (used to detect level-ups). */
 	final Map<Skill, Integer> lastKnownLevels = new EnumMap<>(Skill.class);
+	/** Last-seen XP per skill, indexed by {@link Skill#ordinal()}; baseline for detecting XP gains. */
 	final int[] previousSkillXp = new int[Skill.values().length];
+	/** XP earned but not yet converted to a full credit chunk, indexed by {@link Skill#ordinal()}. */
 	final long[] uncreditedXpBySkill = new long[Skill.values().length];
+	/** Whether {@link #lastKnownLevels} has been populated from a logged-in client this session. */
 	boolean skillLevelsInitialized;
+	/** Whether {@link #previousSkillXp} has been populated from a logged-in client this session. */
 	boolean skillXpInitialized;
+	/** Slayer XP accrued since the last attempt to attest it (e.g. while the cloud session is offline). */
 	long pendingSlayerXpToAttest;
+	/** Slayer XP short of a full {@link XpCreditMath#SLAYER_XP_PER_CHUNK} chunk, carried to the next gain. */
 	long slayerXpRemainder;
 
+	/** Clears level/XP baselines so the next snapshot re-establishes them from the client. */
 	void resetTracking()
 	{
 		lastKnownLevels.clear();
@@ -28,6 +36,7 @@ final class SkillCreditSession
 		Arrays.fill(previousSkillXp, 0);
 	}
 
+	/** Discards all pending uncredited XP (main pool and Slayer pending/remainder). */
 	void clearUncreditedXpPool()
 	{
 		Arrays.fill(uncreditedXpBySkill, 0L);
@@ -35,6 +44,7 @@ final class SkillCreditSession
 		slayerXpRemainder = 0L;
 	}
 
+	/** Replaces the uncredited XP pool with a persisted baseline (e.g. restored after a profile reload). */
 	void restoreUncreditedXp(SkillCreditBaseline saved)
 	{
 		Arrays.fill(uncreditedXpBySkill, 0L);
@@ -61,6 +71,7 @@ final class SkillCreditSession
 		}
 	}
 
+	/** Adds {@code xp} XP to the skill's uncredited pool and returns the new pool total. */
 	long addUncreditedXp(Skill skill, long xp)
 	{
 		if (skill == null || xp <= 0L)
@@ -78,6 +89,7 @@ final class SkillCreditSession
 		return uncreditedXpBySkill[index];
 	}
 
+	/** Currently uncredited XP pooled for {@code skill} (0 if unknown/null skill). */
 	long uncreditedXpFor(Skill skill)
 	{
 		if (skill == null)
@@ -94,6 +106,7 @@ final class SkillCreditSession
 		return uncreditedXpBySkill[index];
 	}
 
+	/** Removes {@code xp} XP from the skill's uncredited pool (clamped at 0), typically after crediting a chunk. */
 	void subtractUncreditedXp(Skill skill, long xp)
 	{
 		if (skill == null || xp <= 0L)
@@ -110,6 +123,7 @@ final class SkillCreditSession
 		uncreditedXpBySkill[index] = Math.max(0L, uncreditedXpBySkill[index] - xp);
 	}
 
+	/** Sum of uncredited XP pooled across all skills. */
 	long totalUncreditedXp()
 	{
 		long total = 0L;
@@ -120,6 +134,7 @@ final class SkillCreditSession
 		return total;
 	}
 
+	/** Builds a persistable snapshot of current XP baselines and non-zero uncredited XP by skill name. */
 	SkillCreditBaseline toBaseline()
 	{
 		Map<String, Long> uncreditedByName = new LinkedHashMap<>();
@@ -144,12 +159,17 @@ final class SkillCreditSession
 			uncreditedByName);
 	}
 
+	/** Snapshots both XP and level baselines from the client, if logged in. */
 	void snapshotBaselinesIfLoggedIn(Client client)
 	{
 		snapshotXpIfLoggedIn(client);
 		snapshotSkillLevelsIfLoggedIn(client);
 	}
 
+	/**
+	 * Snapshots per-skill XP from the client into {@link #previousSkillXp}, if logged in. Once initialized,
+	 * only raises the baseline (never lowers it) so a transient client read can't roll it back.
+	 */
 	void snapshotXpIfLoggedIn(Client client)
 	{
 		if (client == null || client.getGameState() != GameState.LOGGED_IN)
@@ -177,6 +197,10 @@ final class SkillCreditSession
 		skillXpInitialized = true;
 	}
 
+	/**
+	 * Snapshots per-skill levels from the client into {@link #lastKnownLevels}, if logged in. Only raises an
+	 * already-known level, and skips the Overall pseudo-skill.
+	 */
 	void snapshotSkillLevelsIfLoggedIn(Client client)
 	{
 		if (client == null || client.getGameState() != GameState.LOGGED_IN)
@@ -205,6 +229,7 @@ final class SkillCreditSession
 		skillLevelsInitialized = true;
 	}
 
+	/** Looks up a {@link Skill} by its display name (case-insensitive), or {@code null} if not found. */
 	private static Skill skillByName(String name)
 	{
 		if (name == null || name.isEmpty())

--- a/src/main/java/com/osrstcg/credit/XpCreditMath.java
+++ b/src/main/java/com/osrstcg/credit/XpCreditMath.java
@@ -3,15 +3,20 @@ package com.osrstcg.credit;
 /** XP → credit conversion used by {@link CreditAwardService}. */
 final class XpCreditMath
 {
+	/** XP per credit-eligible chunk for regular skills. */
 	static final long XP_PER_CREDIT_CHUNK = 1000L;
+	/** Credits awarded per {@link #XP_PER_CREDIT_CHUNK} XP chunk for regular skills. */
 	static final long CREDITS_PER_CHUNK = 100L;
+	/** XP per credit-eligible chunk for Slayer XP. */
 	static final long SLAYER_XP_PER_CHUNK = 100L;
+	/** Credits awarded per {@link #SLAYER_XP_PER_CHUNK} XP chunk for Slayer XP. */
 	static final long SLAYER_CREDITS_PER_CHUNK = 10L;
 
 	private XpCreditMath()
 	{
 	}
 
+	/** Converts a count of regular-skill XP chunks into credits. */
 	static long creditsFromXpChunks(long chunks)
 	{
 		return chunks * CREDITS_PER_CHUNK;

--- a/src/main/java/com/osrstcg/interop/OwnedCardNamesApiService.java
+++ b/src/main/java/com/osrstcg/interop/OwnedCardNamesApiService.java
@@ -46,6 +46,7 @@ public class OwnedCardNamesApiService
 	private final AtomicBoolean started = new AtomicBoolean(false);
 	private final Runnable onCollectionChanged = this::broadcastChanged;
 
+	/** Stores the event bus, state service, and card database used to answer queries. */
 	@Inject
 	OwnedCardNamesApiService(
 		EventBus eventBus,
@@ -57,6 +58,7 @@ public class OwnedCardNamesApiService
 		this.cardDatabase = cardDatabase;
 	}
 
+	/** Registers on the event bus and collection-change listener; idempotent. */
 	public void start()
 	{
 		if (!started.compareAndSet(false, true))
@@ -67,6 +69,7 @@ public class OwnedCardNamesApiService
 		stateService.addOwnedCollectionListener(onCollectionChanged);
 	}
 
+	/** Unregisters the collection-change listener and event bus subscription; idempotent. */
 	public void stop()
 	{
 		if (!started.compareAndSet(true, false))
@@ -77,6 +80,7 @@ public class OwnedCardNamesApiService
 		eventBus.unregister(this);
 	}
 
+	/** Replies with a fresh snapshot to any {@link #QUERY} message on {@link #NAMESPACE}, ignoring the rest. */
 	@Subscribe
 	public void onPluginMessage(PluginMessage event)
 	{
@@ -90,6 +94,7 @@ public class OwnedCardNamesApiService
 		post(REPLY, snapshotPayload());
 	}
 
+	/** Posts a fresh snapshot as {@link #CHANGED}; called whenever the owned collection mutates. */
 	public void broadcastChanged()
 	{
 		if (!started.get())
@@ -99,6 +104,7 @@ public class OwnedCardNamesApiService
 		post(CHANGED, snapshotPayload());
 	}
 
+	/** Builds the query/changed-event payload: owned/foil names, derived item/NPC ids, and the cloud group key. */
 	private Map<String, Object> snapshotPayload()
 	{
 		CollectionState collection;
@@ -121,6 +127,7 @@ public class OwnedCardNamesApiService
 		return data;
 	}
 
+	/** Looks up each owned name's card definition and adds its item/variant ids into {@code itemIds} or {@code npcIds}. */
 	private void collectOwnedCatalogIds(List<String> ownedNames, Set<Long> itemIds, Set<Long> npcIds)
 	{
 		if (ownedNames == null || ownedNames.isEmpty())
@@ -137,6 +144,7 @@ public class OwnedCardNamesApiService
 		}
 	}
 
+	/** Adds {@code card}'s primary id and all variant ids to {@code target}; no-op if either arg is null. */
 	static void addCatalogIds(CardDefinition card, Set<Long> target)
 	{
 		if (card == null || target == null)
@@ -161,6 +169,7 @@ public class OwnedCardNamesApiService
 		}
 	}
 
+	/** True if {@code card} carries an "NPC" category tag (case-insensitive). */
 	static boolean isNpcCard(CardDefinition card)
 	{
 		if (card == null)
@@ -177,16 +186,19 @@ public class OwnedCardNamesApiService
 		return false;
 	}
 
+	/** Distinct owned card names (any variant), case-insensitively sorted. */
 	static List<String> distinctOwnedNames(CollectionState collection)
 	{
 		return distinctOwnedNames(collection, false);
 	}
 
+	/** Distinct owned foil card names, case-insensitively sorted. */
 	static List<String> distinctOwnedFoilNames(CollectionState collection)
 	{
 		return distinctOwnedNames(collection, true);
 	}
 
+	/** Shared implementation for {@link #distinctOwnedNames(CollectionState)} and {@link #distinctOwnedFoilNames}. */
 	private static List<String> distinctOwnedNames(CollectionState collection, boolean foilOnly)
 	{
 		if (collection == null)
@@ -216,6 +228,7 @@ public class OwnedCardNamesApiService
 		return sorted;
 	}
 
+	/** Posts a {@link PluginMessage} on {@link #NAMESPACE}, swallowing and logging any failure. */
 	private void post(String name, Map<String, Object> data)
 	{
 		try

--- a/src/main/java/com/osrstcg/interop/TcgChatStatsShareService.java
+++ b/src/main/java/com/osrstcg/interop/TcgChatStatsShareService.java
@@ -19,11 +19,13 @@ public class TcgChatStatsShareService
 {
 	private static final long CACHE_TTL_MS = 15L * 60L * 1000L;
 
+	/** A cached stats snapshot plus the time it was stored, for TTL expiry. */
 	private static final class CacheEntry
 	{
 		private final TcgPublicStats stats;
 		private final long storedAtMs;
 
+		/** Stores the snapshot and its capture time. */
 		private CacheEntry(TcgPublicStats stats, long storedAtMs)
 		{
 			this.stats = stats;
@@ -33,11 +35,13 @@ public class TcgChatStatsShareService
 
 	private final ConcurrentHashMap<String, CacheEntry> cache = new ConcurrentHashMap<>();
 
+	/** No collaborators to wire; the cache is self-contained. */
 	@Inject
 	public TcgChatStatsShareService()
 	{
 	}
 
+	/** Caches {@code stats} under the normalized RSN key; no-op if either argument is null/empty. */
 	public void putSanitizedPlayerName(String sanitizedRsn, TcgPublicStats stats)
 	{
 		if (sanitizedRsn == null || sanitizedRsn.isEmpty() || stats == null)
@@ -48,6 +52,7 @@ public class TcgChatStatsShareService
 		cache.put(key, new CacheEntry(stats, System.currentTimeMillis()));
 	}
 
+	/** Returns the cached stats for {@code sanitizedRsn}, or null if absent, empty input, or expired (evicting it). */
 	public TcgPublicStats getBySanitizedPlayerName(String sanitizedRsn)
 	{
 		if (sanitizedRsn == null || sanitizedRsn.isEmpty())
@@ -68,16 +73,19 @@ public class TcgChatStatsShareService
 		return e.stats;
 	}
 
+	/** Renders {@code s} as a chat-colored summary line via {@link ChatMessageBuilder}. */
 	public String buildColoredLine(TcgPublicStats s)
 	{
 		return buildFormattedLine(s, true);
 	}
 
+	/** Renders {@code s} as a plain-text summary line (no chat color codes). */
 	public String buildPlainLine(TcgPublicStats s)
 	{
 		return buildFormattedLine(s, false);
 	}
 
+	/** Shared formatter behind {@link #buildColoredLine} and {@link #buildPlainLine}. */
 	private static String buildFormattedLine(TcgPublicStats s, boolean colored)
 	{
 		String pct = String.format(Locale.US, "%.2f%%", s.getCompletionPct());
@@ -168,6 +176,7 @@ public class TcgChatStatsShareService
 		return plain.toString();
 	}
 
+	/** Trims and lowercases an RSN into its cache key. */
 	private static String normalizeKey(String sanitizedRsn)
 	{
 		return sanitizedRsn.trim().toLowerCase(Locale.ROOT);

--- a/src/main/java/com/osrstcg/interop/TcgPublicStatsCalculator.java
+++ b/src/main/java/com/osrstcg/interop/TcgPublicStatsCalculator.java
@@ -19,12 +19,17 @@ import com.osrstcg.catalog.RollPoolFilter;
 import com.osrstcg.state.TcgStateService;
 import com.osrstcg.ui.layout.PackCloseSnapshot;
 
+/**
+ * Computes {@link TcgPublicStats}/{@link CloudSidebarCollectionStats} summaries of the local player's
+ * collection, for sharing with other players/plugins (e.g. chat stats, sidebar overview).
+ */
 @Singleton
 public class TcgPublicStatsCalculator
 {
 	private final TcgStateService stateService;
 	private final CardDatabase cardDatabase;
 
+	/** Stores the state service and card database used to compute stats. */
 	@Inject
 	public TcgPublicStatsCalculator(TcgStateService stateService, CardDatabase cardDatabase)
 	{
@@ -32,6 +37,7 @@ public class TcgPublicStatsCalculator
 		this.cardDatabase = cardDatabase;
 	}
 
+	/** Computes shareable stats for the current player from cloud overview data if available, else locally. */
 	public TcgPublicStats computeLive()
 	{
 		CloudSidebarCollectionStats cloud = stateService.getCloudCollectionStats();
@@ -73,6 +79,7 @@ public class TcgPublicStatsCalculator
 			false);
 	}
 
+	/** Computes a fresh local {@link CloudSidebarCollectionStats} overview from the current owned collection. */
 	public CloudSidebarCollectionStats computeLocalSidebarStats()
 	{
 		Map<CardCollectionKey, Integer> owned;
@@ -85,6 +92,7 @@ public class TcgPublicStatsCalculator
 		return computeLocalOverview(owned, all, rollPool);
 	}
 
+	/** Uses {@code snap}'s pre-computed overview if it has one, else computes it locally from {@code snap.owned}. */
 	public static CloudSidebarCollectionStats resolveOverview(
 		PackCloseSnapshot snap,
 		List<CardDefinition> allCards,
@@ -97,6 +105,10 @@ public class TcgPublicStatsCalculator
 		return computeLocalOverview(snap == null ? null : snap.owned, allCards, rollPool);
 	}
 
+	/**
+	 * Derives a {@link CloudSidebarCollectionStats} overview from {@code owned}, restricted to cards in
+	 * {@code rollPool}: unique/foil counts, total copies, completion percentages, and the display-score sum.
+	 */
 	public static CloudSidebarCollectionStats computeLocalOverview(
 		Map<CardCollectionKey, Integer> owned,
 		List<CardDefinition> allCards,

--- a/src/main/java/com/osrstcg/notify/CreditNotificationService.java
+++ b/src/main/java/com/osrstcg/notify/CreditNotificationService.java
@@ -17,6 +17,7 @@ public class CreditNotificationService
 	private final ChatMessageManager chatMessageManager;
 	private final Notifier notifier;
 
+	/** Wires the config, chat, and RuneLite notifier used to announce the credit threshold. */
 	@Inject
 	CreditNotificationService(
 		OsrsTcgConfig config,
@@ -28,6 +29,11 @@ public class CreditNotificationService
 		this.notifier = notifier;
 	}
 
+	/**
+	 * Chats (and optionally shows a RuneLite notification) the first time credits cross the
+	 * configured purchase-price threshold. No-op if credit notifications are disabled, credits
+	 * didn't increase, the threshold is unset, or the threshold was already crossed before this gain.
+	 */
 	public void onCreditsIncreased(long creditsBefore, long creditsAfter)
 	{
 		if (!config.creditNotifications() || creditsAfter <= creditsBefore)

--- a/src/main/java/com/osrstcg/notify/DinkNotificationService.java
+++ b/src/main/java/com/osrstcg/notify/DinkNotificationService.java
@@ -10,6 +10,10 @@ import net.runelite.client.events.PluginMessage;
 import com.osrstcg.catalog.RarityMath;
 import com.osrstcg.notify.PullNotifySupport.PackSummaryContent;
 
+/**
+ * Forwards pull and pack-summary notifications to the Dink plugin via its {@link PluginMessage}
+ * namespace, so Dink can relay them (e.g. to Discord) independently of this plugin's own webhook.
+ */
 @Slf4j
 @Singleton
 public class DinkNotificationService
@@ -21,6 +25,7 @@ public class DinkNotificationService
 	private final EventBus eventBus;
 	private final PullNotifySupport pullNotifySupport;
 
+	/** Wires the event bus used to post {@link PluginMessage}s and the shared pull-content builder. */
 	@Inject
 	DinkNotificationService(EventBus eventBus, PullNotifySupport pullNotifySupport)
 	{
@@ -28,6 +33,7 @@ public class DinkNotificationService
 		this.pullNotifySupport = pullNotifySupport;
 	}
 
+	/** Posts a single-card pull notification to Dink, with card/rarity metadata attached. No-op for a blank card name. */
 	public void notifyPackPull(
 		String cardName, boolean newForCollection, boolean foil, RarityMath.Tier tier, String instanceId)
 	{
@@ -43,6 +49,7 @@ public class DinkNotificationService
 			pullMetadata(cardName.trim(), foil, newForCollection, tier, content.imageUrl, content.inspectUrl));
 	}
 
+	/** Posts an end-of-pack summary notification (new cards / duplicates) to Dink. */
 	void notifyPackSummary(PackSummaryContent content)
 	{
 		Map<String, Object> metadata = new HashMap<>();
@@ -55,6 +62,7 @@ public class DinkNotificationService
 			metadata);
 	}
 
+	/** Builds the Dink metadata map for a single card pull (name, foil, new-for-collection, tier, image/inspect links). */
 	private static Map<String, Object> pullMetadata(
 		String cardName, boolean foil, boolean newForCollection, RarityMath.Tier tier,
 		String imageUrl, String inspectUrl)
@@ -75,6 +83,7 @@ public class DinkNotificationService
 		return metadata;
 	}
 
+	/** Assembles and posts the Dink {@link PluginMessage} envelope; swallows failures (Dink not installed, etc.). */
 	private void postNotify(String text, String imageUrl, Map<String, Object> metadata)
 	{
 		Map<String, Object> data = new HashMap<>();

--- a/src/main/java/com/osrstcg/notify/PullExternalNotificationService.java
+++ b/src/main/java/com/osrstcg/notify/PullExternalNotificationService.java
@@ -27,6 +27,10 @@ import okhttp3.ResponseBody;
 import com.osrstcg.catalog.RarityMath;
 import com.osrstcg.notify.PullNotifySupport.PackSummaryContent;
 
+/**
+ * Notifications that leave the client: party broadcasts of pulls, and Discord-style webhook posts
+ * for individual pulls and end-of-pack summaries.
+ */
 @Slf4j
 @Singleton
 public class PullExternalNotificationService
@@ -40,6 +44,7 @@ public class PullExternalNotificationService
 	private final PullNotifySupport pullNotifySupport;
 	private final PartyService partyService;
 
+	/** Wires the HTTP client, JSON codec, game client, config, pull-content builder, and party service. */
 	@Inject
 	PullExternalNotificationService(
 		OkHttpClient okHttpClient,
@@ -57,6 +62,7 @@ public class PullExternalNotificationService
 		this.partyService = partyService;
 	}
 
+	/** Broadcasts a single pull to the current party. No-op if party-announce is disabled or not in a party. */
 	public void notifyParty(String card, boolean newForCollection, boolean foil)
 	{
 		if (!config.partyAnnouncePulls() || !partyService.isInParty())
@@ -77,6 +83,7 @@ public class PullExternalNotificationService
 		}
 	}
 
+	/** Posts a single-card pull as a Discord-style embed to every configured webhook URL. No-op if none configured. */
 	public void sendWebhook(
 		String card, boolean newForCollection, boolean foil, RarityMath.Tier tier, String instanceId)
 	{
@@ -99,6 +106,7 @@ public class PullExternalNotificationService
 		}
 	}
 
+	/** Posts an end-of-pack summary (new cards / duplicates) as a Discord-style embed to every configured webhook URL. */
 	public void sendPackSummary(PackSummaryContent content)
 	{
 		List<HttpUrl> webhookUrls = configuredWebhookUrls();
@@ -122,6 +130,7 @@ public class PullExternalNotificationService
 		}
 	}
 
+	/** Parses the configured webhook URL(s) from config; logs a warning and returns empty if none parse. */
 	private List<HttpUrl> configuredWebhookUrls()
 	{
 		String webhookUrl = config.pullWebhookUrl();
@@ -137,6 +146,7 @@ public class PullExternalNotificationService
 		return webhookUrls;
 	}
 
+	/** Fires the same payload at each webhook URL independently. */
 	private void dispatchWebhook(String card, List<HttpUrl> webhookUrls, String payload)
 	{
 		for (HttpUrl parsedUrl : webhookUrls)
@@ -145,6 +155,7 @@ public class PullExternalNotificationService
 		}
 	}
 
+	/** Sends one async POST to a webhook URL; logs the outcome (success, HTTP error, or transport failure). */
 	private void enqueueWebhook(String card, HttpUrl parsedUrl, String payload)
 	{
 		Request request = new Request.Builder()
@@ -153,12 +164,14 @@ public class PullExternalNotificationService
 			.build();
 		okHttpClient.newCall(request).enqueue(new Callback()
 		{
+			/** Logs a transport-level failure (connection/timeout, not an HTTP error status). */
 			@Override
 			public void onFailure(Call call, IOException e)
 			{
 				log.warn("Pull webhook request failed for '{}' ({}): {}", card, maskWebhookUrl(parsedUrl), e.toString());
 			}
 
+			/** Logs success at debug level, or the response body (truncated) at warn level on a non-2xx status. */
 			@Override
 			public void onResponse(Call call, Response response)
 			{
@@ -187,6 +200,7 @@ public class PullExternalNotificationService
 		});
 	}
 
+	/** Splits the (possibly multi-line) config value into valid {@link HttpUrl}s, skipping blank/unparseable lines. */
 	private static List<HttpUrl> parseWebhookUrls(String raw)
 	{
 		List<HttpUrl> urls = new ArrayList<>();
@@ -208,6 +222,7 @@ public class PullExternalNotificationService
 		return urls;
 	}
 
+	/** Reduces a webhook URL to scheme/host/path for logging, dropping the sensitive token/query portion. */
 	private static String maskWebhookUrl(Object url)
 	{
 		if (url == null)
@@ -228,6 +243,7 @@ public class PullExternalNotificationService
 		return parsed == null ? "<invalid>" : maskWebhookUrl(parsed);
 	}
 
+	/** Builds a single-embed Discord webhook payload from the description, footer, tier color, and links. */
 	private static Map<String, Object> buildPayload(
 		String description, String footerText, RarityMath.Tier tier, String imageUrl, String inspectUrl)
 	{
@@ -252,12 +268,14 @@ public class PullExternalNotificationService
 		return payload;
 	}
 
+	/** Converts a rarity tier's {@link Color} to a Discord embed color integer; white if the tier is unknown. */
 	private static int discordColor(RarityMath.Tier tier)
 	{
 		Color color = tier == null ? Color.WHITE : tier.getColor();
 		return (color.getRed() << 16) | (color.getGreen() << 8) | color.getBlue();
 	}
 
+	/** Sanitizes and returns the local player's name for webhook attribution, or a fallback label if unknown. */
 	private String resolvePlayerName()
 	{
 		if (client.getLocalPlayer() == null || client.getLocalPlayer().getName() == null)
@@ -267,6 +285,7 @@ public class PullExternalNotificationService
 		return PullNotificationMessages.playerLabel(Text.sanitize(client.getLocalPlayer().getName()));
 	}
 
+	/** Collapses newlines and caps a webhook response body at 300 chars for logging. */
 	private static String truncateForLog(String value)
 	{
 		if (value == null || value.isEmpty())

--- a/src/main/java/com/osrstcg/notify/PullNotificationMessages.java
+++ b/src/main/java/com/osrstcg/notify/PullNotificationMessages.java
@@ -6,6 +6,10 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+/**
+ * Static helpers for building the text of pull/pack-summary notifications (chat, webhook, Dink) and
+ * the small immutable value types those builders operate on.
+ */
 public final class PullNotificationMessages
 {
 	public static final String PLUGIN_TITLE = "OSRS TCG";
@@ -14,6 +18,7 @@ public final class PullNotificationMessages
 	{
 	}
 
+	/** One card pull, with the display/rarity data and notification eligibility needed to render it. */
 	public static final class PackPull
 	{
 		public final String cardName;
@@ -23,6 +28,7 @@ public final class PullNotificationMessages
 		public final String instanceId;
 		public final boolean notificationEligible;
 
+		/** Stores the pull's display/rarity data and notification eligibility verbatim. */
 		public PackPull(
 			String cardName,
 			boolean newForCollection,
@@ -40,11 +46,13 @@ public final class PullNotificationMessages
 		}
 	}
 
+	/** A pack's pulls split into new-cards and duplicates summary lines, ordered by rarity. */
 	public static final class PackSummarySections
 	{
 		public final List<String> newCards;
 		public final List<String> duplicates;
 
+		/** Stores the pre-built summary line lists verbatim. */
 		PackSummarySections(List<String> newCards, List<String> duplicates)
 		{
 			this.newCards = newCards;
@@ -52,16 +60,19 @@ public final class PullNotificationMessages
 		}
 	}
 
+	/** True if {@code value} is null, empty, or whitespace-only. */
 	static boolean isBlank(String value)
 	{
 		return value == null || value.trim().isEmpty();
 	}
 
+	/** Trims a player name for display, falling back to a placeholder when blank/unknown. */
 	static String playerLabel(String name)
 	{
 		return isBlank(name) ? "Unknown player" : name.trim();
 	}
 
+	/** Builds the web "inspect this pull" URL for an instance id, or "" if the id is blank. */
 	public static String inspectUrl(String instanceId)
 	{
 		if (instanceId == null || instanceId.isBlank())
@@ -71,6 +82,7 @@ public final class PullNotificationMessages
 		return CloudEndpoints.webUrl("/inspect/" + instanceId.trim());
 	}
 
+	/** Builds the "X just added Y to their collection" message, with an inspect link appended when available. */
 	public static String collectionMessage(
 		String playerName, String cardName, boolean newForCollection, boolean foil, String inspectUrl)
 	{
@@ -80,6 +92,7 @@ public final class PullNotificationMessages
 		return appendInspectLink(body, inspectUrl);
 	}
 
+	/** Appends a markdown "[Inspect card](url)" link when {@code inspectUrl} is non-blank; null-safe on message. */
 	private static String appendInspectLink(String message, String inspectUrl)
 	{
 		if (message == null)
@@ -93,6 +106,7 @@ public final class PullNotificationMessages
 		return message + "\n[Inspect card](" + inspectUrl.trim() + ")";
 	}
 
+	/** True if any pull in the list is flagged {@code notificationEligible}. */
 	public static boolean hasEligiblePull(List<PackPull> pulls)
 	{
 		if (pulls == null || pulls.isEmpty())
@@ -109,6 +123,10 @@ public final class PullNotificationMessages
 		return false;
 	}
 
+	/**
+	 * Returns the pull with the highest rarity tier (used as the summary thumbnail), or the first
+	 * pull if none have a tier. Null if the list is empty.
+	 */
 	public static PackPull highestTierPull(List<PackPull> pulls)
 	{
 		if (pulls == null || pulls.isEmpty())
@@ -130,6 +148,7 @@ public final class PullNotificationMessages
 		return best == null ? pulls.get(0) : best;
 	}
 
+	/** Renders one pull's summary bullet: card name (bolded if eligible), foil marker, and inspect link. */
 	public static String summaryLine(PackPull pull)
 	{
 		String displayName = pull.cardName.trim() + (pull.foil ? " (foil)" : "");
@@ -145,6 +164,7 @@ public final class PullNotificationMessages
 		return displayName;
 	}
 
+	/** Splits pulls into new-cards/duplicates summary lines, sorted highest-tier first within each group. */
 	public static PackSummarySections buildSummarySections(List<PackPull> pulls)
 	{
 		List<String> newCards = new ArrayList<>();
@@ -166,6 +186,7 @@ public final class PullNotificationMessages
 		return new PackSummarySections(newCards, duplicates);
 	}
 
+	/** Builds the "X opened a booster pack!" message with New cards / Duplicates sections appended. */
 	public static String packSummaryMessage(String opener, PackSummarySections sections)
 	{
 		StringBuilder message = new StringBuilder(playerLabel(opener)).append(" opened a booster pack!");
@@ -177,11 +198,13 @@ public final class PullNotificationMessages
 		return message.toString();
 	}
 
+	/** Sort key for a pull by rarity tier ordinal; -1 (lowest) when the pull or tier is missing. */
 	private static int tierRank(PackPull pull)
 	{
 		return pull == null || pull.tier == null ? -1 : pull.tier.ordinal();
 	}
 
+	/** Appends a "**heading**" section with a bulleted line per card, skipping blank entries; no-op if the list is empty. */
 	private static void appendCardSection(StringBuilder message, String heading, List<String> cards)
 	{
 		if (cards == null || cards.isEmpty())

--- a/src/main/java/com/osrstcg/notify/PullNotificationService.java
+++ b/src/main/java/com/osrstcg/notify/PullNotificationService.java
@@ -20,6 +20,10 @@ import javax.inject.Singleton;
 import net.runelite.client.chat.ChatMessageManager;
 import com.osrstcg.catalog.RarityMath;
 
+/**
+ * Entry point for pull/collection-add notifications: routes each pull to chat, party, Dink, and
+ * webhook notifications according to config (per-card vs. end-of-pack summary, tier/foil filters).
+ */
 @Singleton
 public class PullNotificationService
 {
@@ -30,6 +34,7 @@ public class PullNotificationService
 	private final DinkNotificationService dinkNotificationService;
 	private final PullExternalNotificationService externalNotifyService;
 
+	/** Wires config, chat, the card database, the shared pull-content builder, and the Dink/webhook sub-services. */
 	@Inject
 	PullNotificationService(
 		OsrsTcgConfig config,
@@ -47,6 +52,13 @@ public class PullNotificationService
 		this.externalNotifyService = externalNotifyService;
 	}
 
+	/**
+	 * Handles a single card pull: chats and party-broadcasts the collection add, then (if the pull
+	 * meets the configured notify thresholds and the trigger is per-card) fires the webhook and Dink
+	 * notifications immediately.
+	 *
+	 * @return true if party-announce is enabled, so callers know whether a party broadcast was sent
+	 */
 	public boolean notifyPull(
 		String cardName, boolean newForCollection, boolean foil, RarityMath.Tier tier, String instanceId)
 	{
@@ -68,6 +80,7 @@ public class PullNotificationService
 		return config.partyAnnouncePulls();
 	}
 
+	/** Queues the "you added" chat line for one card, resolving rarity color from the card database if not supplied. */
 	public void postCollectionAddChat(String cardName, boolean newForCollection, boolean foil, Color rarityColor)
 	{
 		if (PullNotificationMessages.isBlank(cardName))
@@ -79,6 +92,10 @@ public class PullNotificationService
 		queueCollectionAddChat(trimmed, newForCollection, foil, rarity);
 	}
 
+	/**
+	 * Chats a "you added" line for every pull in a batch (e.g. a full pack open), computing
+	 * new-vs-duplicate per card against the pre-open owned-card snapshot.
+	 */
 	public void postAllCollectionAdds(List<PackCardResult> pulls, Set<CardCollectionKey> preOwnedCards)
 	{
 		if (pulls == null || pulls.isEmpty())
@@ -111,6 +128,7 @@ public class PullNotificationService
 		}
 	}
 
+	/** Chats a "you added" line for a reveal-service card, deriving its display name and rarity color. */
 	public void postCollectionAddChat(RevealCard card)
 	{
 		if (card == null || card.getPull() == null)
@@ -137,6 +155,10 @@ public class PullNotificationService
 		postCollectionAddChat(name, card.isNew(), pull.isFoil(), rarity);
 	}
 
+	/**
+	 * Fires the end-of-pack webhook/Dink summary notification for a whole pack's pulls, when the
+	 * notification trigger is set to end-of-pack rather than per-card.
+	 */
 	public void notifyPackAtEnd(List<PackRevealService.RevealCard> cards)
 	{
 		if (pullNotifySupport.notificationTrigger() != PullNotificationTrigger.AT_END || cards == null || cards.isEmpty())
@@ -153,6 +175,7 @@ public class PullNotificationService
 		});
 	}
 
+	/** Queues the formatted+plain "you added" chat message, if party-announce (which gates local chat too) is on. */
 	private void queueCollectionAddChat(String cardName, boolean newForCollection, boolean foil, Color rarityColor)
 	{
 		if (!config.partyAnnouncePulls())
@@ -165,6 +188,7 @@ public class PullNotificationService
 		TcgPluginGameMessages.queueFormattedGameMessage(chatMessageManager, formatted, plain);
 	}
 
+	/** Builds a case-insensitive "name|foil" key for matching pulls against the pre-owned card snapshot. */
 	private static String normalizeOwnedKey(String cardName, boolean foil)
 	{
 		String name = cardName == null ? "" : cardName.trim().toLowerCase(Locale.ROOT);

--- a/src/main/java/com/osrstcg/notify/PullNotifySupport.java
+++ b/src/main/java/com/osrstcg/notify/PullNotifySupport.java
@@ -16,15 +16,21 @@ import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+/**
+ * Shared logic for building notification content and deciding eligibility, used by chat, party,
+ * webhook, and Dink notifiers so they stay in sync on filtering rules and message text.
+ */
 @Singleton
 public class PullNotifySupport
 {
+	/** Pre-built end-of-pack summary: sections, thumbnail image, and rarity tier for the embed color. */
 	public static final class PackSummaryContent
 	{
 		public final PullNotificationMessages.PackSummarySections sections;
 		public final String imageUrl;
 		public final RarityMath.Tier tier;
 
+		/** Stores the summary sections, thumbnail image URL, and tier verbatim. */
 		PackSummaryContent(PullNotificationMessages.PackSummarySections sections, String imageUrl, RarityMath.Tier tier)
 		{
 			this.sections = sections;
@@ -32,18 +38,21 @@ public class PullNotifySupport
 			this.tier = tier;
 		}
 
+		/** Renders the summary message with the given opener name substituted in. */
 		public String messageFor(String opener)
 		{
 			return PullNotificationMessages.packSummaryMessage(opener, sections);
 		}
 	}
 
+	/** Pre-built per-card notification content: message text, card image URL, and inspect link. */
 	public static final class PullCardContent
 	{
 		public final String description;
 		public final String imageUrl;
 		public final String inspectUrl;
 
+		/** Stores the description, image URL, and inspect URL verbatim. */
 		PullCardContent(String description, String imageUrl, String inspectUrl)
 		{
 			this.description = description;
@@ -57,6 +66,7 @@ public class PullNotifySupport
 	private final TcgPublicStatsCalculator tcgPublicStatsCalculator;
 	private final TcgChatStatsShareService tcgChatStatsShareService;
 
+	/** Wires config, the card database, and the public-stats calculator/share service used to build stats lines. */
 	@Inject
 	PullNotifySupport(
 		OsrsTcgConfig config,
@@ -70,6 +80,10 @@ public class PullNotifySupport
 		this.tcgChatStatsShareService = tcgChatStatsShareService;
 	}
 
+	/**
+	 * Decides whether a pull is eligible for external notification (webhook/Dink), applying the
+	 * new-cards-only, foil, non-foil, and per-category tier-floor config settings.
+	 */
 	public boolean shouldNotify(RarityMath.Tier tier, boolean foil, boolean newForCollection)
 	{
 		PullNotifyTier floor = newForCollection ? config.notifyTier() : config.duplicateNotifyTier();
@@ -92,12 +106,14 @@ public class PullNotifySupport
 		return meetsTier(tier, floor);
 	}
 
+	/** Returns the configured notification trigger, defaulting to per-card when unset. */
 	public PullNotificationTrigger notificationTrigger()
 	{
 		PullNotificationTrigger trigger = config.pullNotificationTrigger();
 		return trigger == null ? PullNotificationTrigger.EVERY_CARD : trigger;
 	}
 
+	/** Converts reveal-service cards into {@link PullNotificationMessages.PackPull}s, computing notify-eligibility for each. */
 	public List<PullNotificationMessages.PackPull> packPullsFromCards(List<RevealCard> cards)
 	{
 		List<PullNotificationMessages.PackPull> pulls = new ArrayList<>();
@@ -122,6 +138,10 @@ public class PullNotifySupport
 		return pulls;
 	}
 
+	/**
+	 * Builds the end-of-pack summary content, or empty if no pull is notification-eligible or both
+	 * summary sections end up empty.
+	 */
 	public Optional<PackSummaryContent> packSummaryContent(List<PullNotificationMessages.PackPull> pulls)
 	{
 		if (!PullNotificationMessages.hasEligiblePull(pulls))
@@ -139,6 +159,7 @@ public class PullNotifySupport
 		return Optional.of(new PackSummaryContent(sections, imageUrl, tier));
 	}
 
+	/** Builds the message text, card image URL, and inspect URL for a single-card notification. */
 	public PullCardContent pullCardContent(
 		String cardName, boolean newForCollection, boolean foil, String instanceId, String opener)
 	{
@@ -150,6 +171,7 @@ public class PullNotifySupport
 			inspectUrl);
 	}
 
+	/** Resolves a card's public image URL (as .webp), or "" if the card is unknown or has no image. */
 	public String cardImageUrl(String cardName)
 	{
 		return cardDatabase.findByName(cardName)
@@ -159,6 +181,7 @@ public class PullNotifySupport
 			.orElse("");
 	}
 
+	/** Rewrites a ".png" image URL to ".webp"; passes other URLs through unchanged. */
 	private static String toWebpUrl(String url)
 	{
 		if (url == null || url.isEmpty())
@@ -168,16 +191,19 @@ public class PullNotifySupport
 		return url.endsWith(".png") ? url.substring(0, url.length() - 4) + ".webp" : url;
 	}
 
+	/** Renders the plain-text public collection stats line shown on external notifications. */
 	public String statsPlainLine()
 	{
 		return tcgChatStatsShareService.buildPlainLine(tcgPublicStatsCalculator.computeLive());
 	}
 
+	/** Appends the public stats line to a notification message, separated by a blank line. */
 	public String messageWithStatsLine(String message)
 	{
 		return message + "\n\n" + statsPlainLine();
 	}
 
+	/** True if {@code tier} meets or exceeds {@code floor} (defaulting to MYTHIC, the strictest, when floor is unset). */
 	private static boolean meetsTier(RarityMath.Tier tier, PullNotifyTier floor)
 	{
 		if (tier == null)

--- a/src/main/java/com/osrstcg/overlay/CreditsInfoboxMenuHandler.java
+++ b/src/main/java/com/osrstcg/overlay/CreditsInfoboxMenuHandler.java
@@ -22,6 +22,7 @@ public class CreditsInfoboxMenuHandler
 	private final PackOpenCoordinator packOpenCoordinator;
 	private final ClientThread clientThread;
 
+	/** Wires the collaborators needed to match clicked menu entries back to boosters and open them. */
 	@Inject
 	public CreditsInfoboxMenuHandler(
 		CreditsInfoboxOverlay creditsInfoboxOverlay,
@@ -37,6 +38,10 @@ public class CreditsInfoboxMenuHandler
 		this.clientThread = clientThread;
 	}
 
+	/**
+	 * Handles a click on one of {@link CreditsInfoboxOverlay}'s menu entries: resets the credits/h
+	 * tracker, or matches the clicked target back to a visible booster and opens it.
+	 */
 	public void onOverlayMenuClicked(OverlayMenuClicked event)
 	{
 		if (event.getOverlay() != creditsInfoboxOverlay)

--- a/src/main/java/com/osrstcg/overlay/CreditsInfoboxOverlay.java
+++ b/src/main/java/com/osrstcg/overlay/CreditsInfoboxOverlay.java
@@ -42,12 +42,18 @@ public class CreditsInfoboxOverlay extends OverlayPanel
 	private final CreditsRateTracker creditsRateTracker;
 	private final PackCatalogService packCatalogService;
 
+	/** Cache of the last painted credits value; render()-thread only, used to skip rebuilding components when unchanged. */
 	private long lastCredits = Long.MIN_VALUE;
+	/** Cache of the last painted credits/h value; render()-thread only. */
 	private Long lastCreditsPerHour;
+	/** Cache of the last "show rate" config flag; render()-thread only. */
 	private boolean lastShowRate;
+	/** Cache of the last "show infobox" config flag; render()-thread only. */
 	private boolean lastShowInfobox = true;
+	/** Hash of the menu-entry-relevant state as of the last {@link #refreshMenuEntries()} call; render()-thread only. */
 	private int lastMenuFingerprint = Integer.MIN_VALUE;
 
+	/** Wires the collaborators used to read credits/rate/catalog state and positions the overlay top-left. */
 	@Inject
 	CreditsInfoboxOverlay(
 		OsrsTcgConfig config,
@@ -63,6 +69,12 @@ public class CreditsInfoboxOverlay extends OverlayPanel
 		setClearChildren(false);
 	}
 
+	/**
+	 * Paints the credits/credits-per-hour panel, rebuilding the child components only when the
+	 * displayed values changed, and refreshing the right-click menu only when its contents changed.
+	 * Called on the client's rendering thread. Returns null (and clears state) while the infobox is
+	 * disabled in config.
+	 */
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
@@ -118,6 +130,7 @@ public class CreditsInfoboxOverlay extends OverlayPanel
 		return super.render(graphics);
 	}
 
+	/** Combines credits, the rate-display flag, and each affordable visible booster into a change-detection hash. */
 	private int menuFingerprint(long credits, boolean showRate)
 	{
 		int hash = showRate ? 1 : 0;
@@ -153,6 +166,7 @@ public class CreditsInfoboxOverlay extends OverlayPanel
 		return "Pack";
 	}
 
+	/** Rebuilds the overlay's right-click menu: a Reset entry when the rate is shown, and an Open entry per affordable visible booster. */
 	private void refreshMenuEntries()
 	{
 		getMenuEntries().clear();

--- a/src/main/java/com/osrstcg/overlay/PackRevealDealLayout.java
+++ b/src/main/java/com/osrstcg/overlay/PackRevealDealLayout.java
@@ -7,14 +7,26 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Layout math for the card-dealing animation phase: computes where each card sits mid-flight from
+ * the pile to its final grid slot, and in what draw order. Pure functions over the caller-supplied
+ * elapsed time, so it carries no mutable state and is safe to call from any thread.
+ */
 public final class PackRevealDealLayout
 {
+	/** Pixel offset applied per waiting card in the still-stacked pile, so later cards peek out from under earlier ones. */
 	static final int DEAL_STACK_STEP = 5;
 
+	/** Not instantiable; all members are static. */
 	private PackRevealDealLayout()
 	{
 	}
 
+	/**
+	 * Computes the current on-screen rectangle for every card during the deal phase: waiting cards are
+	 * stacked at the pile center with a small offset per rank, in-flight cards are eased from the pile
+	 * to their destination slot, and arrived cards sit at their final grid slot.
+	 */
 	static List<Rectangle> layoutDealPhaseCardRects(Rectangle canvas, ViewportLayout layout, int cardCount, long elapsed)
 	{
 		List<Rectangle> out = new ArrayList<>(cardCount);
@@ -38,6 +50,10 @@ public final class PackRevealDealLayout
 		return out;
 	}
 
+	/**
+	 * Draw-order layer for card {@code i} at the given elapsed time: 0 once it has arrived (drawn first,
+	 * i.e. behind), 2 while in flight (drawn on top), 1 while still waiting in the pile.
+	 */
 	static int dealDrawLayer(long elapsed, int i, long stagger, long flight)
 	{
 		long t0 = (long) i * stagger;
@@ -53,6 +69,7 @@ public final class PackRevealDealLayout
 		return 2;
 	}
 
+	/** Linearly interpolates position and size between two rectangles at {@code t} (0 = from, 1 = to). */
 	static Rectangle lerp(Rectangle from, Rectangle to, double t)
 	{
 		int x = (int) Math.round(from.x + ((to.x - from.x) * t));
@@ -62,6 +79,7 @@ public final class PackRevealDealLayout
 		return new Rectangle(x, y, w, h);
 	}
 
+	/** Clamps {@code v} to the [0, 1] range. */
 	public static double clamp01(double v)
 	{
 		if (v <= 0.0d)
@@ -75,12 +93,14 @@ public final class PackRevealDealLayout
 		return v;
 	}
 
+	/** Smoothstep easing (3t^2 - 2t^3) over {@code t}, clamped to [0, 1] first. */
 	static double smoothStep(double t)
 	{
 		t = clamp01(t);
 		return t * t * (3.0d - 2.0d * t);
 	}
 
+	/** Bounding rectangle covering every rect in the list, or an empty rectangle at the origin if the list is null/empty. */
 	static Rectangle unionBounds(List<Rectangle> rects)
 	{
 		if (rects == null || rects.isEmpty())
@@ -95,6 +115,11 @@ public final class PackRevealDealLayout
 		return u;
 	}
 
+	/**
+	 * Per-card rectangle for the deal phase: the destination slot once arrived; a pile-stack position,
+	 * offset by rank among still-waiting cards, before its stagger delay elapses; otherwise an eased
+	 * lerp from the pile center to the destination slot.
+	 */
 	private static Rectangle dealPhaseCardRect(int i, long elapsed, long stagger, long flight,
 		List<Rectangle> slots, Rectangle pileCenterRect, int cw, int ch, int n)
 	{

--- a/src/main/java/com/osrstcg/overlay/PackRevealDrawUtil.java
+++ b/src/main/java/com/osrstcg/overlay/PackRevealDrawUtil.java
@@ -17,6 +17,11 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import net.runelite.client.ui.FontManager;
 
+/**
+ * Stateless drawing helpers for the pack reveal overlay: the close button, glow effects, badges/labels,
+ * and image/rect fitting math. Called from overlay rendering ({@code Graphics2D}) on RuneLite's overlay
+ * render thread; the glow bake cache is synchronized since it may be read/written across renders.
+ */
 final class PackRevealDrawUtil
 {
 	static final int CLOSE_BUTTON_SIZE = 26;
@@ -45,10 +50,12 @@ final class PackRevealDrawUtil
 			}
 		});
 
+	/** No instances; all members are static. */
 	private PackRevealDrawUtil()
 	{
 	}
 
+	/** Fills {@code canvas} with a semi-transparent black wash to dim the game view behind the overlay. */
 	static void drawDim(Graphics2D g, Rectangle canvas)
 	{
 		g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.55f));
@@ -57,6 +64,7 @@ final class PackRevealDrawUtil
 		g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 1.0f));
 	}
 
+	/** Writes the close button's bounds (top-right corner of {@code canvas}, edge-padded) into {@code outBounds}. */
 	static void layoutCloseButton(Rectangle canvas, Rectangle outBounds)
 	{
 		int pad = PackRevealLayout.VIEWPORT_EDGE_PAD;
@@ -68,6 +76,7 @@ final class PackRevealDrawUtil
 			size);
 	}
 
+	/** Draws the rounded close button (shadow, gradient panel, inset highlight, border, X icon) with hover styling. */
 	static void drawCloseButton(Graphics2D g, Rectangle bounds, boolean hover)
 	{
 		if (g == null || bounds == null || bounds.width <= 0 || bounds.height <= 0)
@@ -143,6 +152,7 @@ final class PackRevealDrawUtil
 		}
 	}
 
+	/** Scales {@code r} uniformly by {@code scale} about its center, clamping each dimension to at least 1px. */
 	static Rectangle scaleRectCentered(Rectangle r, double scale)
 	{
 		int nw = Math.max(1, (int) Math.round(r.width * scale));
@@ -152,6 +162,7 @@ final class PackRevealDrawUtil
 		return new Rectangle(nx, ny, nw, nh);
 	}
 
+	/** Scales {@code r}'s width by {@code scaleX} about its horizontal center; height is unchanged. */
 	static Rectangle scaleRectHorizontally(Rectangle r, double scaleX)
 	{
 		int nw = Math.max(1, (int) Math.round(r.width * scaleX));
@@ -159,6 +170,7 @@ final class PackRevealDrawUtil
 		return new Rectangle(nx, r.y, nw, r.height);
 	}
 
+	/** Shrinks {@code r} by {@code inset} on all four sides, clamping each dimension to at least 1px. */
 	static Rectangle uniformInset(Rectangle r, int inset)
 	{
 		if (inset <= 0)
@@ -170,12 +182,17 @@ final class PackRevealDrawUtil
 		return new Rectangle(r.x + inset, r.y + inset, nw, nh);
 	}
 
+	/** Draws a soft glow around {@code r} using the default expand/layer settings and the card's outer arc. */
 	static void drawGlow(Graphics2D g, Rectangle r, Color color, float alpha)
 	{
 		int baseArc = SharedCardRenderer.outerArcDiameter(r.width);
 		drawGlow(g, r, color, alpha, GLOW_MAX_EXPAND, GLOW_LAYERS, baseArc);
 	}
 
+	/**
+	 * Draws a soft glow around {@code r} by blitting a cached, pre-baked layered-rounded-rect image scaled
+	 * to {@code alpha}. No-ops for a null/degenerate rect or near-zero alpha.
+	 */
 	static void drawGlow(Graphics2D g, Rectangle r, Color color, float alpha, float maxExpand, int layers, int baseArc)
 	{
 		Color glow = color == null ? Color.WHITE : color;
@@ -199,6 +216,10 @@ final class PackRevealDrawUtil
 		}
 	}
 
+	/**
+	 * Returns the baked glow image for this size/color/expand/layer combination, building and caching it
+	 * (LRU, capped at {@link #GLOW_CACHE_MAX}) on first use.
+	 */
 	private static BufferedImage cachedGlow(int width, int height, int rgb, int expand, int layers, int baseArc)
 	{
 		String key = width + "x" + height + '|' + rgb + '|' + expand + '|' + layers + '|' + baseArc + '|' + GLOW_LAYER_ALPHA;
@@ -241,11 +262,13 @@ final class PackRevealDrawUtil
 		return img;
 	}
 
+	/** Returns {@code color} (or white if null) with its alpha replaced by {@code alpha}. */
 	static Color withAlpha(Color color, float alpha)
 	{
 		return CardColorMath.withAlpha(color == null ? Color.WHITE : color, alpha);
 	}
 
+	/** Returns the largest rect that fits {@code image} inside {@code bounds} preserving aspect ratio, centered. */
 	static Rectangle fittedImageRect(Rectangle bounds, BufferedImage image)
 	{
 		if (image == null)
@@ -266,12 +289,14 @@ final class PackRevealDrawUtil
 		return new Rectangle(x, y, w, h);
 	}
 
+	/** Draws {@code image} scaled to fit within {@code bounds} preserving aspect ratio, centered. */
 	static void drawImageFit(Graphics2D g, BufferedImage image, Rectangle bounds)
 	{
 		Rectangle r = fittedImageRect(bounds, image);
 		g.drawImage(image, r.x, r.y, r.width, r.height, null);
 	}
 
+	/** Draws a centered "NEW!" badge with a drop shadow above {@code cardBounds}. */
 	static void drawNewBadge(Graphics2D g, Rectangle cardBounds)
 	{
 		Graphics2D g2 = (Graphics2D) g.create();
@@ -293,6 +318,7 @@ final class PackRevealDrawUtil
 		}
 	}
 
+	/** Draws {@code text} centered near the top of {@code cardBounds} with a drop shadow, faded by {@code alpha}. No-op if {@code text} is null or alpha is near zero. */
 	static void drawRarityLabel(Graphics2D g, Rectangle cardBounds, String text, Color color, float alpha)
 	{
 		float clampedAlpha = Math.max(0f, Math.min(1f, alpha));

--- a/src/main/java/com/osrstcg/overlay/PackRevealInputListener.java
+++ b/src/main/java/com/osrstcg/overlay/PackRevealInputListener.java
@@ -13,6 +13,11 @@ import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.MouseListener;
 import net.runelite.client.input.MouseWheelListener;
 
+/**
+ * RuneLite mouse/keyboard listener that intercepts and consumes game input while a pack reveal is
+ * active, routing clicks/keys to the reveal service and overlay instead. Callbacks run on RuneLite's
+ * input handling thread, not the client thread.
+ */
 @Singleton
 public class PackRevealInputListener implements MouseListener, KeyListener, MouseWheelListener
 {
@@ -21,6 +26,7 @@ public class PackRevealInputListener implements MouseListener, KeyListener, Mous
 	private final SidebarRefresh sidebarRefresh;
 	private final ChatMessageManager chatMessageManager;
 
+	/** Wires the collaborators used to detect an active reveal, forward input to it, and refresh the sidebar after close. */
 	@Inject
 	public PackRevealInputListener(
 		PackRevealService revealService,
@@ -34,6 +40,10 @@ public class PackRevealInputListener implements MouseListener, KeyListener, Mous
 		this.chatMessageManager = chatMessageManager;
 	}
 
+	/**
+	 * Aborts the active reveal (no-op if none), optionally chat-announcing {@code reasonMessage} first,
+	 * then refreshes the sidebar.
+	 */
 	private void forceCloseActiveReveal(String reasonMessage)
 	{
 		if (!revealService.isActive())
@@ -54,6 +64,7 @@ public class PackRevealInputListener implements MouseListener, KeyListener, Mous
 		return revealService.isActive();
 	}
 
+	/** Updates the overlay's hover point from {@code e} while a reveal is active, else clears it. */
 	private void syncRevealHoverCanvasFromEvent(java.awt.event.MouseEvent e)
 	{
 		if (e == null)
@@ -68,6 +79,7 @@ public class PackRevealInputListener implements MouseListener, KeyListener, Mous
 		overlay.setRevealHoverCanvasPoint(e.getPoint());
 	}
 
+	/** Consumes clicks while a reveal is active; otherwise passes the event through unconsumed. */
 	@Override
 	public MouseEvent mouseClicked(MouseEvent mouseEvent)
 	{
@@ -79,6 +91,11 @@ public class PackRevealInputListener implements MouseListener, KeyListener, Mous
 		return mouseEvent;
 	}
 
+	/**
+	 * Syncs the hover point, then while a reveal is active: right-click pins the card info tip; left-click
+	 * hits the pinned tip, the close button, or forwards to {@link PackRevealService#handleClick}, refreshing
+	 * the sidebar if that ends the reveal. Consumes the event whenever a reveal is active.
+	 */
 	@Override
 	public MouseEvent mousePressed(MouseEvent mouseEvent)
 	{
@@ -126,6 +143,7 @@ public class PackRevealInputListener implements MouseListener, KeyListener, Mous
 		return mouseEvent;
 	}
 
+	/** Consumes the release while a reveal is active; otherwise passes it through unconsumed. */
 	@Override
 	public MouseEvent mouseReleased(MouseEvent mouseEvent)
 	{
@@ -137,6 +155,7 @@ public class PackRevealInputListener implements MouseListener, KeyListener, Mous
 		return mouseEvent;
 	}
 
+	/** Consumes the enter event while a reveal is active; otherwise passes it through unconsumed. */
 	@Override
 	public MouseEvent mouseEntered(MouseEvent mouseEvent)
 	{
@@ -148,6 +167,7 @@ public class PackRevealInputListener implements MouseListener, KeyListener, Mous
 		return mouseEvent;
 	}
 
+	/** Clears the overlay's hover point, then consumes the exit event while a reveal is active. */
 	@Override
 	public MouseEvent mouseExited(MouseEvent mouseEvent)
 	{
@@ -160,6 +180,7 @@ public class PackRevealInputListener implements MouseListener, KeyListener, Mous
 		return mouseEvent;
 	}
 
+	/** Syncs the hover point, then consumes the drag event while a reveal is active. */
 	@Override
 	public MouseEvent mouseDragged(MouseEvent mouseEvent)
 	{
@@ -176,6 +197,7 @@ public class PackRevealInputListener implements MouseListener, KeyListener, Mous
 		return mouseEvent;
 	}
 
+	/** Syncs the hover point, then consumes the move event while a reveal is active. */
 	@Override
 	public MouseEvent mouseMoved(MouseEvent mouseEvent)
 	{
@@ -192,6 +214,7 @@ public class PackRevealInputListener implements MouseListener, KeyListener, Mous
 		return mouseEvent;
 	}
 
+	/** Syncs the hover point, then nudges the reveal's zoom level and consumes the event while a reveal is active. */
 	@Override
 	public MouseWheelEvent mouseWheelMoved(MouseWheelEvent event)
 	{
@@ -209,6 +232,7 @@ public class PackRevealInputListener implements MouseListener, KeyListener, Mous
 		return event;
 	}
 
+	/** Consumes typed characters while a reveal is active; otherwise leaves the event alone. */
 	@Override
 	public void keyTyped(KeyEvent e)
 	{
@@ -219,6 +243,10 @@ public class PackRevealInputListener implements MouseListener, KeyListener, Mous
 		e.consume();
 	}
 
+	/**
+	 * While a reveal is active: Escape force-closes the reveal, Space advances it (refreshing the sidebar
+	 * if that ends the reveal); all other keys are simply consumed.
+	 */
 	@Override
 	public void keyPressed(KeyEvent e)
 	{
@@ -244,6 +272,7 @@ public class PackRevealInputListener implements MouseListener, KeyListener, Mous
 		e.consume();
 	}
 
+	/** Consumes the key release while a reveal is active; otherwise leaves the event alone. */
 	@Override
 	public void keyReleased(KeyEvent e)
 	{

--- a/src/main/java/com/osrstcg/overlay/PackRevealLayout.java
+++ b/src/main/java/com/osrstcg/overlay/PackRevealLayout.java
@@ -8,6 +8,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.DoubleConsumer;
 
+/**
+ * Layout math for the pack reveal overlay: base/native card and pack sizes, the zoom level that fits
+ * the pack and card grid within the viewport, and the resulting slot rectangles. Pure functions, called
+ * from overlay rendering on RuneLite's overlay render thread.
+ */
 final class PackRevealLayout
 {
 	static final double CARD_SIZE_SCALE = 0.805d * 1.25d;
@@ -30,10 +35,16 @@ final class PackRevealLayout
 	static final int NATIVE_PACK_H = Math.max(1, (int) Math.round(BASE_PACK_H * NATIVE_LAYOUT_SCALE));
 	static final int NATIVE_CARD_GAP = Math.max(4, (int) Math.round(BASE_CARD_GAP * NATIVE_LAYOUT_SCALE));
 
+	/** No instances; all members are static. */
 	private PackRevealLayout()
 	{
 	}
 
+	/**
+	 * Picks the largest zoom multiplier (capped at {@code preferredZoomMul}) at which the pack (and, once
+	 * cards are shown, the card grid) fits inside {@code canvas} minus its edge padding, reports the chosen
+	 * multiplier to {@code onAppliedZoom} if non-null, and returns the resulting pack/card/gap pixel sizes.
+	 */
 	static ViewportLayout computeViewportLayout(Rectangle canvas, int cardCount, PackRevealService.Phase phase,
 		double preferredZoomMul, DoubleConsumer onAppliedZoom)
 	{
@@ -55,6 +66,7 @@ final class PackRevealLayout
 			PackRevealZoomUtil.scalePx(NATIVE_CARD_GAP, zoomMul));
 	}
 
+	/** True while the reveal is still showing the unopened pack, before individual card slots are laid out. */
 	static boolean isPackSizedPhase(PackRevealService.Phase phase)
 	{
 		return phase == PackRevealService.Phase.PACK_READY
@@ -62,6 +74,10 @@ final class PackRevealLayout
 			|| phase == PackRevealService.Phase.AWAITING_PULLS;
 	}
 
+	/**
+	 * Lays out up to 2 cards on a top row and any remainder on a bottom row, both centered within
+	 * {@code canvas}, using the card/gap sizes from {@code layout}. Returns an empty list for {@code count <= 0}.
+	 */
 	static List<Rectangle> layoutCardSlots(Rectangle canvas, int count, ViewportLayout layout)
 	{
 		List<Rectangle> out = new ArrayList<>();
@@ -96,6 +112,7 @@ final class PackRevealLayout
 		return out;
 	}
 
+	/** Edge padding for {@code canvas}: {@link #VIEWPORT_EDGE_PAD} at minimum, scaling down to 1/40 of the short side. */
 	static int viewportEdgePad(Rectangle canvas)
 	{
 		if (canvas == null)
@@ -106,16 +123,19 @@ final class PackRevealLayout
 		return Math.max(VIEWPORT_EDGE_PAD, Math.min(16, shortSide / 40));
 	}
 
+	/** Unscaled (base-size) grid width for {@code count} cards laid out as {@link #layoutCardSlots} would. */
 	private static int naturalGridWidth(int count)
 	{
 		return naturalGridWidthWithSize(count, BASE_CARD_W, BASE_CARD_GAP);
 	}
 
+	/** Unscaled (base-size) grid height for {@code count} cards laid out as {@link #layoutCardSlots} would. */
 	private static int naturalGridHeight(int count)
 	{
 		return naturalGridHeightWithSize(count, BASE_CARD_H, BASE_CARD_GAP);
 	}
 
+	/** Grid width for {@code count} cards at the given card width/gap: up to 2 cards per row, rows centered. */
 	private static int naturalGridWidthWithSize(int count, int cardW, int gap)
 	{
 		if (count <= 0)
@@ -129,6 +149,7 @@ final class PackRevealLayout
 		return Math.max(topWidth, bottomWidth);
 	}
 
+	/** Grid height for {@code count} cards at the given card height/gap: one row, or two rows plus gap if a second row exists. */
 	private static int naturalGridHeightWithSize(int count, int cardH, int gap)
 	{
 		if (count <= 0)
@@ -140,6 +161,10 @@ final class PackRevealLayout
 		return (bottomCount > 0) ? (cardH * 2) + gap : cardH;
 	}
 
+	/**
+	 * True if, at zoom multiplier {@code mul}, the pack alone ({@code packOnly}) or the pack plus the
+	 * {@code cardCount}-card grid fits within {@code availW}x{@code availH}.
+	 */
 	private static boolean nativeLayoutFits(int availW, int availH, int cardCount, boolean packOnly, double mul)
 	{
 		int packW = PackRevealZoomUtil.scalePx(NATIVE_PACK_W, mul);
@@ -158,6 +183,10 @@ final class PackRevealLayout
 		return needW <= availW && needH <= availH;
 	}
 
+	/**
+	 * Computes {@link #NATIVE_LAYOUT_SCALE}: the scale factor applied to base sizes so the reference
+	 * "classic" canvas size fits the max-visible-card grid, clamped to [{@link #MIN_OVERLAY_SCALE}, 1.0].
+	 */
 	private static double classicNativeLayoutScale()
 	{
 		Rectangle canvas = new Rectangle(0, 0, CLASSIC_CANVAS_W, CLASSIC_CANVAS_H);
@@ -175,6 +204,7 @@ final class PackRevealLayout
 		return Math.max(MIN_OVERLAY_SCALE, Math.min(1.0d, fitS));
 	}
 
+	/** On short canvases, fits to height alone (may crop width); otherwise uses the contain scale for both axes. */
 	private static double defaultFitScale(Rectangle canvas, double scaleH, double containS)
 	{
 		if (canvas != null && canvas.height <= SMALL_CANVAS_HEIGHT_PX)
@@ -184,6 +214,7 @@ final class PackRevealLayout
 		return containS;
 	}
 
+	/** Resolved pixel sizes (at the currently applied zoom) for the pack, a card, and the gap between cards. */
 	static final class ViewportLayout
 	{
 		final int packW;
@@ -192,6 +223,7 @@ final class PackRevealLayout
 		final int cardH;
 		final int gap;
 
+		/** Stores the resolved pixel sizes verbatim. */
 		ViewportLayout(int packW, int packH, int cardW, int cardH, int gap)
 		{
 			this.packW = packW;
@@ -201,6 +233,7 @@ final class PackRevealLayout
 			this.gap = gap;
 		}
 
+		/** Returns the pack's rect, sized per this layout and centered within {@code canvas}. */
 		Rectangle packRect(Rectangle canvas)
 		{
 			int x = canvas.x + (canvas.width - packW) / 2;

--- a/src/main/java/com/osrstcg/overlay/PackRevealOverlay.java
+++ b/src/main/java/com/osrstcg/overlay/PackRevealOverlay.java
@@ -46,15 +46,32 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.util.LinkBrowser;
 
+/**
+ * Always-on-top {@link Overlay} that renders the full pack-opening animation: sealed pack, deal-out,
+ * flip-reveal, hover/zoom effects, and the card info tooltip/close button chrome. Registered with the
+ * RuneLite {@code OverlayManager} for the lifetime of the plugin; {@link #render(Graphics2D)} is a
+ * no-op (and clears animation state) whenever {@link PackRevealService} has no active reveal to paint.
+ * {@link #render(Graphics2D)} and its private helpers run on the client's rendering thread. A few
+ * fields ({@link #sessionPackZoomMultiplier}, the hover-listener fields) are written from the input
+ * listener thread and read during render, so they are {@code volatile} or otherwise designed to
+ * tolerate that cross-thread access; everything else is render-thread-only.
+ */
 @Singleton
 public class PackRevealOverlay extends Overlay
 {
+	/** Scale multiplier applied to a face-up card on full hover lift. */
 	private static final double HOVER_CARD_SCALE = 1.072d;
+	/** Scale multiplier applied to the sealed pack image on full hover lift. */
 	private static final double PACK_IMAGE_HOVER_MAX_SCALE = 1.085d;
+	/** Per-reference-frame hover lift lerp factor; scaled to actual frame time by {@link #advanceHoverLerpFactor()}. */
 	private static final double HOVER_LERP = 0.22d;
+	/** Frame rate the {@link #HOVER_LERP} constant was tuned against. */
 	private static final double HOVER_LERP_REFERENCE_HZ = 60.0d;
+	/** Upper bound on the delta-time used for hover lerp, to avoid a huge jump after a stall (e.g. a GC pause). */
 	private static final double HOVER_LERP_MAX_DT_SEC = 0.05d;
+	/** Peak alpha of the rarity-tinted glow drawn behind hovered/face-up cards and the sealed pack. */
 	private static final float HOVER_RARITY_GLOW_ALPHA = 0.30f;
+	/** Inset, in pixels, of the sealed-pack rarity glow from the fitted pack art bounds. */
 	private static final int PACK_SEALED_GLOW_INSET = 2;
 
 	private final Client client;
@@ -65,45 +82,80 @@ public class PackRevealOverlay extends Overlay
 	private final TcgStateService tcgStateService;
 	private final OsrsTcgConfig config;
 
+	/** Shared empty instance to avoid reallocating when the per-slot arrays reset to zero cards. */
 	private static final boolean[] EMPTY_BOOL = new boolean[0];
+	/** Shared empty instance to avoid reallocating when the per-slot arrays reset to zero cards. */
 	private static final SlotFaceCache[] EMPTY_SLOT_CACHE = new SlotFaceCache[0];
 
+	/** User's session-only zoom override (mouse wheel), NaN when none is set; written from the input thread, read during render. */
 	private volatile double sessionPackZoomMultiplier = Double.NaN;
+	/** Zoom multiplier applied on the last render, used to detect a zoom change and invalidate cached face sizes. */
 	private double lastAppliedZoomMul = Double.NaN;
 
+	/** Current eased hover-lift amount [0,1] for the sealed pack image. */
 	private double packHoverLift;
+	/** Current eased hover-lift amount [0,1] per card slot. */
 	private double[] cardHoverLift = new double[0];
+	/** Whether the last known pointer position came from the canvas hover listener rather than polling the client. */
 	private volatile boolean revealHoverFromListener;
+	/** Last canvas X reported by the hover listener; written from the input thread, read during render. */
 	private volatile int revealHoverCanvasX;
+	/** Last canvas Y reported by the hover listener; written from the input thread, read during render. */
 	private volatile int revealHoverCanvasY;
+	/** Whether the pointer was inside the sealed apex-pack bounds on the previous frame, to detect hover-enter for the one-shot sound. */
 	private boolean apexPackPointerWasInside;
+	/** Reusable [x, y] output buffer for {@link #revealPointer(int[])} to avoid allocating a Point every frame. */
 	private final int[] pointerScratch = new int[2];
+	/** Whether the reveal's ambient sound was active on the previous frame, so it can be hard-stopped exactly once when the reveal ends. */
 	private boolean packRevealSoundActivePrev;
+	/** {@link System#nanoTime()} of the previous hover-dynamics update, used to compute the frame delta time. */
 	private long lastHoverDynamicsNanos;
 
+	/** Per-slot flag: whether that card's face image has finished prewarming into the shared render cache. */
 	private boolean[] facePrewarmDone = EMPTY_BOOL;
+	/** Per-slot flag: whether a prewarm task for that card has already been submitted to the pool. */
 	private boolean[] facePrewarmScheduled = EMPTY_BOOL;
+	/** Per-slot cache of the face draw request and its cache key inputs, to avoid rebuilding it every frame. */
 	private SlotFaceCache[] slotFaceCache = EMPTY_SLOT_CACHE;
+	/** Identity string of the currently visible cards' names/art, used to detect when the reveal set changed and caches must be dropped. */
 	private String lastVisibleFaceIdentity = "";
 
+	/** Index of the card the info tip currently targets, or -1 when no tip is showing. */
 	private int tipCardIndex = -1;
+	/** {@link System#currentTimeMillis()} when hovering over {@link #tipCardIndex} began, used for the tip's delay/fade-in. */
 	private long tipHoverStartedAtMs;
+	/** Last known cursor X, used to position the hover glow inside a pinned tip. */
 	private int tipCursorX;
+	/** Last known cursor Y, used to position the hover glow inside a pinned tip. */
 	private int tipCursorY;
+	/** Model content for the currently shown info tip, or null when none is showing. */
 	private CardInfoTipModel.Content tipContent;
+	/** Whether the info tip is click-pinned open (persists regardless of hover) rather than hover-only. */
 	private boolean tipPinned;
+	/** Whether {@link #tipPinnedPanelX}/{@link #tipPinnedPanelY} have been computed for the current pin. */
 	private boolean tipPinBoundsReady;
+	/** Screen X of the pinned tip panel, computed once per pin. */
 	private int tipPinnedPanelX;
+	/** Screen Y of the pinned tip panel, computed once per pin. */
 	private int tipPinnedPanelY;
+	/** Canvas X the pinned tip was anchored to when pinned. */
 	private int tipPinAnchorX;
+	/** Canvas Y the pinned tip was anchored to when pinned. */
 	private int tipPinAnchorY;
+	/** Wiki page slug for the pinned card, or null if it has none. */
 	private String tipPinnedWikiPage;
+	/** Cloud instance id of the pinned card, or null if it has none. */
 	private String tipPinnedInstanceId;
+	/** Screen bounds of the currently drawn info tip panel, used for hit-testing and pin-dismiss distance checks. */
 	private final Rectangle tipPanelBounds = new Rectangle();
+	/** Screen bounds of the reveal overlay's close button, used for hover styling and click hit-testing. */
 	private final Rectangle closeButtonBounds = new Rectangle();
+	/** Screen bounds of each clickable action (inspect/wiki) inside the pinned tip, keyed by action id. */
 	private final Map<String, Rectangle> tipActionBounds = new HashMap<>();
+	/** Extra padding, in pixels, around the pinned tip panel within which the cursor keeps it open. */
 	private static final int TIP_PIN_DISMISS_PAD_PX = 48;
 
+	/** Wires the collaborators used to read reveal state, resolve art, and pin this overlay always-on-top above everything else. */
 	@Inject
 	public PackRevealOverlay(Client client, PackRevealService revealService, CardImageCacheService imageCacheService,
 		PackCatalogService packCatalogService, PackRevealSoundService packRevealSoundService,
@@ -121,6 +173,12 @@ public class PackRevealOverlay extends Overlay
 		setPriority(Overlay.PRIORITY_HIGHEST);
 	}
 
+	/**
+	 * Called from the canvas mouse-listener thread with the latest hover position (or null when the
+	 * pointer left the canvas / hover is unavailable), so render() can hit-test against a fresher
+	 * position than polling the client each frame. Also dismisses a pinned info tip once the cursor
+	 * moves far enough away from it.
+	 */
 	public void setRevealHoverCanvasPoint(Point canvasPoint)
 	{
 		if (canvasPoint == null)
@@ -138,6 +196,12 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/**
+	 * Paints one frame of the pack-reveal animation for whichever phase {@link PackRevealService} is
+	 * currently in: dims the screen, draws the sealed pack / deal-out / flip-reveal cards with their
+	 * hover and rarity-glow effects, and the close button and card info tooltip chrome. Returns null
+	 * (and resets all animation state) when no reveal is active. Runs on the client's rendering thread.
+	 */
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
@@ -296,6 +360,11 @@ public class PackRevealOverlay extends Overlay
 		return null;
 	}
 
+	/**
+	 * Builds (or returns the cached) {@link CardFaceDrawRequest} for a card slot, keyed on size, art
+	 * identity, wear-visibility config, and art path; also lazily creates the slot's foil/wear FX so
+	 * they persist for the life of that reveal rather than being re-rolled every frame.
+	 */
 	private CardFaceDrawRequest cachedFaceRequest(int index, PackRevealService.RevealCard card, BufferedImage art,
 		int width, int height)
 	{
@@ -356,6 +425,7 @@ public class PackRevealOverlay extends Overlay
 		return req;
 	}
 
+	/** Whether the "NEW" badge should be shown for a pulled card: always for foils/unnamed pulls, otherwise only if the player didn't already own that card as a foil. */
 	private static boolean shouldShowNewBadge(PackRevealService.RevealCard card, Set<String> preOwnedFoilNames)
 	{
 		PackCardResult pull = card.getPull();
@@ -371,6 +441,7 @@ public class PackRevealOverlay extends Overlay
 		return !preOwnedFoilNames.contains(name.trim().toLowerCase(Locale.ROOT));
 	}
 
+	/** Resolves the art path to draw for a card: the foil variant when this was a foil pull and one exists, otherwise the normal card image. */
 	private static String artPathFor(PackRevealService.RevealCard card)
 	{
 		if (card == null)
@@ -387,6 +458,11 @@ public class PackRevealOverlay extends Overlay
 		return def == null ? null : def.getImageUrl();
 	}
 
+	/**
+	 * Kicks off background rendering of up to two not-yet-cached card faces per frame (via
+	 * {@link SharedCardRenderer}'s shared cache), so a card's flip animation finds its face already
+	 * rendered instead of stalling the render thread the first time it's needed.
+	 */
 	private void prewarmNextRevealFace(List<PackRevealService.RevealCard> cards, List<Rectangle> slotBounds)
 	{
 		if (cards == null || slotBounds == null || cards.isEmpty() || slotBounds.size() < cards.size())
@@ -452,6 +528,7 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/** Submits a one-shot background task to render and cache a card's face at the given size, marking the slot as scheduled so it isn't submitted twice. */
 	private void scheduleFacePrewarm(int index, int width, int height, CardFaceDrawRequest req)
 	{
 		if (req == null || index < 0 || index >= facePrewarmScheduled.length || facePrewarmScheduled[index])
@@ -462,6 +539,7 @@ public class PackRevealOverlay extends Overlay
 		ForkJoinPool.commonPool().execute(() -> SharedCardRenderer.prewarmFace(width, height, req));
 	}
 
+	/** Deterministic seed string for a card's FX (foil sparkle / wear), derived from its pulled name, or empty if unknown. */
 	private static String seedNameFor(PackRevealService.RevealCard card)
 	{
 		if (card.getPull() != null && card.getPull().getCardName() != null
@@ -472,6 +550,7 @@ public class PackRevealOverlay extends Overlay
 		return "";
 	}
 
+	/** Clears every slot's cached face request/FX and prewarm flags when the visible set of cards (names/art) has changed since the last frame. */
 	private void invalidateFaceSlotsIfChanged(List<PackRevealService.RevealCard> cards)
 	{
 		String identity = visibleFaceIdentity(cards);
@@ -503,6 +582,7 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/** Builds a cheap identity string (seed name + art path per slot) used to detect when the reveal's card set has changed. */
 	private static String visibleFaceIdentity(List<PackRevealService.RevealCard> cards)
 	{
 		if (cards == null || cards.isEmpty())
@@ -527,6 +607,11 @@ public class PackRevealOverlay extends Overlay
 		return sb.toString();
 	}
 
+	/**
+	 * Combines a card's flip progress with its hover-lift state into the rectangle, face-up flag, lift
+	 * amount, and flip progress used to draw it: hover scaling only applies once a card has fully
+	 * settled face-down (no flip in progress).
+	 */
 	private RevealCardVisual revealCardVisual(int index, Rectangle baseBounds, PackRevealService.RevealPaintSnapshot snap)
 	{
 		float flipProgress = snap.getFlipProgress(index);
@@ -544,6 +629,7 @@ public class PackRevealOverlay extends Overlay
 		return new RevealCardVisual(r, faceUp, lift, flipProgress);
 	}
 
+	/** Grows {@link #slotFaceCache}, {@link #facePrewarmDone}, and {@link #facePrewarmScheduled} to cover {@code index} if needed, preserving existing entries. */
 	private void ensureSlotFaceCache(int index)
 	{
 		int needed = index + 1;
@@ -572,6 +658,7 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/** Drops all per-slot face caches and prewarm flags back to the shared empty arrays; called once a reveal ends. */
 	private void clearSlotCaches()
 	{
 		lastVisibleFaceIdentity = "";
@@ -589,6 +676,7 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/** Drops each slot's cached draw request/size (but keeps foil/wear FX) so faces re-render at the new size after a zoom change. */
 	private void invalidateFaceSizes()
 	{
 		for (SlotFaceCache slot : slotFaceCache)
@@ -610,6 +698,11 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/**
+	 * Draws a card mid-flip by horizontally scaling it (a cheap pseudo-3D flip) from flat card-back
+	 * (0deg) through edge-on to flat card-face (180deg), switching artwork at the 90-degree halfway
+	 * point. Falls back to the card back if the face isn't cached yet, scheduling a prewarm for it.
+	 */
 	private void drawFlippingCard(Graphics2D graphics, int index, Rectangle r, PackRevealService.RevealCard card,
 		float flipProgress)
 	{
@@ -659,6 +752,7 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/** Resolved per-frame visual state for one card slot: its drawn rectangle, whether it's showing its face, hover lift, and flip progress. */
 	private static final class RevealCardVisual
 	{
 		private final Rectangle rect;
@@ -666,6 +760,7 @@ public class PackRevealOverlay extends Overlay
 		private final double lift;
 		private final float flipProgress;
 
+		/** Stores the resolved fields verbatim. */
 		private RevealCardVisual(Rectangle rect, boolean faceUp, double lift, float flipProgress)
 		{
 			this.rect = rect;
@@ -675,6 +770,11 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/**
+	 * Current on-screen bounds of the sealed pack image (including hover scale), or null when no
+	 * reveal is active or it isn't in the {@code PACK_READY} phase. Callable from outside the render
+	 * thread; synchronizes on {@link #revealService} to read a consistent phase/card snapshot.
+	 */
 	public Rectangle currentPackBounds()
 	{
 		synchronized (revealService)
@@ -691,6 +791,10 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/**
+	 * Current on-screen bounds of each card slot (including hover scale), or an empty list outside the
+	 * card-reveal/wait-close phases. Synchronizes on {@link #revealService} for a consistent snapshot.
+	 */
 	public List<Rectangle> currentCardBounds()
 	{
 		synchronized (revealService)
@@ -710,6 +814,7 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/** Index of the face-up (already-revealed) card slot under the given canvas point, or -1 if none. */
 	private int faceUpCardIndexAt(Point canvasPoint)
 	{
 		if (canvasPoint == null)
@@ -732,6 +837,7 @@ public class PackRevealOverlay extends Overlay
 		return -1;
 	}
 
+	/** Shared tail for phases that don't show individual cards yet (pack ready/fading/dealing): paints the close button, clears the info tip, and returns null. */
 	private Dimension finishEarlyPhase(Graphics2D graphics, Rectangle canvas, PackRevealService.RevealPaintSnapshot snap)
 	{
 		paintRevealChrome(graphics, canvas, snap, null);
@@ -739,11 +845,13 @@ public class PackRevealOverlay extends Overlay
 		return null;
 	}
 
+	/** Draws the face-down card back for a slot, foil-styled when the underlying pull is a foil. */
 	private void drawRevealCardBack(Graphics2D g2, Rectangle r, PackRevealService.RevealCard card)
 	{
 		SharedCardRenderer.drawCardBack(g2, r, card.getPull().isFoil(), cardBackImage());
 	}
 
+	/** Draws the overlay chrome common to every phase: the close button (hover-styled) and, when cards are showing, the card info tooltip. */
 	private void paintRevealChrome(Graphics2D graphics, Rectangle canvas, PackRevealService.RevealPaintSnapshot snap,
 		List<PackRevealService.RevealCard> cards)
 	{
@@ -761,12 +869,14 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/** Whether a click at the given canvas point should close the reveal: inside the close button and not intercepted by the info tip. */
 	public boolean handleCloseButtonClick(Point canvasPoint)
 	{
 		return canvasPoint != null && closeButtonBounds.width > 0
 			&& closeButtonBounds.contains(canvasPoint) && !cardInfoTipCoversPoint(canvasPoint);
 	}
 
+	/** Whether the given point falls within the currently visible (delay-elapsed or pinned) card info tip panel, so clicks/hover under it don't fall through to what's behind it. */
 	private boolean cardInfoTipCoversPoint(Point p)
 	{
 		if (tipContent == null || tipPanelBounds.width <= 0)
@@ -781,6 +891,7 @@ public class PackRevealOverlay extends Overlay
 		return tipPanelBounds.contains(p.x, p.y);
 	}
 
+	/** Index of the first rectangle in the list containing the current pointer position, or -1 if none / pointer unavailable. */
 	private int indexOfRectUnderMouse(List<Rectangle> rects)
 	{
 		if (!revealPointer(pointerScratch))
@@ -799,6 +910,7 @@ public class PackRevealOverlay extends Overlay
 		return -1;
 	}
 
+	/** Whether the current pointer position falls inside the given rectangle. */
 	private boolean mouseInRect(Rectangle r)
 	{
 		if (r == null)
@@ -808,6 +920,7 @@ public class PackRevealOverlay extends Overlay
 		return revealPointer(pointerScratch) && r.contains(pointerScratch[0], pointerScratch[1]);
 	}
 
+	/** Saves the session zoom override back to persisted state if the player nudged it (mouse wheel) during this reveal. */
 	private void persistPackZoomIfNeeded()
 	{
 		if (!Double.isNaN(sessionPackZoomMultiplier))
@@ -816,6 +929,7 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/** Resets all hover/zoom/tip animation state to its idle defaults; called when a reveal ends or leaves a recognized phase. */
 	private void resetHoverAnimations()
 	{
 		packHoverLift = 0.0d;
@@ -828,6 +942,7 @@ public class PackRevealOverlay extends Overlay
 		clearCardInfoTip();
 	}
 
+	/** Clears the card info tooltip's state entirely, whether it was hover-shown or pinned. */
 	private void clearCardInfoTip()
 	{
 		tipCardIndex = -1;
@@ -841,6 +956,11 @@ public class PackRevealOverlay extends Overlay
 		tipActionBounds.clear();
 	}
 
+	/**
+	 * Click-pins the card info tip for the face-up card at the given canvas point, so it stays open
+	 * without hover. Fails (returns false) if there's no face-up card there or it has neither a wiki
+	 * page nor an inspectable instance id. Synchronizes on {@link #revealService} to read the card.
+	 */
 	public boolean pinCardInfoTipAt(Point canvasPoint)
 	{
 		if (canvasPoint == null)
@@ -880,11 +1000,17 @@ public class PackRevealOverlay extends Overlay
 		return true;
 	}
 
+	/** Whether the card info tip is currently pinned open. */
 	public boolean isCardInfoTipPinned()
 	{
 		return tipPinned;
 	}
 
+	/**
+	 * Handles a click while the tip is pinned: opens the inspect page or wiki page if the click landed
+	 * on that action, and always clears the pin afterward. Returns whether the click was consumed by
+	 * the tip (an action, or anywhere else inside its bounds) rather than falling through.
+	 */
 	public boolean handlePinnedTipClick(Point canvasPoint)
 	{
 		if (!tipPinned || canvasPoint == null)
@@ -916,6 +1042,11 @@ public class PackRevealOverlay extends Overlay
 		return onTip;
 	}
 
+	/**
+	 * Updates which card (if any) the hover info tip targets: dismisses a pinned tip once the cursor
+	 * strays too far, otherwise finds the fully-flipped face-up card under the cursor and starts its
+	 * hover timer when it changes.
+	 */
 	private void updateCardInfoTip(List<PackRevealService.RevealCard> cards, List<Rectangle> bases,
 		PackRevealService.RevealPaintSnapshot snap, Rectangle canvas)
 	{
@@ -969,6 +1100,7 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/** Whether the given point is within {@link #TIP_PIN_DISMISS_PAD_PX} of the pinned tip's panel bounds. */
 	private boolean cursorNearPinnedTip(int mx, int my)
 	{
 		int pad = TIP_PIN_DISMISS_PAD_PX;
@@ -978,6 +1110,11 @@ public class PackRevealOverlay extends Overlay
 			&& my < tipPanelBounds.y + tipPanelBounds.height + pad;
 	}
 
+	/**
+	 * Paints the card info tip if one should be visible: full opacity and anchored near the pinning
+	 * click when pinned, or fading/sliding in near the top-right once the hover delay has elapsed.
+	 * Records the panel's screen bounds and (when pinned) its action hitboxes for hit-testing.
+	 */
 	private void paintCardInfoTip(Graphics2D graphics, Rectangle canvas, List<PackRevealService.RevealCard> cards)
 	{
 		if (tipContent == null || tipCardIndex < 0 || tipCardIndex >= cards.size())
@@ -1035,6 +1172,10 @@ public class PackRevealOverlay extends Overlay
 			hoverX, hoverY, actionOut);
 	}
 
+	/**
+	 * Writes the current pointer's canvas coordinates into {@code outXY} and returns true, preferring
+	 * the last position reported by the hover listener over polling {@link Client#getMouseCanvasPosition()}.
+	 */
 	private boolean revealPointer(int[] outXY)
 	{
 		if (revealHoverFromListener)
@@ -1053,12 +1194,14 @@ public class PackRevealOverlay extends Overlay
 		return true;
 	}
 
+	/** Starts/stops the mythic-pull ambient hum: wanted whenever there's an unrevealed mythic card and the pack isn't still sealed. */
 	private void tryPlayMythicHum(PackRevealService.Phase phase, PackRevealService.RevealPaintSnapshot snap)
 	{
 		boolean humWanted = phase != PackRevealService.Phase.PACK_READY && snap.hasUnrevealedMythic();
 		packRevealSoundService.tryPlayMythicHum(humWanted);
 	}
 
+	/** Drives the per-card "whoosh" motion sounds during the deal phase, and stops them outside it. */
 	private void tickDealCardMotionSounds(PackRevealService.Phase phase, int cardCount, long phaseElapsedMs)
 	{
 		if (phase == PackRevealService.Phase.CARD_DEAL && cardCount > 0)
@@ -1072,6 +1215,12 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/**
+	 * Advances the eased hover-lift values ({@link #packHoverLift}, {@link #cardHoverLift}) one frame
+	 * toward their per-phase targets: the sealed pack lifts on hover in {@code PACK_READY}; cards lift
+	 * on hover once dealt and only while still face-down. Falls back to a full reset for any
+	 * unrecognized phase.
+	 */
 	private void updateHoverDynamics(Rectangle canvas, PackRevealLayout.ViewportLayout layout, int cardCount,
 		PackRevealService.Phase phase, long phaseElapsedMs)
 	{
@@ -1125,6 +1274,7 @@ public class PackRevealOverlay extends Overlay
 		resetHoverAnimations();
 	}
 
+	/** Frame-rate-independent lerp factor for this frame, derived from wall-clock delta since the last call so hover animation speed doesn't vary with FPS. */
 	private double advanceHoverLerpFactor()
 	{
 		long now = System.nanoTime();
@@ -1139,17 +1289,20 @@ public class PackRevealOverlay extends Overlay
 		return 1.0d - Math.pow(1.0d - HOVER_LERP, dt * HOVER_LERP_REFERENCE_HZ);
 	}
 
+	/** One exponential-decay step of {@code current} toward {@code target} by {@code factor}. */
 	private static double stepToward(double current, double target, double factor)
 	{
 		return current + (target - current) * factor;
 	}
 
+	/** Applies the sealed pack's current hover-scale to its base (unscaled) rectangle. */
 	private Rectangle packDrawRect(Rectangle packBase)
 	{
 		double scale = 1.0d + (PACK_IMAGE_HOVER_MAX_SCALE - 1.0d) * packHoverLift;
 		return PackRevealDrawUtil.scaleRectCentered(packBase, scale);
 	}
 
+	/** Applies each card's current hover-scale to its base slot rectangle; already-revealed cards are left at base size. */
 	private List<Rectangle> withCardHoverVisualScale(List<Rectangle> bases)
 	{
 		List<Rectangle> out = new ArrayList<>(bases.size());
@@ -1167,6 +1320,7 @@ public class PackRevealOverlay extends Overlay
 		return out;
 	}
 
+	/** The zoom multiplier to lay out with: the session override if the player has nudged it this reveal, otherwise the clamped persisted value. */
 	private double preferredZoomMultiplier()
 	{
 		if (!Double.isNaN(sessionPackZoomMultiplier))
@@ -1176,6 +1330,10 @@ public class PackRevealOverlay extends Overlay
 		return PackRevealZoomUtil.clamp(tcgStateService.getState().getPackRevealOverlayScale());
 	}
 
+	/**
+	 * Applies one mouse-wheel step to the pack reveal zoom, persists the new value immediately, and
+	 * invalidates cached card face sizes so they re-render at the new scale.
+	 */
 	public void nudgeSessionPackZoom(int wheelRotation)
 	{
 		if (wheelRotation == 0)
@@ -1188,6 +1346,7 @@ public class PackRevealOverlay extends Overlay
 		invalidateFaceSizes();
 	}
 
+	/** Resizes {@link #cardHoverLift} to exactly {@code n} entries (clamped to non-negative) if it isn't already that length, resetting lift to zero. */
 	private void ensureCardHoverLength(int n)
 	{
 		if (n < 0)
@@ -1200,6 +1359,7 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/** Steps every card's hover lift toward zero, used in phases where cards can't be individually hovered. */
 	private void decayAllCardHovers(double lerpFactor)
 	{
 		if (cardHoverLift == null || cardHoverLift.length == 0)
@@ -1212,16 +1372,19 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/** Computes the viewport layout for the current canvas/card count/phase at the preferred zoom, reporting the applied zoom back via {@link #noteAppliedZoom}. */
 	private PackRevealLayout.ViewportLayout computeViewportLayout(Rectangle canvas, int cardCount, PackRevealService.Phase phase)
 	{
 		return PackRevealLayout.computeViewportLayout(canvas, cardCount, phase, preferredZoomMultiplier(), this::noteAppliedZoom);
 	}
 
+	/** The full RuneLite game canvas as a rectangle at the origin. */
 	private Rectangle fullCanvas()
 	{
 		return new Rectangle(0, 0, client.getCanvasWidth(), client.getCanvasHeight());
 	}
 
+	/** Callback from the layout computation: invalidates cached face sizes when the actually-applied zoom differs from last frame's. */
 	private void noteAppliedZoom(double zoomMul)
 	{
 		if (Double.compare(lastAppliedZoomMul, zoomMul) != 0)
@@ -1231,6 +1394,11 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/**
+	 * Draws every card as a face-down back during the deal animation, in {@link PackRevealDealLayout}'s
+	 * layer order (waiting pile, then in-flight cards on top, then arrived cards) so flying cards
+	 * correctly occlude the ones still stacked or already placed.
+	 */
 	private void drawDealPhase(Graphics2D graphics, Rectangle canvas, List<PackRevealService.RevealCard> cards,
 		PackRevealLayout.ViewportLayout layout, int cardCount, long phaseElapsedMs)
 	{
@@ -1256,6 +1424,7 @@ public class PackRevealOverlay extends Overlay
 		}
 	}
 
+	/** Draws the sealed pack's art (or a generic card back if the booster has none) at the given alpha, for the sealed and fade-out phases. */
 	private void drawPackImage(Graphics2D g, Rectangle bounds, float alpha, String boosterPackId)
 	{
 		BufferedImage packArt = packArtForPackId(boosterPackId);
@@ -1271,11 +1440,13 @@ public class PackRevealOverlay extends Overlay
 		g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 1.0f));
 	}
 
+	/** The shared generic card-back image, from the image cache. */
 	private BufferedImage cardBackImage()
 	{
 		return imageCacheService.getCached(SharedCardRenderer.CARD_BACK_PATH);
 	}
 
+	/** Resolves a booster's reveal-sleeve art from the catalog cache, or null if the booster/path/image is unknown. */
 	private BufferedImage packArtForPackId(String boosterPackId)
 	{
 		if (boosterPackId == null || boosterPackId.isBlank())
@@ -1291,6 +1462,7 @@ public class PackRevealOverlay extends Overlay
 		return imageCacheService.getCached(imagePath);
 	}
 
+	/** Per-card-slot cache of the built {@link CardFaceDrawRequest} plus the FX and size/identity keys it was built from, to avoid recomputing every frame. */
 	private static final class SlotFaceCache
 	{
 		private WearFx wear;

--- a/src/main/java/com/osrstcg/pack/CardFlipEasing.java
+++ b/src/main/java/com/osrstcg/pack/CardFlipEasing.java
@@ -9,6 +9,10 @@ final class CardFlipEasing
 	{
 	}
 
+	/**
+	 * Eases a linear 0..1 flip time into 0..1 progress along the cubic-bezier curve, via Newton-Raphson
+	 * inversion of the bezier's x(u) against {@code t}.
+	 */
 	static float flipEase(float t)
 	{
 		if (t <= 0f)
@@ -42,12 +46,14 @@ final class CardFlipEasing
 		return cubicBezier(u, 0.7f, 1f);
 	}
 
+	/** Evaluates a single component of the unit cubic bezier at parameter {@code u} for control points {@code p1}/{@code p2}. */
 	private static float cubicBezier(float u, float p1, float p2)
 	{
 		float omu = 1f - u;
 		return 3f * omu * omu * u * p1 + 3f * omu * u * u * p2 + u * u * u;
 	}
 
+	/** Derivative of {@link #cubicBezier} with respect to {@code u}, used by the Newton-Raphson step. */
 	private static float cubicBezierDerivative(float u, float p1, float p2)
 	{
 		float omu = 1f - u;

--- a/src/main/java/com/osrstcg/pack/PackOpenCoordinator.java
+++ b/src/main/java/com/osrstcg/pack/PackOpenCoordinator.java
@@ -41,6 +41,7 @@ public class PackOpenCoordinator
 	private final ChatMessageManager chatMessageManager;
 	private final OsrsTcgConfig config;
 
+	/** Wires the collaborators used to buy packs, run the reveal state machine, and refresh the UI afterwards. */
 	@Inject
 	public PackOpenCoordinator(
 		PackRevealService packRevealService,
@@ -94,6 +95,11 @@ public class PackOpenCoordinator
 			invokeLater));
 	}
 
+	/**
+	 * Guards against concurrent opens, freezes the sidebar, snapshots pre-owned cards, begins the
+	 * pending reveal, then buys/opens the pack on {@link #scheduler} and resumes on {@code ui.invokeLater}.
+	 * Must be called on the client thread.
+	 */
 	private void open(BoosterPackDefinition booster, UiHooks ui)
 	{
 		if (booster == null)
@@ -145,6 +151,10 @@ public class PackOpenCoordinator
 		});
 	}
 
+	/**
+	 * Async continuation of {@link #open}, run on the UI thread after the buy/open call returns: unfreezes
+	 * the sidebar and reports failure, or hands successful pulls to the reveal service and announces credits.
+	 */
 	private void applyOpenResult(PackOpenResult result, HashSet<CardCollectionKey> preOwned, UiHooks ui)
 	{
 		if (!packRevealService.isActive() && !packRevealService.isAwaitingServerPulls())
@@ -186,6 +196,7 @@ public class PackOpenCoordinator
 		ui.refresh.run();
 	}
 
+	/** Caller-specific UI callbacks/flags that let {@link #open} and {@link #applyOpenResult} stay caller-agnostic. */
 	private static final class UiHooks
 	{
 		final boolean announceCreditsOnSuccess;
@@ -196,6 +207,7 @@ public class PackOpenCoordinator
 		final Runnable refresh;
 		final Consumer<Runnable> invokeLater;
 
+		/** Stores the caller-supplied flags and callbacks verbatim. */
 		UiHooks(boolean announceCreditsOnSuccess, boolean chatWhenBusy,
 			AtomicBoolean inFlight, Runnable beginFreeze, Runnable clearFreeze, Runnable refresh,
 			Consumer<Runnable> invokeLater)

--- a/src/main/java/com/osrstcg/pack/PackRevealService.java
+++ b/src/main/java/com/osrstcg/pack/PackRevealService.java
@@ -33,20 +33,35 @@ import com.osrstcg.notify.PullNotificationService;
 import com.osrstcg.ui.tip.CardInfoTipModel;
 import com.osrstcg.ui.SharedCardRenderer;
 
+/**
+ * State machine driving the pack-open reveal overlay: pack-tap animation, waiting for the server's pulls,
+ * dealing cards in batches, per-card flip reveals, and the wait-to-close pause. All public methods are
+ * {@code synchronized} on this instance and are expected to be called from the client thread; {@link #tick()}
+ * and {@link #capturePaintFrame()} are driven once per paint frame to advance time-based phases.
+ */
 @Singleton
 public class PackRevealService
 {
+	/** Reveal overlay phases, advanced by {@link #tick()} (time-driven) or user input ({@link #handleClick}, {@link #advanceFromKeyboard}). */
 	public enum Phase
 	{
+		/** No reveal in progress. */
 		IDLE,
+		/** Pack sleeve shown, waiting for the player to click/tap it. */
 		PACK_READY,
+		/** Pack sleeve fading out after being tapped. */
 		PACK_FADING,
+		/** Fade finished but the server hasn't supplied pulls yet ({@link #supplyRevealPulls} not yet called). */
 		AWAITING_PULLS,
+		/** Cards animating into their dealt positions. */
 		CARD_DEAL,
+		/** Cards dealt and awaiting per-card flip clicks/keyboard advance. */
 		CARD_REVEAL,
+		/** Current batch fully revealed; waiting for input to start the next batch or close the overlay. */
 		WAIT_CLOSE
 	}
 
+	/** One resolved reveal card: the raw server pull, its display definition, rarity tier/color, and new-to-collection flag. */
 	@Value
 	public static class RevealCard
 	{
@@ -57,6 +72,7 @@ public class PackRevealService
 		boolean isNew;
 	}
 
+	/** Immutable copy of the current reveal state for the overlay to paint one frame from, without holding the service lock. */
 	@Getter
 	public static final class RevealPaintSnapshot
 	{
@@ -71,6 +87,7 @@ public class PackRevealService
 		private final String boosterPackId;
 		private final boolean apexPackOpen;
 
+		/** Copies the given frame state; array/collection ownership is transferred from the caller. */
 		private RevealPaintSnapshot(Phase phase, List<RevealCard> cards, boolean[] revealedByIndex,
 			float[] flipProgressByIndex, long phaseElapsedMs,
 			double packFadeProgress, String boosterPackId, boolean apexPackOpen)
@@ -85,11 +102,13 @@ public class PackRevealService
 			this.apexPackOpen = apexPackOpen;
 		}
 
+		/** Whether the visible card at {@code index} has completed its flip. */
 		public boolean isCardRevealed(int index)
 		{
 			return index >= 0 && index < revealedByIndex.length && revealedByIndex[index];
 		}
 
+		/** Eased flip progress (0..1) for the visible card at {@code index}; 1 once revealed, 0 if out of range. */
 		public float getFlipProgress(int index)
 		{
 			if (index < 0 || flipProgressByIndex == null || index >= flipProgressByIndex.length)
@@ -99,6 +118,7 @@ public class PackRevealService
 			return flipProgressByIndex[index];
 		}
 
+		/** Whether any still-face-down card in this batch would play mythic/legendary-foil reveal audio when flipped. */
 		public boolean hasUnrevealedMythic()
 		{
 			return hasUnrevealedPremiumAudio(cards, revealedByIndex);
@@ -148,6 +168,11 @@ public class PackRevealService
 		this.revealCardResolver = new RevealCardResolver(cardDatabase);
 	}
 
+	/**
+	 * Starts a reveal in {@link Phase#PACK_READY} with placeholder cards, before the server has responded
+	 * with actual pulls. Call {@link #supplyRevealPulls} once the pulls arrive, or {@link #abortPendingReveal}
+	 * if the buy call fails.
+	 */
 	public synchronized void beginPendingReveal(String boosterPackId,
 		boolean apexPackOpen, int expectedCardCount)
 	{
@@ -168,6 +193,7 @@ public class PackRevealService
 		this.phase = Phase.PACK_READY;
 	}
 
+	/** Kicks off async preloading of the card-back and (if resolvable) pack-specific reveal sleeve images. */
 	private void preloadRevealSleeve(String packId)
 	{
 		ArrayList<String> urls = new ArrayList<>(2);
@@ -184,6 +210,12 @@ public class PackRevealService
 		imageCacheService.preloadAsync(urls);
 	}
 
+	/**
+	 * Async continuation of {@link #beginPendingReveal}: resolves the server's pulls into shuffled
+	 * {@link RevealCard}s, preloads their images, and advances the phase out of {@code AWAITING_PULLS}/
+	 * pending {@code CARD_DEAL}/{@code CARD_REVEAL} if the corresponding wait has already elapsed.
+	 * Returns {@code false} (leaving state untouched) if the reveal was aborted or the pulls resolved to nothing.
+	 */
 	public synchronized boolean supplyRevealPulls(List<PackCardResult> pulls, Set<CardCollectionKey> preOwnedCards,
 		boolean apexPackOpen)
 	{
@@ -240,12 +272,14 @@ public class PackRevealService
 		return true;
 	}
 
+	/** Cancels a reveal that never received server pulls (buy call failed) and returns to {@link Phase#IDLE}. */
 	public synchronized void abortPendingReveal()
 	{
 		packRevealSoundService.hardStop();
 		reset();
 	}
 
+	/** Display name used for the pull/party chat announcement for a revealed card. */
 	private static String cardNameForParty(RevealCard card)
 	{
 		return CardDisplayNames.titleForDefinition(
@@ -253,6 +287,11 @@ public class PackRevealService
 			card == null ? null : card.getPull());
 	}
 
+	/**
+	 * Handles a click/tap on the reveal overlay: taps the pack sleeve to start fading it, clicks past a
+	 * fully-revealed batch to advance, or clicks an individual face-down card to start its flip (playing
+	 * flip/mythic sound and posting the pull notification).
+	 */
 	public synchronized void handleClick(Point click, Rectangle packBounds, List<Rectangle> cardBounds)
 	{
 		if (phase == Phase.IDLE)
@@ -305,6 +344,11 @@ public class PackRevealService
 		}
 	}
 
+	/**
+	 * Keyboard equivalent of tapping through the reveal: starts the pack fade, force-reveals the current
+	 * batch (skipping the deal/flip animation) if pulls are resolvable, or advances past a finished batch.
+	 * @return {@code true} if this call closed the reveal overlay entirely
+	 */
 	public synchronized boolean advanceFromKeyboard()
 	{
 		if (phase == Phase.IDLE)
@@ -334,6 +378,7 @@ public class PackRevealService
 		return advancePastWaitClose();
 	}
 
+	/** Starts the next card batch if any remain, otherwise closes the reveal. @return {@code true} if the reveal closed */
 	private boolean advancePastWaitClose()
 	{
 		if (hasMoreBatches())
@@ -345,6 +390,7 @@ public class PackRevealService
 		return true;
 	}
 
+	/** Marks every card in the current batch revealed immediately, announces pulls, and enters {@link Phase#WAIT_CLOSE}. */
 	private void forceRevealBatchAndWaitClose()
 	{
 		int batchSize = visibleCount();
@@ -371,6 +417,11 @@ public class PackRevealService
 		phaseStartedAt = System.currentTimeMillis();
 	}
 
+	/**
+	 * Timer-driven: advances time-based phase transitions (pending-pulls timeout, pack fade to deal/await,
+	 * deal to reveal, reveal to wait-close once fully face-up). Called once per paint frame via
+	 * {@link #capturePaintFrame()}.
+	 */
 	public synchronized void tick()
 	{
 		if (awaitingServerPulls
@@ -412,6 +463,7 @@ public class PackRevealService
 		}
 	}
 
+	/** Whether every card in the batch has a real (non-placeholder) pull identity, i.e. the server has responded. */
 	private boolean hasResolvablePulls()
 	{
 		if (cards.isEmpty())
@@ -428,6 +480,7 @@ public class PackRevealService
 		return true;
 	}
 
+	/** Total duration of the deal animation for a batch of {@code cardCount} cards (stagger between cards plus one flight). */
 	public static long packDealPhaseTotalMs(int cardCount)
 	{
 		if (cardCount <= 0)
@@ -437,11 +490,17 @@ public class PackRevealService
 		return (long) (cardCount - 1) * PACK_DEAL_STAGGER_MS + PACK_DEAL_FLIGHT_MS;
 	}
 
+	/** Whether a reveal is in progress (any phase other than {@link Phase#IDLE}). */
 	public synchronized boolean isActive()
 	{
 		return phase != Phase.IDLE;
 	}
 
+	/**
+	 * Timer-driven: advances the state machine ({@link #tick()}, completing any finished card flips) and
+	 * returns an immutable snapshot of the current frame for the overlay to paint, or empty if there's
+	 * nothing to draw.
+	 */
 	public synchronized Optional<RevealPaintSnapshot> capturePaintFrame()
 	{
 		tick();
@@ -472,6 +531,10 @@ public class PackRevealService
 			apexPackOpen));
 	}
 
+	/**
+	 * Marks any in-progress card flip revealed once {@link #CARD_FLIP_MS} has elapsed since it started, and
+	 * enters {@link Phase#WAIT_CLOSE} if that completes the batch.
+	 */
 	private void completeFinishedFlipsLocked()
 	{
 		if (flipStartedAtMs.length == 0)
@@ -509,6 +572,7 @@ public class PackRevealService
 		}
 	}
 
+	/** Computes per-card eased flip progress (1 if revealed, 0 if not started, eased elapsed fraction otherwise). */
 	private float[] buildFlipProgressLocked()
 	{
 		float[] out = new float[Math.max(revealedByIndex.length, flipStartedAtMs.length)];
@@ -531,6 +595,7 @@ public class PackRevealService
 		return out;
 	}
 
+	/** Milliseconds elapsed since the current phase began, or 0 if the phase has no start time. */
 	private long computePhaseElapsedMsLocked()
 	{
 		if (phaseStartedAt <= 0L)
@@ -540,6 +605,7 @@ public class PackRevealService
 		return Math.max(0L, System.currentTimeMillis() - phaseStartedAt);
 	}
 
+	/** Pack-sleeve fade progress (0..1): 1 once past the fade, in-progress fraction during {@code PACK_FADING}, else 0. */
 	private double computePackFadeProgressLocked()
 	{
 		if (phase == Phase.AWAITING_PULLS
@@ -557,26 +623,31 @@ public class PackRevealService
 		return PackRevealDealLayout.clamp01(elapsed / (double) PACK_FADE_MS);
 	}
 
+	/** Current reveal phase. */
 	public synchronized Phase getPhase()
 	{
 		return phase;
 	}
 
+	/** Cards in the currently visible batch (up to {@link #MAX_VISIBLE_REVEAL_CARDS}). */
 	public synchronized List<RevealCard> getCards()
 	{
 		return List.copyOf(visibleCards());
 	}
 
+	/** Whether the visible card at {@code index} has completed its flip. */
 	public synchronized boolean isCardRevealed(int index)
 	{
 		return index >= 0 && index < revealedByIndex.length && revealedByIndex[index];
 	}
 
+	/** Whether a reveal has started but the server's pulls haven't arrived yet. */
 	public synchronized boolean isAwaitingServerPulls()
 	{
 		return awaitingServerPulls;
 	}
 
+	/** Consumes (clears) and returns whether the pending-pulls wait timed out since the last call. */
 	public synchronized boolean consumePendingPullsTimeout()
 	{
 		if (!pendingPullsTimedOut)
@@ -587,6 +658,7 @@ public class PackRevealService
 		return true;
 	}
 
+	/** Clears all reveal state and returns to {@link Phase#IDLE}. */
 	public synchronized void reset()
 	{
 		phase = Phase.IDLE;
@@ -604,11 +676,13 @@ public class PackRevealService
 		preOwnedFoilNames = Set.of();
 	}
 
+	/** Lower-cased names of cards the player already owned as foils before this reveal, for "already have" UI hints. */
 	public synchronized Set<String> getPreOwnedFoilNames()
 	{
 		return Set.copyOf(preOwnedFoilNames);
 	}
 
+	/** Extracts lower-cased, normalized names of foil cards from the pre-reveal owned-cards set. */
 	private static Set<String> buildPreOwnedFoilNames(Set<CardCollectionKey> preOwnedCards)
 	{
 		if (preOwnedCards == null || preOwnedCards.isEmpty())
@@ -624,6 +698,11 @@ public class PackRevealService
 			.collect(Collectors.toUnmodifiableSet());
 	}
 
+	/**
+	 * Force-closes an in-progress reveal (e.g. plugin shutdown or forced navigation away): announces any
+	 * unrevealed pulls and pending collection chat, stops sounds, resets to idle, and returns the full
+	 * card list that was in play.
+	 */
 	public synchronized List<RevealCard> abortActiveReveal()
 	{
 		if (!isActive())
@@ -638,6 +717,7 @@ public class PackRevealService
 		return snapshot;
 	}
 
+	/** Posts the collection-add chat message for any real pull that hasn't had one posted yet. */
 	private void announceRemainingCollectionChat()
 	{
 		for (int i = 0; i < cards.size(); i++)
@@ -659,6 +739,7 @@ public class PackRevealService
 		}
 	}
 
+	/** Whether {@code card} carries an actual server pull (as opposed to a placeholder awaiting server pulls). */
 	private static boolean hasRealPullIdentity(RevealCard card)
 	{
 		return card != null
@@ -667,6 +748,7 @@ public class PackRevealService
 			&& !card.getPull().getCardName().isBlank();
 	}
 
+	/** Posts the pull notification for {@code card} and marks its collection chat as posted if it was sent. */
 	private void notifyPullAndMarkPosted(RevealCard card, int absIndex)
 	{
 		if (pullNotificationService.notifyPull(
@@ -681,6 +763,7 @@ public class PackRevealService
 		}
 	}
 
+	/** Whether any not-yet-revealed card in {@code cards} would trigger premium (mythic/legendary-foil) reveal audio. */
 	private static boolean hasUnrevealedPremiumAudio(List<RevealCard> cards, boolean[] revealedByIndex)
 	{
 		for (int i = 0; i < cards.size(); i++)
@@ -698,6 +781,7 @@ public class PackRevealService
 		return false;
 	}
 
+	/** Index of the card bounds rectangle containing {@code click}, or -1 if none matched. */
 	private int clickedCardIndex(List<Rectangle> bounds, Point click)
 	{
 		if (bounds == null || click == null)
@@ -715,6 +799,11 @@ public class PackRevealService
 		return -1;
 	}
 
+	/**
+	 * Posts pull notifications for cards not yet revealed. When {@code currentBatchOnly} is true, limits
+	 * this to the visible batch (used when force-revealing it); otherwise covers every unrevealed card
+	 * across the whole reveal (used when aborting).
+	 */
 	private void announcePartyUnrevealedPulls(boolean currentBatchOnly)
 	{
 		if (currentBatchOnly)
@@ -744,6 +833,7 @@ public class PackRevealService
 		}
 	}
 
+	/** Notifies party/chat of the full pack contents once every 5th card position is reached (i.e. pack fully revealed). */
 	private void notifyPackAtBatchEnd()
 	{
 		if ((batchOffset + visibleCount()) % 5 == 0)
@@ -752,6 +842,7 @@ public class PackRevealService
 		}
 	}
 
+	/** Whether the card at absolute index {@code absIndex} (across all batches) has been revealed. */
 	private boolean isAbsolutelyRevealed(int absIndex)
 	{
 		if (absIndex < batchOffset)
@@ -766,6 +857,7 @@ public class PackRevealService
 		return false;
 	}
 
+	/** Whether {@code card} should play the premium reveal sting: any Godly pull, or a foil Legendary+ pull. */
 	private static boolean isPremiumRevealAudioPull(RevealCard card)
 	{
 		if (card == null)
@@ -783,11 +875,13 @@ public class PackRevealService
 		return card.getTier().ordinal() >= RarityMath.Tier.LEGENDARY.ordinal();
 	}
 
+	/** Whether {@code card}'s underlying pull is a foil. */
 	private static boolean isFoilPull(RevealCard card)
 	{
 		return card != null && card.getPull() != null && card.getPull().isFoil();
 	}
 
+	/** Whether every slot in the current batch is revealed (and the batch is fully sized/populated). */
 	private boolean allRevealSlotsFaceUp()
 	{
 		int batchSize = visibleCount();
@@ -805,6 +899,7 @@ public class PackRevealService
 		return true;
 	}
 
+	/** Number of cards visible in the current batch, capped at {@link #MAX_VISIBLE_REVEAL_CARDS}. */
 	private int visibleCount()
 	{
 		if (cards.isEmpty() || batchOffset >= cards.size())
@@ -814,6 +909,7 @@ public class PackRevealService
 		return Math.min(MAX_VISIBLE_REVEAL_CARDS, cards.size() - batchOffset);
 	}
 
+	/** The sublist of {@link #cards} making up the current batch. */
 	private List<RevealCard> visibleCards()
 	{
 		int n = visibleCount();
@@ -824,11 +920,13 @@ public class PackRevealService
 		return cards.subList(batchOffset, batchOffset + n);
 	}
 
+	/** Whether cards remain beyond the current batch. */
 	private boolean hasMoreBatches()
 	{
 		return batchOffset + visibleCount() < cards.size();
 	}
 
+	/** (Re)allocates the per-slot revealed/flip-start arrays for the current batch and resets the revealed count. */
 	private void initCurrentBatchRevealFlags()
 	{
 		int n = visibleCount();
@@ -837,6 +935,7 @@ public class PackRevealService
 		flipStartedAtMs = new long[n];
 	}
 
+	/** Advances the batch offset past the current batch and begins dealing the next one. */
 	private void startNextBatch()
 	{
 		batchOffset += visibleCount();
@@ -846,6 +945,7 @@ public class PackRevealService
 		phaseStartedAt = System.currentTimeMillis();
 	}
 
+	/** Notifies the full pack contents if this batch completes it, then enters {@link Phase#WAIT_CLOSE}. */
 	private void enterWaitCloseAfterBatch()
 	{
 		notifyPackAtBatchEnd();

--- a/src/main/java/com/osrstcg/pack/PackRevealSoundService.java
+++ b/src/main/java/com/osrstcg/pack/PackRevealSoundService.java
@@ -6,6 +6,11 @@ import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.audio.AudioPlayer;
 
+/**
+ * Plays the pack-reveal sound effects (mythic hum/reveal, card flip, card deal stagger, apex hover),
+ * gated by {@link OsrsTcgConfig#enableSounds()}. Not thread-confined to the client thread, but all
+ * public methods are {@code synchronized} against shared per-resource/per-reveal state.
+ */
 @Slf4j
 @Singleton
 public class PackRevealSoundService
@@ -33,6 +38,7 @@ public class PackRevealSoundService
 	/** Greatest card index whose deal-start sound has been played this deal phase ({@code -1} = none). */
 	private int dealMotionSoundUpToIndex = -1;
 
+	/** Wires the config (for the sound-enabled toggle) and the shared audio player. */
 	@Inject
 	public PackRevealSoundService(OsrsTcgConfig config, AudioPlayer audioPlayer)
 	{
@@ -40,6 +46,7 @@ public class PackRevealSoundService
 		this.audioPlayer = audioPlayer;
 	}
 
+	/** Plays the mythic hum once per reveal, when wanted and not previously failed/played. */
 	public synchronized void tryPlayMythicHum(boolean humWanted)
 	{
 		if (!config.enableSounds() || humOpenFailed || humPlayedThisReveal || !humWanted)
@@ -56,6 +63,7 @@ public class PackRevealSoundService
 		humPlayedThisReveal = true;
 	}
 
+	/** Plays the mythic/legendary-foil reveal sting. */
 	public synchronized void playMythicReveal()
 	{
 		if (!config.enableSounds() || revealOpenFailed)
@@ -68,6 +76,7 @@ public class PackRevealSoundService
 		}
 	}
 
+	/** Plays the card-flip sound. */
 	public synchronized void playCardFlip()
 	{
 		if (!config.enableSounds() || flipOpenFailed)
@@ -80,6 +89,7 @@ public class PackRevealSoundService
 		}
 	}
 
+	/** Plays the apex-pack hover sound once, at reduced gain; no-ops after it fails to open. */
 	public synchronized void playApexPackHoverOneShot()
 	{
 		if (!config.enableSounds() || apexHoverOpenFailed)
@@ -92,6 +102,11 @@ public class PackRevealSoundService
 		}
 	}
 
+	/**
+	 * Timer-driven: called every paint frame during the card-deal phase to play one deal-stagger sound
+	 * per card whose stagger offset ({@code index * staggerMs}) has elapsed since the phase began.
+	 * Resets the played-up-to index when the deal phase isn't active.
+	 */
 	public synchronized void tickDealMotionSounds(boolean dealPhaseActive, long elapsedMs, int cardCount, long staggerMs)
 	{
 		if (!dealPhaseActive || !config.enableSounds())
@@ -121,17 +136,23 @@ public class PackRevealSoundService
 		}
 	}
 
+	/** Resets the deal-stagger progress so the next batch's deal sounds play from the start. */
 	public synchronized void resetDealMotionSounds()
 	{
 		dealMotionSoundUpToIndex = -1;
 	}
 
+	/** Clears per-reveal sound state (mythic hum played flag, deal-stagger progress) when a reveal ends or aborts. */
 	public synchronized void hardStop()
 	{
 		humPlayedThisReveal = false;
 		dealMotionSoundUpToIndex = -1;
 	}
 
+	/**
+	 * Plays the given resource at {@code gainDb}, logging and returning {@code false} if the resource is
+	 * missing or playback throws.
+	 */
 	private boolean playResource(String resourcePath, String logName, float gainDb)
 	{
 		if (PackRevealSoundService.class.getResource(resourcePath) == null)
@@ -152,6 +173,7 @@ public class PackRevealSoundService
 		}
 	}
 
+	/** Converts a 0..1 linear gain to decibels, clamping input to {@code [0, 1]} and flooring silence at -80dB. */
 	private static float linearGainToDb(float linear01)
 	{
 		float v = Math.max(0f, Math.min(1f, linear01));

--- a/src/main/java/com/osrstcg/pack/RevealCardResolver.java
+++ b/src/main/java/com/osrstcg/pack/RevealCardResolver.java
@@ -33,6 +33,7 @@ final class RevealCardResolver
 		this.cardDatabase = cardDatabase;
 	}
 
+	/** Rebuilds the card-name-to-rarity-tier lookup from the current catalog; call before resolving a reveal. */
 	void rebuildRarityTierIndex()
 	{
 		rarityTierByCardName.clear();
@@ -47,6 +48,7 @@ final class RevealCardResolver
 		}
 	}
 
+	/** Builds {@code count} face-down common placeholder cards shown while server pulls are pending. */
 	List<PackRevealService.RevealCard> createPlaceholderCards(int count)
 	{
 		if (count <= 0)
@@ -67,6 +69,11 @@ final class RevealCardResolver
 		return List.copyOf(out);
 	}
 
+	/**
+	 * Converts server pack pulls into {@link PackRevealService.RevealCard}s: resolves each pull against the
+	 * card catalog, materializes a display definition, resolves rarity tier, and flags cards not already
+	 * present in {@code preOwnedCards} as new. Pulls with a null card name are dropped.
+	 */
 	List<PackRevealService.RevealCard> resolveRevealCards(List<PackCardResult> pulls, Set<CardCollectionKey> preOwnedCards)
 	{
 		if (pulls == null || pulls.isEmpty())
@@ -114,6 +121,11 @@ final class RevealCardResolver
 		return tierForCard(catalogCardName);
 	}
 
+	/**
+	 * Builds the {@link CardDefinition} shown for a pull: starts from the local catalog entry when found
+	 * (falling back to a minimal definition otherwise), then overlays server-supplied image paths, artist
+	 * credit, examine text, wiki page, and score/tier for pulls carrying server data.
+	 */
 	private CardDefinition materializeRevealDefinition(PackCardResult pull, CardDefinition catalog)
 	{
 		CardDefinition definition = new CardDefinition();
@@ -201,6 +213,7 @@ final class RevealCardResolver
 		return definition;
 	}
 
+	/** Case-insensitive lookup of a catalog card by name. */
 	private Optional<CardDefinition> findCard(String name)
 	{
 		return cardDatabase.getCards().stream()
@@ -209,6 +222,7 @@ final class RevealCardResolver
 			.findFirst();
 	}
 
+	/** Looks up the local catalog display tier for a card name, defaulting to {@code COMMON} when unknown. */
 	private RarityMath.Tier tierForCard(String cardName)
 	{
 		if (cardName == null)
@@ -218,6 +232,7 @@ final class RevealCardResolver
 		return rarityTierByCardName.getOrDefault(cardName.toLowerCase(), RarityMath.Tier.COMMON);
 	}
 
+	/** Builds a case-insensitive, foil-aware dedup key for pre-owned-card comparisons. */
 	private static String normalizeKey(String cardName, boolean foil)
 	{
 		return (cardName == null ? "" : cardName.trim().toLowerCase()) + "|" + (foil ? "1" : "0");

--- a/src/main/java/com/osrstcg/party/TcgCollectionSetCompletePartyMessage.java
+++ b/src/main/java/com/osrstcg/party/TcgCollectionSetCompletePartyMessage.java
@@ -11,5 +11,6 @@ import net.runelite.client.party.messages.PartyMemberMessage;
 @EqualsAndHashCode(callSuper = false)
 public class TcgCollectionSetCompletePartyMessage extends PartyMemberMessage
 {
+	/** Display name of the completed collection/set. */
 	private String collectionName;
 }

--- a/src/main/java/com/osrstcg/party/TcgPartyAnnouncer.java
+++ b/src/main/java/com/osrstcg/party/TcgPartyAnnouncer.java
@@ -6,6 +6,7 @@ import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.party.PartyService;
 
+/** Broadcasts collection/set-completion events to the current RuneLite party. */
 @Slf4j
 @Singleton
 public class TcgPartyAnnouncer
@@ -13,6 +14,7 @@ public class TcgPartyAnnouncer
 	private final PartyService partyService;
 	private final OsrsTcgConfig config;
 
+	/** Wires the party service and config used to gate and send announcements. */
 	@Inject
 	public TcgPartyAnnouncer(PartyService partyService, OsrsTcgConfig config)
 	{
@@ -20,6 +22,10 @@ public class TcgPartyAnnouncer
 		this.config = config;
 	}
 
+	/**
+	 * Sends a {@link TcgCollectionSetCompletePartyMessage} to the party. No-op if party-announce is
+	 * disabled, the name is blank, or not currently in a party.
+	 */
 	public void announceSetComplete(String collectionDisplayName)
 	{
 		if (!config.partyAnnouncePulls())

--- a/src/main/java/com/osrstcg/party/TcgPartyInboundHandler.java
+++ b/src/main/java/com/osrstcg/party/TcgPartyInboundHandler.java
@@ -11,6 +11,10 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.party.PartyMember;
 import net.runelite.client.party.PartyService;
 
+/**
+ * Handles incoming party messages from other members (pulls, set completions) and turns them into
+ * local chat announcements. Ignores messages that originated from the local player.
+ */
 @Singleton
 public class TcgPartyInboundHandler
 {
@@ -19,6 +23,7 @@ public class TcgPartyInboundHandler
 	private final PartyService partyService;
 	private final ChatMessageManager chatMessageManager;
 
+	/** Wires config, the card database (for rarity color), the party service, and chat. */
 	@Inject
 	public TcgPartyInboundHandler(
 		OsrsTcgConfig config,
@@ -32,6 +37,10 @@ public class TcgPartyInboundHandler
 		this.chatMessageManager = chatMessageManager;
 	}
 
+	/**
+	 * Chats a "so-and-so added X to their collection" line for a party member's pull. No-op if
+	 * party-announce is off, the message/card name is blank, or the message came from the local player.
+	 */
 	public void onPull(TcgPullPartyMessage message)
 	{
 		if (!config.partyAnnouncePulls() || message == null)
@@ -57,6 +66,10 @@ public class TcgPartyInboundHandler
 		TcgPluginGameMessages.queueFormattedGameMessage(chatMessageManager, formatted, plain);
 	}
 
+	/**
+	 * Chats a "so-and-so just finished X!" line for a party member's set completion. No-op if
+	 * party-announce is off, the message/collection name is blank, or the message came from the local player.
+	 */
 	public void onCollectionSetComplete(TcgCollectionSetCompletePartyMessage message)
 	{
 		if (!config.partyAnnouncePulls() || message == null)
@@ -77,12 +90,14 @@ public class TcgPartyInboundHandler
 			String.format(Locale.US, "%s just finished %s!", who, collectionName.trim()));
 	}
 
+	/** True if {@code memberId} is the local player's own party member id. */
 	private boolean isLocalMember(long memberId)
 	{
 		PartyMember localMember = partyService.getLocalMember();
 		return localMember != null && memberId == localMember.getMemberId();
 	}
 
+	/** Resolves a party member's display name for chat, falling back to "A party member" if unknown/blank. */
 	private String displayName(long memberId)
 	{
 		PartyMember author = partyService.getMemberById(memberId);

--- a/src/main/java/com/osrstcg/party/TcgPullPartyMessage.java
+++ b/src/main/java/com/osrstcg/party/TcgPullPartyMessage.java
@@ -4,11 +4,18 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import net.runelite.client.party.messages.PartyMemberMessage;
 
+/**
+ * Party websocket payload: a party member pulled a card, for the other members' inbound handlers
+ * to chat as a collection-add announcement.
+ */
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class TcgPullPartyMessage extends PartyMemberMessage
 {
+	/** Display name of the pulled card. */
 	private String cardName;
+	/** True if this was a new card for the puller's collection, false if a duplicate. */
 	private boolean newForCollection;
+	/** True if the pulled copy is foil. */
 	private boolean foil;
 }

--- a/src/main/java/com/osrstcg/persist/TcgSaveTrigger.java
+++ b/src/main/java/com/osrstcg/persist/TcgSaveTrigger.java
@@ -3,9 +3,14 @@ package com.osrstcg.persist;
 /** Reason for a local {@code tcg.save} write. */
 public enum TcgSaveTrigger
 {
+	/** Triggered by {@code ::tcg-reset}. */
 	RESET,
+	/** Player logged out. */
 	LOGOUT,
+	/** Client is shutting down. */
 	CLIENT_SHUTDOWN,
+	/** Plugin was disabled/unloaded. */
 	PLUGIN_UNLOAD,
+	/** Explicit save not tied to a lifecycle event. */
 	MANUAL
 }

--- a/src/main/java/com/osrstcg/persist/TcgStateCodec.java
+++ b/src/main/java/com/osrstcg/persist/TcgStateCodec.java
@@ -20,18 +20,24 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Converts between {@link TcgState} and its JSON save-file representation (schema versioning,
+ * legacy field migration, and null/default coercion on load and save).
+ */
 @Singleton
 @Slf4j
 public class TcgStateCodec
 {
 	private final Gson gson;
 
+	/** Stores the Gson instance used for (de)serialization. */
 	@Inject
 	public TcgStateCodec(Gson gson)
 	{
 		this.gson = gson;
 	}
 
+	/** Parses raw save JSON into a {@link TcgState}, returning empty on blank input or malformed JSON. */
 	public Optional<TcgState> tryFromJson(String rawState)
 	{
 		try
@@ -57,11 +63,13 @@ public class TcgStateCodec
 		}
 	}
 
+	/** Same as {@link #tryFromJson} but returns {@link TcgState#empty()} instead of an empty {@link Optional}. */
 	public TcgState fromJson(String rawState)
 	{
 		return tryFromJson(rawState).orElseGet(TcgState::empty);
 	}
 
+	/** Builds a {@link TcgState} from a deserialized {@link SerializedState}, clamping/defaulting each field. */
 	private TcgState parseSerializedState(SerializedState stored)
 	{
 		List<OwnedCardInstance> rows = parseCollectionRows(stored);
@@ -101,6 +109,7 @@ public class TcgStateCodec
 		);
 	}
 
+	/** Prefers the current {@code cardEntries} format, falling back to the legacy {@code cardInstances} list. */
 	private static List<OwnedCardInstance> parseCollectionRows(SerializedState stored)
 	{
 		if (stored.cardEntries != null && !stored.cardEntries.isEmpty())
@@ -110,6 +119,7 @@ public class TcgStateCodec
 		return parseLegacyCardInstances(stored.cardInstances);
 	}
 
+	/** Converts pre-{@code cardEntries} per-instance rows into {@link OwnedCardInstance}s, skipping unnamed entries. */
 	private static List<OwnedCardInstance> parseLegacyCardInstances(List<SerializedInstance> cardInstances)
 	{
 		List<OwnedCardInstance> rows = new ArrayList<>();
@@ -132,6 +142,7 @@ public class TcgStateCodec
 		return rows;
 	}
 
+	/** Serializes a {@link TcgState} (or {@link TcgState#empty()} if null) to save-file JSON via {@link SerializedState}. */
 	public String toJson(TcgState state)
 	{
 		TcgState s = Objects.requireNonNullElse(state, TcgState.empty());
@@ -164,6 +175,10 @@ public class TcgStateCodec
 		return gson.toJson(serialized);
 	}
 
+	/**
+	 * Parses a stored skill-credit baseline, migrating the legacy single {@code uncreditedXp} remainder
+	 * (dropped with a warning, since it can't be attributed to a specific skill) to the per-skill map.
+	 */
 	private static SkillCreditBaseline parseSkillCreditBaseline(SerializedSkillCreditBaseline stored)
 	{
 		if (stored == null)
@@ -217,6 +232,7 @@ public class TcgStateCodec
 		return SkillCreditBaseline.of(xp, uncreditedBySkill);
 	}
 
+	/** Converts a {@link SkillCreditBaseline} to its serialized form, writing empty maps when absent. */
 	private static SerializedSkillCreditBaseline serializeSkillCreditBaseline(SkillCreditBaseline baseline)
 	{
 		SkillCreditBaseline b = baseline == null ? SkillCreditBaseline.absent() : baseline;
@@ -233,6 +249,7 @@ public class TcgStateCodec
 		return out;
 	}
 
+	/** Gson-mapped shape of the on-disk save JSON; field names are the wire format. */
 	private static class SerializedState
 	{
 		private int schemaVersion = TcgState.CURRENT_SCHEMA_VERSION;
@@ -250,6 +267,7 @@ public class TcgStateCodec
 		private int[] sidebarRanks;
 	}
 
+	/** Gson-mapped shape of the serialized skill-credit baseline, including the legacy {@code uncreditedXp} field. */
 	private static class SerializedSkillCreditBaseline
 	{
 		private Map<String, Integer> skillXp;
@@ -257,6 +275,7 @@ public class TcgStateCodec
 		private Long uncreditedXp;
 	}
 
+	/** Gson-mapped shape of a legacy pre-{@code cardEntries} per-instance row. */
 	private static class SerializedInstance
 	{
 		private String id;

--- a/src/main/java/com/osrstcg/persist/TcgStateFileBackupStore.java
+++ b/src/main/java/com/osrstcg/persist/TcgStateFileBackupStore.java
@@ -16,6 +16,11 @@ import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 
+/**
+ * Reads and writes the per-account {@code tcg.save} file on disk: resolves the account's save
+ * directory, and performs atomic, hash-verified writes and best-effort reads. All I/O here is
+ * blocking and must be called off the client thread.
+ */
 @Singleton
 @Slf4j
 public class TcgStateFileBackupStore
@@ -28,6 +33,7 @@ public class TcgStateFileBackupStore
 	private final TcgStateCodec stateCodec;
 	private volatile long lastKnownAccountHash = -1L;
 
+	/** Stores the RuneLite client (for account hash lookups) and the state codec used to parse loaded saves. */
 	@Inject
 	public TcgStateFileBackupStore(
 		Client client,
@@ -37,6 +43,7 @@ public class TcgStateFileBackupStore
 		this.stateCodec = stateCodec;
 	}
 
+	/** Atomically writes {@code encodedBlob} to {@value #MASTER_FILENAME} in the current account's save directory. */
 	public boolean writeMaster(String encodedBlob)
 	{
 		if (encodedBlob == null || encodedBlob.isEmpty())
@@ -48,6 +55,7 @@ public class TcgStateFileBackupStore
 		return writeMasterFile(encodedBlob, hashHex);
 	}
 
+	/** Reads and decodes {@value #MASTER_FILENAME} from the current account's save directory, if present and valid. */
 	public Optional<TcgState> loadMaster()
 	{
 		Path dir = saveDirectory();
@@ -58,6 +66,7 @@ public class TcgStateFileBackupStore
 		return tryLoadEncodedFile(dir.resolve(MASTER_FILENAME));
 	}
 
+	/** Returns the client's current account hash, or the last known one if logged out (-1). */
 	long resolveAccountHashForIo()
 	{
 		long hash = client.getAccountHash();
@@ -69,26 +78,34 @@ public class TcgStateFileBackupStore
 		return lastKnownAccountHash;
 	}
 
+	/** Hashed directory name for the current account, as used under {@link #profilesRoot()}. */
 	public String currentAccountDirName()
 	{
 		return ProfileKeyHasher.accountDirName(resolveAccountHashForIo());
 	}
 
+	/** Root directory containing one subdirectory per account. */
 	Path profilesRoot()
 	{
 		return ProfileKeyHasher.profilesRoot();
 	}
 
+	/** Root directory for legacy per-account backup subdirectories, kept for old save layouts. */
 	Path legacyBackupsRoot()
 	{
 		return ProfileKeyHasher.tcgRoot().resolve("backups");
 	}
 
+	/** Save directory for the current account. */
 	Path saveDirectory()
 	{
 		return saveDirectory(null);
 	}
 
+	/**
+	 * Save directory for {@code accountDirId}, or the current account's when null/blank.
+	 * Returns null when {@code accountDirId} doesn't resolve to a valid directory name.
+	 */
 	Path saveDirectory(String accountDirId)
 	{
 		String dirName = resolveAccountDirName(accountDirId);
@@ -102,6 +119,10 @@ public class TcgStateFileBackupStore
 		return root.resolve(dirName);
 	}
 
+	/**
+	 * Resolves {@code accountDirId} to a validated directory name: current account when null/blank,
+	 * the legacy "default" directory verbatim, or a lowercased 64-hex-char account hash; else null.
+	 */
 	String resolveAccountDirName(String accountDirId)
 	{
 		if (accountDirId == null || accountDirId.isBlank())
@@ -120,6 +141,11 @@ public class TcgStateFileBackupStore
 		return trimmed.toLowerCase(Locale.ROOT);
 	}
 
+	/**
+	 * Writes {@code encodedBlob} to a temp file in the save directory, verifies it hashes to
+	 * {@code expectedHash} by reading it back, then atomically renames it onto {@value #MASTER_FILENAME}.
+	 * The temp file is always removed afterwards.
+	 */
 	private boolean writeMasterFile(String encodedBlob, String expectedHash)
 	{
 		try
@@ -162,6 +188,7 @@ public class TcgStateFileBackupStore
 		}
 	}
 
+	/** Reads {@code file}, hash-validates and decodes its contents, and parses it into a {@link TcgState}. */
 	private Optional<TcgState> tryLoadEncodedFile(Path file)
 	{
 		if (file == null || !Files.isRegularFile(file))
@@ -186,6 +213,7 @@ public class TcgStateFileBackupStore
 		}
 	}
 
+	/** Checks {@code encoded}'s hash against {@code expectedHash} (when given) and that it parses into a state. */
 	private boolean validateMasterContent(String encoded, String expectedHash)
 	{
 		if (expectedHash != null && !expectedHash.equalsIgnoreCase(TcgStateHash.hexOfUtf8(encoded)))
@@ -195,6 +223,7 @@ public class TcgStateFileBackupStore
 		return tryParseEncodedBlob(encoded).isPresent();
 	}
 
+	/** Decodes the storage blob to JSON via {@link TcgStateStorageEncoding} and parses it with {@link #stateCodec}. */
 	private Optional<TcgState> tryParseEncodedBlob(String encoded)
 	{
 		String json = TcgStateStorageEncoding.decode(encoded);

--- a/src/main/java/com/osrstcg/persist/TcgStateHash.java
+++ b/src/main/java/com/osrstcg/persist/TcgStateHash.java
@@ -4,12 +4,14 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+/** SHA-256 hashing helper used to verify save-file writes/reads round-trip correctly. */
 public final class TcgStateHash
 {
 	private TcgStateHash()
 	{
 	}
 
+	/** Returns the lowercase hex SHA-256 digest of {@code s} (treated as UTF-8; null treated as empty). */
 	public static String hexOfUtf8(String s)
 	{
 		String input = s == null ? "" : s;

--- a/src/main/java/com/osrstcg/persist/TcgStateLoadResult.java
+++ b/src/main/java/com/osrstcg/persist/TcgStateLoadResult.java
@@ -2,22 +2,26 @@ package com.osrstcg.persist;
 
 import com.osrstcg.state.TcgState;
 
+/** Result of a {@link TcgStateStore#load()} call: the resolved state plus where it came from. */
 public final class TcgStateLoadResult
 {
 	private final TcgState state;
 	private final TcgStateLoadSource source;
 
+	/** Defaults null {@code state}/{@code source} to {@link TcgState#empty()} and {@link TcgStateLoadSource#EMPTY}. */
 	public TcgStateLoadResult(TcgState state, TcgStateLoadSource source)
 	{
 		this.state = state == null ? TcgState.empty() : state;
 		this.source = source == null ? TcgStateLoadSource.EMPTY : source;
 	}
 
+	/** The loaded (or empty default) state. */
 	public TcgState getState()
 	{
 		return state;
 	}
 
+	/** Where {@link #getState()} was loaded from. */
 	public TcgStateLoadSource getSource()
 	{
 		return source;

--- a/src/main/java/com/osrstcg/persist/TcgStateLoadSource.java
+++ b/src/main/java/com/osrstcg/persist/TcgStateLoadSource.java
@@ -1,7 +1,10 @@
 package com.osrstcg.persist;
 
+/** Where a loaded {@link TcgState} came from. */
 public enum TcgStateLoadSource
 {
+	/** Loaded from the on-disk {@code tcg.save} file. */
 	DISK,
+	/** No valid save was found; an empty default state was used. */
 	EMPTY
 }

--- a/src/main/java/com/osrstcg/persist/TcgStateStorageEncoding.java
+++ b/src/main/java/com/osrstcg/persist/TcgStateStorageEncoding.java
@@ -31,6 +31,7 @@ public final class TcgStateStorageEncoding
 	{
 	}
 
+	/** Gzip-compresses (fastest level) and Base64-encodes {@code plainJson} with the {@code RLTCG_v3:} prefix. */
 	public static String encode(String plainJson)
 	{
 		try
@@ -46,6 +47,11 @@ public final class TcgStateStorageEncoding
 		}
 	}
 
+	/**
+	 * Decodes a {@code RLTCG_v3:} or legacy {@code RLTCG_v2:} blob back to plain JSON (v2 additionally
+	 * XOR-decrypted with {@link #XOR_SALT} before gzip decompression). Returns empty on blank input or
+	 * any decode failure.
+	 */
 	public static String decode(String stored)
 	{
 		String s = Objects.requireNonNullElse(stored, "");
@@ -75,6 +81,7 @@ public final class TcgStateStorageEncoding
 		}
 	}
 
+	/** Gzip-compresses {@code input} using {@link FastGzipOutputStream} (best-speed deflate level). */
 	private static byte[] gzipCompress(byte[] input) throws IOException
 	{
 		ByteArrayOutputStream baos = new ByteArrayOutputStream(Math.max(256, input.length / 3 + 64));
@@ -85,6 +92,7 @@ public final class TcgStateStorageEncoding
 		return baos.toByteArray();
 	}
 
+	/** Gzip-decompresses {@code compressed} into a UTF-8 string. */
 	private static String gzipDecompress(byte[] compressed) throws IOException
 	{
 		try (GZIPInputStream gzis = new GZIPInputStream(new ByteArrayInputStream(compressed)))
@@ -93,6 +101,7 @@ public final class TcgStateStorageEncoding
 		}
 	}
 
+	/** XORs {@code data} in place with the repeating {@link #XOR_SALT} (used only for legacy v2 blobs). */
 	private static void xorWithSalt(byte[] data)
 	{
 		for (int i = 0; i < data.length; i++)
@@ -101,8 +110,10 @@ public final class TcgStateStorageEncoding
 		}
 	}
 
+	/** {@link GZIPOutputStream} forced to {@link Deflater#BEST_SPEED} to keep save writes fast. */
 	private static final class FastGzipOutputStream extends GZIPOutputStream
 	{
+		/** Wraps {@code out} and lowers the deflate level to best-speed. */
 		private FastGzipOutputStream(ByteArrayOutputStream out) throws IOException
 		{
 			super(out);

--- a/src/main/java/com/osrstcg/persist/TcgStateStore.java
+++ b/src/main/java/com/osrstcg/persist/TcgStateStore.java
@@ -6,6 +6,10 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Facade over {@link TcgStateFileBackupStore} for loading and saving {@link TcgState}: encodes/decodes
+ * via {@link TcgStateCodec} and {@link TcgStateStorageEncoding} on top of the raw file I/O.
+ */
 @Singleton
 @Slf4j
 public class TcgStateStore
@@ -13,6 +17,7 @@ public class TcgStateStore
 	private final TcgStateCodec stateCodec;
 	private final TcgStateFileBackupStore fileBackupStore;
 
+	/** Stores the codec and backup store used for all loads/saves. */
 	@Inject
 	public TcgStateStore(
 		TcgStateCodec stateCodec,
@@ -22,6 +27,7 @@ public class TcgStateStore
 		this.fileBackupStore = fileBackupStore;
 	}
 
+	/** Test-only constructor with no backup store; loads return empty and saves no-op. */
 	TcgStateStore(TcgStateCodec stateCodec)
 	{
 		this(stateCodec, null);
@@ -38,6 +44,7 @@ public class TcgStateStore
 		return new TcgStateLoadResult(TcgState.empty(), TcgStateLoadSource.EMPTY);
 	}
 
+	/** Loads {@code tcg.save} directly, without the {@link TcgStateLoadResult} wrapper. Empty if none/invalid. */
 	public Optional<TcgState> loadMaster()
 	{
 		if (fileBackupStore == null)
@@ -47,16 +54,23 @@ public class TcgStateStore
 		return fileBackupStore.loadMaster();
 	}
 
+	/** Saves {@code state}, defaulting a null {@code trigger} to {@link TcgSaveTrigger#LOGOUT}. */
 	public boolean saveFullCheckpoint(TcgState state, TcgSaveTrigger trigger)
 	{
 		return writeMaster(state, trigger == null ? TcgSaveTrigger.LOGOUT : trigger);
 	}
 
+	/** Saves {@code state}, defaulting a null {@code trigger} to {@link TcgSaveTrigger#MANUAL}. */
 	public boolean saveCheckpoint(TcgState state, TcgSaveTrigger trigger)
 	{
 		return writeMaster(state, trigger == null ? TcgSaveTrigger.MANUAL : trigger);
 	}
 
+	/**
+	 * Encodes {@code state} to JSON then to the on-disk storage format and hands it to the file backup
+	 * store to write. Fails (without touching disk) if {@code state} is null, there is no backup store,
+	 * or encoding produces an empty payload.
+	 */
 	private boolean writeMaster(TcgState state, TcgSaveTrigger trigger)
 	{
 		if (state == null || fileBackupStore == null)

--- a/src/main/java/com/osrstcg/state/CardCollectionKey.java
+++ b/src/main/java/com/osrstcg/state/CardCollectionKey.java
@@ -2,27 +2,35 @@ package com.osrstcg.state;
 
 import java.util.Objects;
 
+/**
+ * Identity key for aggregating owned card counts: card name plus foil flag. Used as the map key
+ * in {@link CollectionState#getOwnedCards()}.
+ */
 public final class CardCollectionKey
 {
 	private final String cardName;
 	private final boolean foil;
 
+	/** Normalizes a null card name to empty string. */
 	public CardCollectionKey(String cardName, boolean foil)
 	{
 		this.cardName = cardName == null ? "" : cardName;
 		this.foil = foil;
 	}
 
+	/** Returns the card name (never null). */
 	public String getCardName()
 	{
 		return cardName;
 	}
 
+	/** Returns whether this key represents the foil variant of the card. */
 	public boolean isFoil()
 	{
 		return foil;
 	}
 
+	/** Equal when card name and foil flag both match. */
 	@Override
 	public boolean equals(Object o)
 	{

--- a/src/main/java/com/osrstcg/state/CardEntry.java
+++ b/src/main/java/com/osrstcg/state/CardEntry.java
@@ -2,8 +2,13 @@ package com.osrstcg.state;
 
 import java.util.List;
 
+/**
+ * One card's grouped owned copies, keyed by name, for profile save and web share JSON. Built and
+ * expanded via {@link CardEntrySerializer}.
+ */
 public final class CardEntry
 {
 	public String cardName;
+	/** Owned copies of this card (each entry is one physical/foil variant instance or legacy quantity group). */
 	public List<CardVariant> variants;
 }

--- a/src/main/java/com/osrstcg/state/CardEntrySerializer.java
+++ b/src/main/java/com/osrstcg/state/CardEntrySerializer.java
@@ -13,11 +13,18 @@ public final class CardEntrySerializer
 	{
 	}
 
+	/** Groups instances into {@link CardEntry} rows for profile/web-share persistence. */
 	public static List<CardEntry> buildProfileEntries(List<OwnedCardInstance> instances)
 	{
 		return buildEntries(instances);
 	}
 
+	/**
+	 * Reverses {@link #buildProfileEntries}: expands each {@link CardVariant} back into one or more
+	 * {@link OwnedCardInstance} rows, honoring the legacy {@code quantity} field by repeating the
+	 * variant (only the first repeated row keeps the original instance id). Null/invalid entries and
+	 * variants are skipped; zero-or-negative quantities are dropped.
+	 */
 	public static List<OwnedCardInstance> expandToInstances(List<CardEntry> entries)
 	{
 		List<OwnedCardInstance> rows = new ArrayList<>();
@@ -57,6 +64,10 @@ public final class CardEntrySerializer
 		return rows;
 	}
 
+	/**
+	 * Filters out invalid instances, sorts them by name/foil/pulled-at/pulled-by for stable output,
+	 * then groups by card name into {@link CardEntry} rows with variants sorted the same way.
+	 */
 	private static List<CardEntry> buildEntries(List<OwnedCardInstance> instances)
 	{
 		if (instances == null || instances.isEmpty())
@@ -121,6 +132,7 @@ public final class CardEntrySerializer
 		return new ArrayList<>(byName.values());
 	}
 
+	/** Returns whether a variant is marked foil (treats null/absent as non-foil). */
 	private static boolean isFoil(CardVariant variant)
 	{
 		return variant != null && Boolean.TRUE.equals(variant.foil);

--- a/src/main/java/com/osrstcg/state/CardVariant.java
+++ b/src/main/java/com/osrstcg/state/CardVariant.java
@@ -9,7 +9,9 @@ public final class CardVariant
 	public String id;
 	/** Omitted when false; absent or null means normal. */
 	public Boolean foil;
+	/** RSN of the player who pulled this copy, when known. */
 	public String pulledBy;
+	/** Epoch millis when this copy was pulled, when known. */
 	public Long pulledAt;
 	/** Legacy profile save: expanded on load when present. */
 	public Integer quantity;

--- a/src/main/java/com/osrstcg/state/CloudSidebarCollectionStats.java
+++ b/src/main/java/com/osrstcg/state/CloudSidebarCollectionStats.java
@@ -7,6 +7,11 @@ import java.util.List;
 import java.util.Map;
 import lombok.Value;
 
+/**
+ * Collection overview counters shown in the sidebar (unique/foil/total owned, completion, score).
+ * Immutable; instances are either parsed from server JSON or derived locally via the {@code with*}/{@code
+ * fromStatsJson} factories.
+ */
 @Value
 public class CloudSidebarCollectionStats
 {
@@ -19,6 +24,7 @@ public class CloudSidebarCollectionStats
 	double foilCompletionPct;
 	long collectionScore;
 
+	/** Parses a collection overview payload, tolerating either canonical or legacy alias field names. */
 	public static CloudSidebarCollectionStats fromStatsJson(JsonObject stats)
 	{
 		if (stats == null)
@@ -62,6 +68,11 @@ public class CloudSidebarCollectionStats
 			|| stats.has("collectionScore");
 	}
 
+	/**
+	 * Applies pack pulls on top of a base overview before the server confirms them, so the sidebar updates
+	 * immediately. {@code ownedBefore} is the pre-pull owned quantities keyed by name/foil; used to detect
+	 * newly-unique names and foil upgrades.
+	 */
 	public static CloudSidebarCollectionStats withOptimisticPackPulls(
 		CloudSidebarCollectionStats base,
 		Map<CardCollectionKey, Integer> ownedBefore,
@@ -129,6 +140,7 @@ public class CloudSidebarCollectionStats
 			Math.max(0L, collectionScore));
 	}
 
+	/** True when the four raw ownership counts match between a server and a local overview (null-safe: true if either is null). */
 	public static boolean countsAgree(CloudSidebarCollectionStats server, CloudSidebarCollectionStats local)
 	{
 		if (server == null || local == null)
@@ -141,11 +153,13 @@ public class CloudSidebarCollectionStats
 			&& server.getFoilOwned() == local.getFoilOwned();
 	}
 
+	/** Total owned quantity of a card name across both foil and non-foil variants. */
 	private static int qtyByName(Map<CardCollectionKey, Integer> owned, String cardName)
 	{
 		return qty(owned, cardName, false) + qty(owned, cardName, true);
 	}
 
+	/** Owned quantity for one name/foil key; 0 if absent or the map/name is null. */
 	private static int qty(Map<CardCollectionKey, Integer> owned, String cardName, boolean foil)
 	{
 		if (owned == null || cardName == null)

--- a/src/main/java/com/osrstcg/state/CollectionState.java
+++ b/src/main/java/com/osrstcg/state/CollectionState.java
@@ -7,11 +7,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * Immutable snapshot of a player's owned card collection: the per-copy instance list plus a
+ * precomputed name+foil quantity aggregate. Every mutation method returns a new instance.
+ */
 public final class CollectionState
 {
 	private final List<OwnedCardInstance> instances;
 	private final Map<CardCollectionKey, Integer> ownedCards;
 
+	/** Filters out null/nameless instances, then aggregates quantities including beta copies. */
 	private CollectionState(List<OwnedCardInstance> instances)
 	{
 		List<OwnedCardInstance> copy = new ArrayList<>();
@@ -29,37 +34,47 @@ public final class CollectionState
 		this.ownedCards = Collections.unmodifiableMap(aggregateQuantities(copy, false));
 	}
 
+	/** Trusts both arguments as already-filtered/aggregated; used internally to avoid recomputation. */
 	private CollectionState(List<OwnedCardInstance> instances, Map<CardCollectionKey, Integer> ownedCards)
 	{
 		this.instances = Collections.unmodifiableList(instances);
 		this.ownedCards = Collections.unmodifiableMap(ownedCards);
 	}
 
+	/** Returns a state with no owned cards. */
 	public static CollectionState empty()
 	{
 		return new CollectionState(List.of());
 	}
 
+	/** Builds a state from a raw instance list, filtering invalid entries and aggregating quantities. */
 	public static CollectionState copyOf(List<OwnedCardInstance> instances)
 	{
 		return new CollectionState(instances);
 	}
 
+	/** Returns the unmodifiable list of owned card instances. */
 	public List<OwnedCardInstance> getOwnedInstances()
 	{
 		return instances;
 	}
 
+	/** Returns owned quantities aggregated by name+foil, including beta copies. */
 	public Map<CardCollectionKey, Integer> getOwnedCards()
 	{
 		return ownedCards;
 	}
 
+	/** Recomputes owned quantities aggregated by name+foil, excluding beta copies. */
 	public Map<CardCollectionKey, Integer> getOwnedCardsExcludingBeta()
 	{
 		return aggregateQuantities(instances, true);
 	}
 
+	/**
+	 * Returns a new state with {@code toAdd} appended, after filtering invalid entries. Returns
+	 * {@code this} unchanged if there is nothing valid to add.
+	 */
 	public CollectionState withInstancesAdded(List<OwnedCardInstance> toAdd)
 	{
 		if (toAdd == null || toAdd.isEmpty())
@@ -89,6 +104,7 @@ public final class CollectionState
 		return new CollectionState(next, nextOwned);
 	}
 
+	/** Counts instances per {@link CardCollectionKey}, optionally skipping beta copies and null entries. */
 	private static Map<CardCollectionKey, Integer> aggregateQuantities(
 		List<OwnedCardInstance> list,
 		boolean excludeBeta)
@@ -106,6 +122,7 @@ public final class CollectionState
 		return map;
 	}
 
+	/** Equal when the owned instance lists are equal; the derived {@link #ownedCards} map is not compared. */
 	@Override
 	public boolean equals(Object o)
 	{

--- a/src/main/java/com/osrstcg/state/EconomyState.java
+++ b/src/main/java/com/osrstcg/state/EconomyState.java
@@ -1,26 +1,31 @@
 package com.osrstcg.state;
 
+/** Immutable snapshot of a player's credit balance and lifetime pack-open count. */
 public final class EconomyState
 {
 	private final long credits;
 	private final long openedPacks;
 
+	/** Clamps both values to non-negative. */
 	public EconomyState(long credits, long openedPacks)
 	{
 		this.credits = Math.max(0L, credits);
 		this.openedPacks = Math.max(0L, openedPacks);
 	}
 
+	/** Returns a zero-credits, zero-packs state. */
 	public static EconomyState empty()
 	{
 		return new EconomyState(0L, 0L);
 	}
 
+	/** Returns the current credit balance. */
 	public long getCredits()
 	{
 		return credits;
 	}
 
+	/** Returns the total number of packs opened. */
 	public long getOpenedPacks()
 	{
 		return openedPacks;

--- a/src/main/java/com/osrstcg/state/OptimisticCreditBuffer.java
+++ b/src/main/java/com/osrstcg/state/OptimisticCreditBuffer.java
@@ -8,16 +8,19 @@ final class OptimisticCreditBuffer
 {
 	private long pending;
 
+	/** Returns the currently pending (unacked) optimistic credit amount. */
 	long get()
 	{
 		return pending;
 	}
 
+	/** Resets the pending amount to zero. */
 	void clear()
 	{
 		pending = 0L;
 	}
 
+	/** Adds an optimistic credit gain; non-positive amounts are ignored. */
 	void add(long amount)
 	{
 		if (amount > 0L)
@@ -26,6 +29,7 @@ final class OptimisticCreditBuffer
 		}
 	}
 
+	/** Removes a now-acked amount from the pending total, floored at zero. */
 	void clearAmount(long amount)
 	{
 		if (amount <= 0L || pending <= 0L)

--- a/src/main/java/com/osrstcg/state/OwnedCardInstance.java
+++ b/src/main/java/com/osrstcg/state/OwnedCardInstance.java
@@ -4,6 +4,11 @@ import java.util.Objects;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * One physical owned copy of a card, tracked individually (rather than as a bare quantity) so
+ * pull attribution/timestamp and foil/beta status survive per-copy. Identity is by
+ * {@link #instanceId} alone.
+ */
 @Getter
 public final class OwnedCardInstance
 {
@@ -14,12 +19,14 @@ public final class OwnedCardInstance
 	private final long pulledAtEpochMs;
 	private final boolean beta;
 
+	/** Non-beta convenience overload; delegates with {@code beta = false}. */
 	public OwnedCardInstance(String instanceId, String cardName, boolean foil, String pulledByUsername,
 		long pulledAtEpochMs)
 	{
 		this(instanceId, cardName, foil, pulledByUsername, pulledAtEpochMs, false);
 	}
 
+	/** Generates a random {@code instanceId} when null/empty; normalizes other fields to non-null/non-negative. */
 	public OwnedCardInstance(String instanceId, String cardName, boolean foil, String pulledByUsername,
 		long pulledAtEpochMs, boolean beta)
 	{
@@ -33,6 +40,7 @@ public final class OwnedCardInstance
 		this.beta = beta;
 	}
 
+	/** Equal when {@link #instanceId} matches; other fields are not compared. */
 	@Override
 	public boolean equals(Object o)
 	{

--- a/src/main/java/com/osrstcg/state/PackCardResult.java
+++ b/src/main/java/com/osrstcg/state/PackCardResult.java
@@ -3,6 +3,7 @@ package com.osrstcg.state;
 import com.osrstcg.cloud.api.JsonObjects;
 import lombok.Getter;
 
+/** One card pulled from a booster pack, with its foil/tier/scoring/artist metadata and provenance. */
 @Getter
 public class PackCardResult
 {
@@ -23,11 +24,13 @@ public class PackCardResult
 	private final Long pulledAtEpochMs;
 	private final String wikiPage;
 
+	/** Minimal pull with just name and foil flag; all other fields default to null/zero. */
 	public PackCardResult(String cardName, boolean foil)
 	{
 		this(cardName, foil, null, null, 0L, null, null, null, null, null, null, null, null, null, null, null);
 	}
 
+	/** Full pull with server-provided metadata; blank strings are normalized to null. */
 	public PackCardResult(
 		String cardName,
 		boolean foil,
@@ -64,6 +67,7 @@ public class PackCardResult
 		this.wikiPage = JsonObjects.blankToNull(wikiPage);
 	}
 
+	/** Returns a copy of this pull with who/when it was pulled filled in. */
 	public PackCardResult withProvenance(String pulledBy, long pulledAtEpochMs)
 	{
 		return new PackCardResult(
@@ -85,6 +89,7 @@ public class PackCardResult
 			displayName);
 	}
 
+	/** Normalizes line endings and trims; returns null for blank/null input. */
 	private static String normalizeExamine(String value)
 	{
 		if (value == null)
@@ -96,6 +101,7 @@ public class PackCardResult
 		return trimmed.isEmpty() ? null : trimmed;
 	}
 
+	/** True when the server assigned a non-blank display tier for this pull. */
 	public boolean hasServerTier()
 	{
 		return tierLabel != null && !tierLabel.isBlank();

--- a/src/main/java/com/osrstcg/state/PackOpenResult.java
+++ b/src/main/java/com/osrstcg/state/PackOpenResult.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import lombok.Value;
 
+/** Outcome of one pack-open request: credits before/after, price, and the pulled cards (or a failure message). */
 @Value
 public class PackOpenResult
 {
@@ -19,12 +20,14 @@ public class PackOpenResult
 	/** True when pulls used apex rules (top three display tiers + boosted foils). */
 	boolean apexPack;
 
+	/** Builds a failure result; credits are unchanged and there are no pulls. */
 	public static PackOpenResult failed(String message, long creditsBefore, int packPrice)
 	{
 		return new PackOpenResult(false, message, creditsBefore, creditsBefore, packPrice,
 			Collections.emptyList(), null, null, false);
 	}
 
+	/** Builds a success result with the given pulls; a null pulls list is normalized to empty. */
 	public static PackOpenResult succeeded(String message, long creditsBefore, long creditsAfter, int packPrice,
 		List<PackCardResult> pulls, String boosterDisplayName, String boosterPackId, boolean apexPack)
 	{

--- a/src/main/java/com/osrstcg/state/SkillCreditBaseline.java
+++ b/src/main/java/com/osrstcg/state/SkillCreditBaseline.java
@@ -7,6 +7,12 @@ import java.util.Objects;
 import java.util.OptionalLong;
 import net.runelite.api.Skill;
 
+/**
+ * Immutable snapshot of a player's per-skill XP totals (and any not-yet-credited XP remainder per skill)
+ * captured as the reference point for awarding future skill-XP credits. Distinguishes "no baseline saved
+ * yet" ({@link #missing()}) from "baseline saved but empty" ({@link #absent()}) so callers know whether a
+ * profile-save schema upgrade is needed.
+ */
 public final class SkillCreditBaseline
 {
 	private static final SkillCreditBaseline MISSING = new SkillCreditBaseline(Kind.MISSING, Map.of(), Map.of());
@@ -30,16 +36,23 @@ public final class SkillCreditBaseline
 		this.uncreditedXpBySkill = uncreditedXpBySkill;
 	}
 
+	/** No baseline has been persisted yet for this profile; the caller should upgrade the save schema. */
 	public static SkillCreditBaseline missing()
 	{
 		return MISSING;
 	}
 
+	/** Baseline was persisted but has no skill XP recorded (e.g. player has no tracked skills). */
 	public static SkillCreditBaseline absent()
 	{
 		return ABSENT;
 	}
 
+	/**
+	 * Builds a present baseline from raw skill-XP and uncredited-remainder maps, discarding null/blank
+	 * keys and clamping values to non-negative. Falls back to {@link #absent()} when the XP map is empty
+	 * after filtering.
+	 */
 	public static SkillCreditBaseline of(Map<String, Integer> skillXpByName, Map<String, Long> uncreditedXpBySkill)
 	{
 		Map<String, Integer> xpCopy = new LinkedHashMap<>();
@@ -62,6 +75,7 @@ public final class SkillCreditBaseline
 		return new SkillCreditBaseline(Kind.PRESENT, Collections.unmodifiableMap(xpCopy), uncreditedCopy);
 	}
 
+	/** Builds a present baseline from the RuneLite client's raw per-skill XP array, indexed by {@link Skill#values()}. */
 	public static SkillCreditBaseline fromClientExperiences(int[] experiences, Map<String, Long> uncreditedXpBySkill)
 	{
 		Map<String, Integer> byName = new LinkedHashMap<>();
@@ -79,6 +93,7 @@ public final class SkillCreditBaseline
 		return of(byName, uncreditedXpBySkill);
 	}
 
+	/** Copies the uncredited-XP map, dropping null/blank keys, null values, and non-positive remainders. */
 	private static Map<String, Long> copyUncreditedXpBySkill(Map<String, Long> uncreditedXpBySkill)
 	{
 		Map<String, Long> copy = new LinkedHashMap<>();
@@ -101,26 +116,31 @@ public final class SkillCreditBaseline
 		return Collections.unmodifiableMap(copy);
 	}
 
+	/** True when this baseline has recorded skill XP (as opposed to {@link #missing()} or {@link #absent()}). */
 	public boolean isPresent()
 	{
 		return kind == Kind.PRESENT;
 	}
 
+	/** True when this is a {@link #missing()} baseline and the profile save should be upgraded to persist one. */
 	public boolean needsSchemaUpgradePersist()
 	{
 		return kind == Kind.MISSING;
 	}
 
+	/** Returns the uncredited XP remainder per skill name (unmodifiable). */
 	public Map<String, Long> getUncreditedXpBySkill()
 	{
 		return uncreditedXpBySkill;
 	}
 
+	/** Returns the baseline XP per skill name (unmodifiable). */
 	public Map<String, Integer> getSkillXpByName()
 	{
 		return skillXpByName;
 	}
 
+	/** Returns the uncredited XP remainder for a skill, or empty when this baseline isn't present or the skill is unknown. */
 	public OptionalLong uncreditedXpFor(Skill skill)
 	{
 		if (kind != Kind.PRESENT || skill == null || skill.getName() == null)
@@ -131,6 +151,7 @@ public final class SkillCreditBaseline
 		return remainder == null ? OptionalLong.empty() : OptionalLong.of(remainder);
 	}
 
+	/** Equal when kind and both maps match. */
 	@Override
 	public boolean equals(Object o)
 	{
@@ -148,6 +169,7 @@ public final class SkillCreditBaseline
 			&& Objects.equals(uncreditedXpBySkill, that.uncreditedXpBySkill);
 	}
 
+	/** Consistent with {@link #equals}. */
 	@Override
 	public int hashCode()
 	{

--- a/src/main/java/com/osrstcg/state/TcgCloudStateApplier.java
+++ b/src/main/java/com/osrstcg/state/TcgCloudStateApplier.java
@@ -3,10 +3,12 @@ package com.osrstcg.state;
 /** Pure cloud→local state apply used by {@link TcgStateService} under its lock. */
 final class TcgCloudStateApplier
 {
+	/** Static-only helper; not instantiable. */
 	private TcgCloudStateApplier()
 	{
 	}
 
+	/** Applies economy-only fields from a cloud response (credits, opened packs, total gained), clamping to valid ranges. */
 	static TcgState applyEconomy(TcgState state, long credits, int openedPacks, long totalCreditsGained)
 	{
 		return state
@@ -15,6 +17,7 @@ final class TcgCloudStateApplier
 			.withTotalCreditsGained(Math.max(totalCreditsGained, credits));
 	}
 
+	/** Applies a full cloud state sync (collection, economy, sync markers), substituting empty defaults for nulls. */
 	static TcgState applyFull(
 		TcgState state,
 		CollectionState collection,

--- a/src/main/java/com/osrstcg/state/TcgState.java
+++ b/src/main/java/com/osrstcg/state/TcgState.java
@@ -5,6 +5,11 @@ import java.util.Arrays;
 import lombok.AccessLevel;
 import lombok.Getter;
 
+/**
+ * Immutable root of persisted plugin state: economy, collection, cloud sync markers, and profile
+ * metadata. Persisted to disk/cloud via {@code TcgStateStore}; every mutation is expressed as a
+ * {@code withXxx} method returning a new instance.
+ */
 @Getter
 public final class TcgState
 {
@@ -24,6 +29,7 @@ public final class TcgState
 	@Getter(AccessLevel.NONE)
 	private final int[] sidebarRanks;
 
+	/** Legacy-schema convenience overload: no cloud sync markers or sidebar ranks. */
 	public TcgState(int schemaVersion, EconomyState economyState, CollectionState collectionState,
 		double packRevealOverlayScale, SkillCreditBaseline skillCreditBaseline,
 		long totalCreditsGained, long profileCreatedAtUnix, long profileSavedAtUnix)
@@ -33,6 +39,7 @@ public final class TcgState
 			profileSavedAtUnix, 0L, "", null);
 	}
 
+	/** Convenience overload: no sidebar ranks. */
 	public TcgState(int schemaVersion, EconomyState economyState, CollectionState collectionState,
 		double packRevealOverlayScale, SkillCreditBaseline skillCreditBaseline,
 		long totalCreditsGained, long profileCreatedAtUnix, long profileSavedAtUnix,
@@ -43,6 +50,12 @@ public final class TcgState
 			profileSavedAtUnix, cloudRevision, cloudStateHash, null);
 	}
 
+	/**
+	 * Full constructor. Normalizes every field: a non-positive schema version falls back to
+	 * {@link #CURRENT_SCHEMA_VERSION}, null sub-states become their {@code empty()}/{@code absent()}
+	 * forms, the overlay scale is clamped via {@link PackRevealZoomUtil}, and numeric fields are
+	 * floored at zero.
+	 */
 	public TcgState(int schemaVersion, EconomyState economyState, CollectionState collectionState,
 		double packRevealOverlayScale, SkillCreditBaseline skillCreditBaseline,
 		long totalCreditsGained, long profileCreatedAtUnix, long profileSavedAtUnix,
@@ -61,6 +74,7 @@ public final class TcgState
 		this.sidebarRanks = copyRanks(sidebarRanks);
 	}
 
+	/** Returns a fresh state for a new profile: zero economy, no cards, {@code profileCreatedAtUnix} set to now. */
 	public static TcgState empty()
 	{
 		long now = currentUnixSeconds();
@@ -69,11 +83,16 @@ public final class TcgState
 			0L, now, 0L, 0L, "", null);
 	}
 
+	/** Returns the current time as Unix seconds, used to stamp {@code profileCreatedAtUnix}/{@code profileSavedAtUnix}. */
 	public static long currentUnixSeconds()
 	{
 		return System.currentTimeMillis() / 1000L;
 	}
 
+	/**
+	 * Validates and defensively copies a sidebar-rank array: returns null if the length doesn't
+	 * match {@link #SIDEBAR_RANK_COUNT} or any entry is negative.
+	 */
 	public static int[] copyRanks(int[] ranks)
 	{
 		if (ranks == null || ranks.length != SIDEBAR_RANK_COUNT)
@@ -90,11 +109,13 @@ public final class TcgState
 		return Arrays.copyOf(ranks, SIDEBAR_RANK_COUNT);
 	}
 
+	/** Returns a defensive copy of the sidebar ranks array, or null if unset. */
 	public int[] getSidebarRanks()
 	{
 		return sidebarRanks == null ? null : Arrays.copyOf(sidebarRanks, sidebarRanks.length);
 	}
 
+	/** Builds a new {@code TcgState} with the given fields, keeping this instance's {@link #schemaVersion}. */
 	private TcgState copy(
 		EconomyState economy,
 		CollectionState collection,
@@ -111,56 +132,67 @@ public final class TcgState
 			baseline, gained, createdAt, savedAt, revision, stateHash, ranks);
 	}
 
+	/** Returns a copy with the credit balance replaced, opened-pack count unchanged. */
 	public TcgState withCredits(long newCredits)
 	{
 		return copy(new EconomyState(newCredits, economyState.getOpenedPacks()), collectionState, packRevealOverlayScale, skillCreditBaseline, totalCreditsGained, profileCreatedAtUnix, profileSavedAtUnix, cloudRevision, cloudStateHash, sidebarRanks);
 	}
 
+	/** Returns a copy with the opened-pack count replaced, credit balance unchanged. */
 	public TcgState withOpenedPacks(long openedPacks)
 	{
 		return copy(new EconomyState(economyState.getCredits(), openedPacks), collectionState, packRevealOverlayScale, skillCreditBaseline, totalCreditsGained, profileCreatedAtUnix, profileSavedAtUnix, cloudRevision, cloudStateHash, sidebarRanks);
 	}
 
+	/** Returns a copy with the collection state replaced. */
 	public TcgState withCollection(CollectionState newCollectionState)
 	{
 		return copy(economyState, newCollectionState, packRevealOverlayScale, skillCreditBaseline, totalCreditsGained, profileCreatedAtUnix, profileSavedAtUnix, cloudRevision, cloudStateHash, sidebarRanks);
 	}
 
+	/** Returns a copy with the pack reveal overlay scale replaced (clamped by the constructor). */
 	public TcgState withPackRevealOverlayScale(double multiplier)
 	{
 		return copy(economyState, collectionState, multiplier, skillCreditBaseline, totalCreditsGained, profileCreatedAtUnix, profileSavedAtUnix, cloudRevision, cloudStateHash, sidebarRanks);
 	}
 
+	/** Returns a copy with the skill credit baseline replaced; null falls back to {@code absent()}. */
 	public TcgState withSkillCreditBaseline(SkillCreditBaseline baseline)
 	{
 		return copy(economyState, collectionState, packRevealOverlayScale, baseline == null ? SkillCreditBaseline.absent() : baseline, totalCreditsGained, profileCreatedAtUnix, profileSavedAtUnix, cloudRevision, cloudStateHash, sidebarRanks);
 	}
 
+	/** Returns a copy with the lifetime total credits gained replaced. */
 	public TcgState withTotalCreditsGained(long gained)
 	{
 		return copy(economyState, collectionState, packRevealOverlayScale, skillCreditBaseline, gained, profileCreatedAtUnix, profileSavedAtUnix, cloudRevision, cloudStateHash, sidebarRanks);
 	}
 
+	/** Returns a copy with the profile creation timestamp replaced. */
 	public TcgState withProfileCreatedAtUnix(long unixSeconds)
 	{
 		return copy(economyState, collectionState, packRevealOverlayScale, skillCreditBaseline, totalCreditsGained, unixSeconds, profileSavedAtUnix, cloudRevision, cloudStateHash, sidebarRanks);
 	}
 
+	/** Returns a copy with the profile last-saved timestamp replaced. */
 	public TcgState withProfileSavedAtUnix(long unixSeconds)
 	{
 		return copy(economyState, collectionState, packRevealOverlayScale, skillCreditBaseline, totalCreditsGained, profileCreatedAtUnix, unixSeconds, cloudRevision, cloudStateHash, sidebarRanks);
 	}
 
+	/** Returns a copy with the cloud revision number and state hash replaced. */
 	public TcgState withCloudSyncMarkers(long revision, String stateHash)
 	{
 		return copy(economyState, collectionState, packRevealOverlayScale, skillCreditBaseline, totalCreditsGained, profileCreatedAtUnix, profileSavedAtUnix, revision, stateHash, sidebarRanks);
 	}
 
+	/** Returns a copy with the economy state and total credits gained replaced together; null economy falls back to {@code empty()}. */
 	public TcgState withEconomy(EconomyState nextEconomy, long totalGained)
 	{
 		return copy(nextEconomy == null ? EconomyState.empty() : nextEconomy, collectionState, packRevealOverlayScale, skillCreditBaseline, totalGained, profileCreatedAtUnix, profileSavedAtUnix, cloudRevision, cloudStateHash, sidebarRanks);
 	}
 
+	/** Returns a copy with the sidebar ranks replaced (validated by {@link #copyRanks}). */
 	public TcgState withSidebarRanks(int[] ranks)
 	{
 		return copy(economyState, collectionState, packRevealOverlayScale, skillCreditBaseline, totalCreditsGained, profileCreatedAtUnix, profileSavedAtUnix, cloudRevision, cloudStateHash, ranks);

--- a/src/main/java/com/osrstcg/state/TcgStateNotifier.java
+++ b/src/main/java/com/osrstcg/state/TcgStateNotifier.java
@@ -10,6 +10,7 @@ final class TcgStateNotifier
 	private final CopyOnWriteArrayList<Runnable> stateChangeListeners = new CopyOnWriteArrayList<>();
 	private final CopyOnWriteArrayList<Runnable> ownedCollectionListeners = new CopyOnWriteArrayList<>();
 
+	/** Registers a listener for general state changes; ignored if null or already registered. */
 	void addStateChangeListener(Runnable listener)
 	{
 		if (listener != null)
@@ -18,6 +19,7 @@ final class TcgStateNotifier
 		}
 	}
 
+	/** Unregisters a previously-added state change listener; no-op if null or not registered. */
 	void removeStateChangeListener(Runnable listener)
 	{
 		if (listener != null)
@@ -26,6 +28,7 @@ final class TcgStateNotifier
 		}
 	}
 
+	/** Registers a listener for owned-collection changes; ignored if null or already registered. */
 	void addOwnedCollectionListener(Runnable listener)
 	{
 		if (listener != null)
@@ -34,6 +37,7 @@ final class TcgStateNotifier
 		}
 	}
 
+	/** Unregisters a previously-added owned-collection listener; no-op if null or not registered. */
 	void removeOwnedCollectionListener(Runnable listener)
 	{
 		if (listener != null)
@@ -42,11 +46,13 @@ final class TcgStateNotifier
 		}
 	}
 
+	/** Runs all registered state change listeners, logging but not propagating failures. */
 	void notifyStateChangeListeners()
 	{
 		runListeners(stateChangeListeners, "State change listener failed");
 	}
 
+	/** Runs all registered owned-collection listeners, logging but not propagating failures. */
 	void notifyOwnedCollectionListeners()
 	{
 		runListeners(ownedCollectionListeners, "Owned collection listener failed");
@@ -59,6 +65,7 @@ final class TcgStateNotifier
 		notifyOwnedCollectionListeners();
 	}
 
+	/** Invokes each listener, catching and debug-logging any exception so one bad listener doesn't block the rest. */
 	private void runListeners(CopyOnWriteArrayList<Runnable> listeners, String failLog)
 	{
 		for (Runnable notify : listeners)

--- a/src/main/java/com/osrstcg/state/TcgStateService.java
+++ b/src/main/java/com/osrstcg/state/TcgStateService.java
@@ -15,6 +15,14 @@ import com.osrstcg.credit.CreditsRateTracker;
 import com.osrstcg.notify.CreditNotificationService;
 import com.osrstcg.OsrsTcgConfig;
 
+/**
+ * Single owner of the live {@link TcgState} for the plugin session: exposes mutation methods that
+ * replace the state and notify listeners, and delegates persistence to {@link TcgStateStore}.
+ * All mutating methods are {@code synchronized}; the plain getter reads the volatile reference
+ * without locking so any thread can observe the current snapshot cheaply. Also layers an
+ * {@link OptimisticCreditBuffer} on top of the persisted credit balance so UI can show credits
+ * gained before the server confirms them.
+ */
 @Singleton
 @Slf4j
 public class TcgStateService
@@ -43,6 +51,7 @@ public class TcgStateService
 		this.config = config;
 	}
 
+	/** Test/standalone constructor: no store, no notifications; starts from the given state (or {@code empty()}). */
 	public TcgStateService(TcgState initialState)
 	{
 		this.stateStore = null;
@@ -52,6 +61,11 @@ public class TcgStateService
 		this.state = initialState == null ? TcgState.empty() : initialState;
 	}
 
+	/**
+	 * Loads state from {@link #stateStore}, replacing the in-memory state and clearing optimistic
+	 * credits, then applies any pending schema-upgrade fixups. Returns an {@link TcgStateLoadSource#EMPTY}
+	 * result with the current in-memory state if this service was constructed without a store.
+	 */
 	public synchronized TcgStateLoadResult load()
 	{
 		if (stateStore == null)
@@ -72,6 +86,7 @@ public class TcgStateService
 		return result;
 	}
 
+	/** Ensures the loaded state has a non-null skill credit baseline, defaulting to {@code absent()}. */
 	private boolean ensureSkillBaselineSchema()
 	{
 		SkillCreditBaseline baseline = state.getSkillCreditBaseline();
@@ -83,6 +98,7 @@ public class TcgStateService
 		return baseline.needsSchemaUpgradePersist();
 	}
 
+	/** Backfills {@code profileCreatedAtUnix} to now for profiles saved before that field existed. */
 	private boolean ensureProfileMetaSchemaFields()
 	{
 		boolean changed = false;
@@ -94,6 +110,7 @@ public class TcgStateService
 		return changed;
 	}
 
+	/** Replaces the skill credit baseline; a no-op if it already equals {@code baseline}. */
 	public synchronized void replaceSkillCreditBaseline(SkillCreditBaseline baseline)
 	{
 		SkillCreditBaseline next = baseline == null ? SkillCreditBaseline.absent() : baseline;
@@ -104,6 +121,7 @@ public class TcgStateService
 		state = state.withSkillCreditBaseline(next);
 	}
 
+	/** Stamps the profile-saved timestamp and delegates an incremental checkpoint save to the store. */
 	public synchronized boolean saveCheckpoint(TcgSaveTrigger trigger)
 	{
 		if (stateStore == null)
@@ -114,6 +132,7 @@ public class TcgStateService
 		return stateStore.saveCheckpoint(state, trigger == null ? TcgSaveTrigger.MANUAL : trigger);
 	}
 
+	/** Stamps the profile-saved timestamp and delegates a full checkpoint save to the store. */
 	public synchronized boolean saveFullCheckpoint(TcgSaveTrigger trigger)
 	{
 		if (stateStore == null)
@@ -124,41 +143,49 @@ public class TcgStateService
 		return stateStore.saveFullCheckpoint(state, trigger == null ? TcgSaveTrigger.LOGOUT : trigger);
 	}
 
+	/** Registers a listener invoked on any state change (economy, collection, ranks, etc). */
 	public void addCollectionChangeListener(Runnable listener)
 	{
 		notifier.addStateChangeListener(listener);
 	}
 
+	/** Unregisters a listener added via {@link #addCollectionChangeListener}. */
 	public void removeCollectionChangeListener(Runnable listener)
 	{
 		notifier.removeStateChangeListener(listener);
 	}
 
+	/** Registers a listener invoked specifically when the owned card collection is mutated. */
 	public void addOwnedCollectionListener(Runnable listener)
 	{
 		notifier.addOwnedCollectionListener(listener);
 	}
 
+	/** Unregisters a listener added via {@link #addOwnedCollectionListener}. */
 	public void removeOwnedCollectionListener(Runnable listener)
 	{
 		notifier.removeOwnedCollectionListener(listener);
 	}
 
+	/** Fires all general state-change listeners. */
 	private void notifyStateChangeListeners()
 	{
 		notifier.notifyStateChangeListeners();
 	}
 
+	/** Fires the collection-mutated notification path (general listeners plus owned-collection listeners). */
 	private void notifyCollectionMutated()
 	{
 		notifier.notifyCollectionMutated();
 	}
 
+	/** Returns the current state snapshot. */
 	public TcgState getState()
 	{
 		return state;
 	}
 
+	/** Sets the pack reveal overlay zoom, clamped to the valid range; a no-op if unchanged. */
 	public synchronized void setPackRevealOverlayScale(double multiplier)
 	{
 		double clamped = PackRevealZoomUtil.clamp(multiplier);
@@ -169,26 +196,34 @@ public class TcgStateService
 		state = state.withPackRevealOverlayScale(clamped);
 	}
 
+	/** Returns the display credit balance: persisted credits plus any pending optimistic credits. */
 	public long getCredits()
 	{
 		return getAuthoritativeCredits() + optimistic.get();
 	}
 
+	/** Returns the persisted credit balance, excluding any optimistic/unconfirmed credits. */
 	public synchronized long getAuthoritativeCredits()
 	{
 		return state.getEconomyState().getCredits();
 	}
 
+	/** Returns the amount of credits currently shown optimistically but not yet confirmed by the server. */
 	public synchronized long getPendingOptimisticCredits()
 	{
 		return optimistic.get();
 	}
 
+	/** Returns whether debug chat messages are enabled in config (false if no config is available). */
 	public boolean isDebugChatEnabled()
 	{
 		return config != null && config.get().debugMessages();
 	}
 
+	/**
+	 * Applies a server-confirmed economy snapshot (credits, opened packs, lifetime total) without
+	 * touching the collection, then notifies state-change listeners.
+	 */
 	public synchronized void replaceCloudEconomyCache(long credits, int openedPacks, long totalCreditsGained)
 	{
 		long pending = optimistic.get();
@@ -198,6 +233,10 @@ public class TcgStateService
 		notifyStateChangeListeners();
 	}
 
+	/**
+	 * Replaces the full state (collection and economy) from a cloud sync response, updates the
+	 * cached sidebar stats and collection hash, and notifies collection-mutated listeners.
+	 */
 	public synchronized void replaceFromCloudState(
 		CollectionState collection,
 		EconomyState economy,
@@ -221,6 +260,7 @@ public class TcgStateService
 		notifyCollectionMutated();
 	}
 
+	/** Updates the cloud revision/hash markers if they differ from the current ones (case-insensitive hash compare). */
 	public synchronized void applyCloudSyncMarkers(long revision, String stateHash)
 	{
 		long nextRevision = Math.max(0L, revision);
@@ -233,11 +273,13 @@ public class TcgStateService
 		state = state.withCloudSyncMarkers(nextRevision, nextHash);
 	}
 
+	/** Returns the current sidebar rank order, or null if unset. */
 	public int[] getSidebarRanks()
 	{
 		return state.getSidebarRanks();
 	}
 
+	/** Validates and replaces the sidebar ranks; a no-op if unchanged, otherwise notifies state-change listeners. */
 	public synchronized void replaceSidebarRanks(int[] ranks)
 	{
 		int[] next = TcgState.copyRanks(ranks);
@@ -250,28 +292,33 @@ public class TcgStateService
 		notifyStateChangeListeners();
 	}
 
+	/** Replaces the cached cloud sidebar collection stats and notifies state-change listeners. */
 	public synchronized void replaceCollectionStatsCache(CloudSidebarCollectionStats stats)
 	{
 		this.cloudCollectionStats = stats;
 		notifyStateChangeListeners();
 	}
 
+	/** Returns the cached cloud collection hash (never null). */
 	public String getCloudCollectionHash()
 	{
 		String hash = cloudCollectionHash;
 		return hash == null ? "" : hash;
 	}
 
+	/** Returns the cached cloud sidebar collection stats, or null if none cached. */
 	public CloudSidebarCollectionStats getCloudCollectionStats()
 	{
 		return cloudCollectionStats;
 	}
 
+	/** Clears the cached cloud sidebar collection stats. */
 	public synchronized void clearCollectionStatsCache()
 	{
 		this.cloudCollectionStats = null;
 	}
 
+	/** Sets the cloud group key (trimmed; blank/null clears it); a no-op if unchanged, otherwise notifies owned-collection listeners. */
 	public synchronized void replaceCloudGroupKey(String groupKey)
 	{
 		String next = groupKey == null || groupKey.isBlank() ? null : groupKey.trim();
@@ -283,21 +330,29 @@ public class TcgStateService
 		notifier.notifyOwnedCollectionListeners();
 	}
 
+	/** Returns the current cloud group key, or null if not in a cloud group. */
 	public String getCloudGroupKey()
 	{
 		return cloudGroupKey;
 	}
 
+	/** Clears the cloud group key. */
 	public synchronized void clearCloudGroupKey()
 	{
 		replaceCloudGroupKey(null);
 	}
 
+	/** Clears any pending optimistic (unconfirmed) credits. */
 	public synchronized void clearOptimisticCredits()
 	{
 		optimistic.clear();
 	}
 
+	/**
+	 * Adds an optimistic credit gain (shown immediately, ahead of server confirmation), records it
+	 * for the credits-per-hour rate tracker, and fires the credit-increase notification. A no-op for
+	 * non-positive amounts.
+	 */
 	public synchronized void addOptimisticCredits(long amount)
 	{
 		if (amount <= 0)
@@ -319,6 +374,7 @@ public class TcgStateService
 		}
 	}
 
+	/** Clears a specific amount of pending optimistic credits (e.g. once the server confirms that portion). */
 	public synchronized void clearOptimisticCredits(long amount)
 	{
 		if (amount <= 0 || optimistic.get() <= 0)
@@ -328,6 +384,7 @@ public class TcgStateService
 		optimistic.clearAmount(amount);
 	}
 
+	/** Appends newly-pulled card instances to the collection and notifies collection-mutated listeners. */
 	public synchronized void addOwnedCardInstances(List<OwnedCardInstance> instances)
 	{
 		if (instances == null || instances.isEmpty())
@@ -338,12 +395,14 @@ public class TcgStateService
 		notifyCollectionMutated();
 	}
 
+	/** Replaces the entire owned card collection wholesale and notifies collection-mutated listeners. */
 	public synchronized void setCollectionInstances(List<OwnedCardInstance> replacement)
 	{
 		state = state.withCollection(CollectionState.copyOf(replacement == null ? List.of() : replacement));
 		notifyCollectionMutated();
 	}
 
+	/** Resets to a fresh empty state, clears optimistic credits, persists a full checkpoint, and notifies listeners. */
 	public synchronized void resetAll()
 	{
 		optimistic.clear();

--- a/src/main/java/com/osrstcg/ui/CardFaceCache.java
+++ b/src/main/java/com/osrstcg/ui/CardFaceCache.java
@@ -13,9 +13,11 @@ import java.util.Map;
 final class CardFaceCache
 {
 	private static final int FACE_CACHE_MAX = 48;
+	/** Access-ordered map so {@code removeEldestEntry} evicts the least-recently-used face once the cap is exceeded. */
 	private static final Map<String, BufferedImage> FACE_CACHE = Collections.synchronizedMap(
 		new LinkedHashMap<String, BufferedImage>(32, 0.75f, true)
 		{
+			/** Evicts the eldest entry once the cache exceeds {@link #FACE_CACHE_MAX}. */
 			@Override
 			protected boolean removeEldestEntry(Map.Entry<String, BufferedImage> eldest)
 			{
@@ -23,10 +25,16 @@ final class CardFaceCache
 			}
 		});
 
+	/** Not instantiated; all members are static. */
 	private CardFaceCache()
 	{
 	}
 
+	/**
+	 * Returns the cached face for the given request, rendering and caching it via
+	 * {@link SharedCardRenderer#renderFace} on a miss. Returns {@code null} if art is expected but not
+	 * yet loaded (see {@link #expectsArtButMissing}).
+	 */
 	static BufferedImage cachedFace(int w, int h, CardFaceDrawRequest req)
 	{
 		if (expectsArtButMissing(req))
@@ -44,16 +52,22 @@ final class CardFaceCache
 		return face;
 	}
 
+	/** Returns whether a rendered face is already cached for this request, without rendering it. */
 	static boolean contains(int w, int h, CardFaceDrawRequest req)
 	{
 		return FACE_CACHE.containsKey(cacheKey(w, h, req));
 	}
 
+	/** Returns the cached face for this request, or {@code null} on a miss (never renders). */
 	static BufferedImage getIfPresent(int w, int h, CardFaceDrawRequest req)
 	{
 		return FACE_CACHE.get(cacheKey(w, h, req));
 	}
 
+	/**
+	 * Cache-key fragment distinguishing art variants: the art key plus a pending marker or the art
+	 * image's identity hash, so a request whose art hasn't loaded yet doesn't collide with one that has.
+	 */
 	private static String artIdentity(CardFaceDrawRequest req)
 	{
 		String artKey = req.getArtKey();
@@ -68,6 +82,7 @@ final class CardFaceCache
 		return req.getArt() == null ? "0" : Integer.toHexString(System.identityHashCode(req.getArt()));
 	}
 
+	/** Returns true when the request names an art key but the art image hasn't been loaded yet. */
 	static boolean expectsArtButMissing(CardFaceDrawRequest req)
 	{
 		if (req == null)
@@ -78,6 +93,7 @@ final class CardFaceCache
 		return artKey != null && !artKey.isEmpty() && req.getArt() == null;
 	}
 
+	/** Builds the cache key from every visual input that affects the rendered face's pixels. */
 	static String cacheKey(int w, int h, CardFaceDrawRequest req)
 	{
 		CardDefinition card = req.getCard();

--- a/src/main/java/com/osrstcg/ui/CardTextLayout.java
+++ b/src/main/java/com/osrstcg/ui/CardTextLayout.java
@@ -10,21 +10,31 @@ import java.awt.Shape;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Text layout helpers shared by {@link SharedCardRenderer}: word wrapping, ellipsizing, and
+ * centered/wrapped drawing, plus fixed-size full-art width math independent of the actual render scale.
+ */
 final class CardTextLayout
 {
 	private static final int FULL_ART_DESIGN_W = 180;
 	private static final int FULL_ART_DESIGN_H = 260;
 	private static final int FULL_ART_EXAMINE_MAX = 5;
 
+	/** Not instantiated; all members are static. */
 	private CardTextLayout()
 	{
 	}
 
+	/** Ellipsizes a full-art title to fit the fixed-design title width, falling back to "Unknown Card" if blank. */
 	static String ellipsizeFullArtTitle(FontMetrics fm, String text)
 	{
 		return ellipsizeToWidth(valueOrFallback(text, "Unknown Card"), fm, fullArtDesignTitleMaxWidth());
 	}
 
+	/**
+	 * Wraps full-art examine text to the fixed-design examine width, capping at
+	 * {@link #FULL_ART_EXAMINE_MAX} lines and ellipsizing the last line if more text remains.
+	 */
 	static List<String> wrapFullArtExamine(FontMetrics fm, String text)
 	{
 		String raw = text == null ? "" : text.trim();
@@ -43,6 +53,7 @@ final class CardTextLayout
 		return lines;
 	}
 
+	/** Max pixel width for full-art title text at the fixed design size ({@link #FULL_ART_DESIGN_W}x{@link #FULL_ART_DESIGN_H}, scale 1.0). */
 	static int fullArtDesignTitleMaxWidth()
 	{
 		int innerW = fullArtDesignInnerWidth();
@@ -50,6 +61,7 @@ final class CardTextLayout
 		return Math.max(8, innerW - titlePadX * 2);
 	}
 
+	/** Max pixel width for full-art examine text at the fixed design size. */
 	private static int fullArtDesignExamineMaxWidth()
 	{
 		int innerW = fullArtDesignInnerWidth();
@@ -58,6 +70,7 @@ final class CardTextLayout
 		return Math.max(8, examineW - examinePadX * 2);
 	}
 
+	/** Inner well width at the fixed design size, mirroring {@code SharedCardRenderer.Geometry}'s rim math at scale 1.0. */
 	private static int fullArtDesignInnerWidth()
 	{
 		int rim = Math.max(1, Math.min(Math.min(FULL_ART_DESIGN_W, FULL_ART_DESIGN_H) / 4,
@@ -65,6 +78,7 @@ final class CardTextLayout
 		return Math.max(1, FULL_ART_DESIGN_W - rim * 2);
 	}
 
+	/** Draws single-line text centered in {@code rect}, ellipsized to fit and clipped to the rect. */
 	static void drawCenteredText(Graphics2D g2, Rectangle rect, String text, Font font, Color color, int horizontalPadding)
 	{
 		g2.setFont(font == null ? CardFonts.body(1.0d) : font);
@@ -87,6 +101,10 @@ final class CardTextLayout
 		}
 	}
 
+	/**
+	 * Word-wraps text to fit {@code rect}'s width, truncates to {@code maxLines} (dropping overflow
+	 * rather than merging or splitting words), then draws it centered or top-aligned, clipped to the rect.
+	 */
 	static void drawWrappedCentered(Graphics2D g2, Rectangle rect, String text, Font font, Color color, int maxLines,
 		int horizontalPadding, boolean topAlign)
 	{
@@ -127,6 +145,10 @@ final class CardTextLayout
 		}
 	}
 
+	/**
+	 * Greedy word-wraps text (normalizing line endings, splitting on paragraphs) to fit within
+	 * {@code maxWidth}; never breaks a word mid-way. Always returns at least one (possibly empty) line.
+	 */
 	static List<String> wrapLines(FontMetrics fm, String text, int maxWidth)
 	{
 		List<String> lines = new ArrayList<>();
@@ -176,6 +198,11 @@ final class CardTextLayout
 		return lines;
 	}
 
+	/**
+	 * Truncates text character by character and appends "..." so the result fits within
+	 * {@code maxWidth}; returns "" if even the ellipsis doesn't fit, or {@code text} unchanged if it
+	 * already fits.
+	 */
 	static String ellipsizeToWidth(String text, FontMetrics fm, int maxWidth)
 	{
 		if (text == null)
@@ -207,6 +234,7 @@ final class CardTextLayout
 		return out + ellipsis;
 	}
 
+	/** Returns {@code value} trimmed, or {@code fallback} if {@code value} is null/blank. */
 	static String valueOrFallback(String value, String fallback)
 	{
 		return (value == null || value.trim().isEmpty()) ? fallback : value.trim();

--- a/src/main/java/com/osrstcg/ui/SharedCardRenderer.java
+++ b/src/main/java/com/osrstcg/ui/SharedCardRenderer.java
@@ -23,6 +23,11 @@ import java.awt.image.BufferedImage;
 import java.util.List;
 import net.runelite.client.ui.ColorScheme;
 
+/**
+ * Rasterizes card faces and backs (banded and full-art layouts) for {@link TcgPanel} and other card
+ * UI. Rendering itself is pure AWT/Graphics2D work with no threading requirement; callers on the EDT
+ * typically go through {@link CardFaceCache} to avoid re-rendering on every repaint.
+ */
 public final class SharedCardRenderer
 {
 	public static final int DEFAULT_CARD_WIDTH = 180;
@@ -39,10 +44,15 @@ public final class SharedCardRenderer
 
 	public static final String CARD_BACK_PATH = "/images/Cardback_new.png";
 
+	/** Not instantiated; all members are static. */
 	private SharedCardRenderer()
 	{
 	}
 
+	/**
+	 * Paints the request's face into {@code bounds} only if already rasterized in {@link CardFaceCache};
+	 * does not render on a miss. Returns whether it painted anything.
+	 */
 	public static boolean drawCardFaceIfCached(Graphics2D g, Rectangle bounds, CardFaceDrawRequest req)
 	{
 		if (g == null || bounds == null || req == null || bounds.width < 4 || bounds.height < 4)
@@ -58,6 +68,7 @@ public final class SharedCardRenderer
 		return true;
 	}
 
+	/** Blits a pre-rendered face image and, for foil requests, overlays an animated sparkle pass on top. */
 	private static void paintCachedFace(Graphics2D g, Rectangle bounds, CardFaceDrawRequest req, BufferedImage face)
 	{
 		g.drawImage(face, bounds.x, bounds.y, null);
@@ -79,6 +90,7 @@ public final class SharedCardRenderer
 		}
 	}
 
+	/** Draws the card back into {@code bounds}: the given image if provided, else a plain foil/dark placeholder. */
 	public static void drawCardBack(Graphics2D g, Rectangle bounds, boolean foil,
 		BufferedImage cardBack)
 	{
@@ -111,6 +123,7 @@ public final class SharedCardRenderer
 		}
 	}
 
+	/** Maps a rarity color back to its {@link RarityMath.Tier} label; falls back to Common if no tier matches. */
 	public static String tierLabelForRarityColor(Color color)
 	{
 		if (color == null)
@@ -127,6 +140,7 @@ public final class SharedCardRenderer
 		return RarityMath.Tier.COMMON.getLabel();
 	}
 
+	/** Renders and caches a face ahead of paint time, skipping requests with no size or missing art. */
 	public static void prewarmFace(int w, int h, CardFaceDrawRequest req)
 	{
 		if (req == null || w < 4 || h < 4 || CardFaceCache.expectsArtButMissing(req))
@@ -136,6 +150,7 @@ public final class SharedCardRenderer
 		CardFaceCache.cachedFace(w, h, req);
 	}
 
+	/** Returns whether {@code req} already has a rendered face cached at this size, without rendering it. */
 	public static boolean isFaceCached(int w, int h, CardFaceDrawRequest req)
 	{
 		if (req == null || w < 4 || h < 4)
@@ -145,6 +160,11 @@ public final class SharedCardRenderer
 		return CardFaceCache.contains(w, h, req);
 	}
 
+	/**
+	 * Fully rasterizes a card face at {@code w}x{@code h}: banded or full-art layout per
+	 * {@link CardFaceDrawRequest#isFullArt()}, then wear filter/overlay if the request carries a
+	 * {@link WearFx}. Called by {@link CardFaceCache} on a cache miss.
+	 */
 	static BufferedImage renderFace(int w, int h, CardFaceDrawRequest req)
 	{
 		BufferedImage face = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
@@ -177,6 +197,7 @@ public final class SharedCardRenderer
 		return face;
 	}
 
+	/** Paints the classic five-band layout: title, art, tier, examine text, and score bands stacked vertically. */
 	private static void paintBanded(Graphics2D g2, Geometry geo, CardFaceDrawRequest req)
 	{
 		CardDefinition card = req.getCard();
@@ -222,6 +243,11 @@ public final class SharedCardRenderer
 			CardFonts.bold(geo.scale), Color.WHITE, geo.bandPadX);
 	}
 
+	/**
+	 * Paints the full-bleed art layout: art fills the inner well with title/examine/score overlaid as
+	 * scrimmed, shadowed text. Disables text antialiasing/fractional metrics for crisper small text,
+	 * restoring both hints in the {@code finally} block.
+	 */
 	private static void paintFullArt(Graphics2D g2, Geometry geo, CardFaceDrawRequest req)
 	{
 		CardDefinition card = req.getCard();
@@ -325,6 +351,7 @@ public final class SharedCardRenderer
 		}
 	}
 
+	/** Strokes a thin rounded-rect ring just inside the card's outer edge, e.g. the foil highlight ring. */
 	private static void drawInsetRing(Graphics2D g2, Geometry geo, Color color)
 	{
 		float ringWidth = (float) Math.max(1.0d, Math.round(geo.scale));
@@ -338,6 +365,7 @@ public final class SharedCardRenderer
 		g2.setStroke(new BasicStroke(1f));
 	}
 
+	/** Fills {@code rect} with a black gradient that fades out away from the top (or bottom) edge, used behind overlaid text. */
 	private static void paintVerticalScrim(Graphics2D g2, Rectangle rect, boolean fromTop)
 	{
 		if (rect.height <= 0 || rect.width <= 0)
@@ -359,6 +387,7 @@ public final class SharedCardRenderer
 		g2.fillRect(rect.x, rect.y, rect.width, rect.height);
 	}
 
+	/** Draws pre-wrapped full-art examine text, one centered stroked/shadowed line at a time. */
 	private static void drawFullArtExamine(Graphics2D g2, int left, int top, int width,
 		List<String> lines, Font font, int lineHeight, double scale)
 	{
@@ -374,6 +403,7 @@ public final class SharedCardRenderer
 		}
 	}
 
+	/** Draws {@code text} as a glyph outline with a soft drop shadow and a dark stroke around the fill, for legibility over art. */
 	private static void drawStrokedShadowedString(Graphics2D g2, String text, int x, int y,
 		Color fill, float strokeWidth, double scale)
 	{
@@ -393,6 +423,10 @@ public final class SharedCardRenderer
 		g2.setStroke(new BasicStroke(1f));
 	}
 
+	/**
+	 * Centers (or top-aligns) shadowed text within {@code rect}, optionally ellipsizing to fit, clipped
+	 * to the rect while drawing.
+	 */
 	private static void drawCenteredTextShadowed(Graphics2D g2, Rectangle rect, String text, Font font,
 		Color color, int horizontalPadding, double scale, boolean ellipsize, boolean topAlign)
 	{
@@ -419,6 +453,7 @@ public final class SharedCardRenderer
 		}
 	}
 
+	/** Draws multi-pass drop-shadowed/outlined text (title and score overlays) using {@code drawString}, cheaper than glyph outlines. */
 	private static void drawTitleScoreShadow(Graphics2D g2, String text, int x, int y, Color color, double scale)
 	{
 		int drop = Math.max(1, (int) Math.round(1.0d * scale));
@@ -434,12 +469,14 @@ public final class SharedCardRenderer
 		g2.drawString(text, x, y);
 	}
 
+	/** Fills a banded-layout section with a solid rounded-rect color. */
 	private static void fillBand(Graphics2D g2, Rectangle band, Color fill, int radius)
 	{
 		g2.setColor(fill);
 		g2.fillRoundRect(band.x, band.y, band.width, band.height, radius * 2, radius * 2);
 	}
 
+	/** Draws the banded layout's art band: the card's art image fit-centered, or a loading/placeholder message if art isn't loaded. */
 	private static void drawArt(Graphics2D g2, Geometry geo, CardFaceDrawRequest req)
 	{
 		Rectangle inner = inset(geo.art, geo.artPad);
@@ -457,6 +494,7 @@ public final class SharedCardRenderer
 			ColorScheme.LIGHT_GRAY_COLOR, geo.bandPadX);
 	}
 
+	/** Draws the banded layout's examine text: fits an em size that wraps within the band, then wraps and centers each line. */
 	private static void drawExamine(Graphics2D g2, Geometry geo, String examine)
 	{
 		String text = CardTextLayout.valueOrFallback(examine, "No examine text.");
@@ -492,6 +530,7 @@ public final class SharedCardRenderer
 		}
 	}
 
+	/** Formats the score to display: the server-supplied display score if present, else the card's computed (foil-adjusted) score, or "-" with no card. */
 	static String scoreText(CardFaceDrawRequest req)
 	{
 		Long server = req.getDisplayScore();
@@ -508,6 +547,7 @@ public final class SharedCardRenderer
 		return NumberFormatting.format(card.displayScore(foil));
 	}
 
+	/** Pre-computed layout for a card of a given pixel size: outer/inner bounds and the five band rectangles. */
 	private static final class Geometry
 	{
 		private final int width;
@@ -529,6 +569,7 @@ public final class SharedCardRenderer
 		private final Rectangle examine;
 		private final Rectangle score;
 
+		/** Computes scale-relative paddings/radii and divides the inner well into five bands per {@link #BAND_FRACTIONS}. */
 		private Geometry(int width, int height)
 		{
 			this.width = width;
@@ -576,21 +617,28 @@ public final class SharedCardRenderer
 		}
 	}
 
+	/** Corner radius scaled proportionally to card width, relative to {@link #DEFAULT_CARD_WIDTH}. */
 	private static double outerRadius(int width)
 	{
 		return Math.max(1.0d, 11.0d * width / (double) DEFAULT_CARD_WIDTH);
 	}
 
+	/** Rounded-rect arc diameter (2x radius) matching {@link #outerRadius(int)}, for callers that need Swing's arc-diameter convention. */
 	public static int outerArcDiameter(int width)
 	{
 		return Math.max(2, (int) Math.round(outerRadius(width) * 2.0d));
 	}
 
+	/** Shrinks a rectangle by {@code pad} on all sides, clamping width/height to at least 1. */
 	private static Rectangle inset(Rectangle r, int pad)
 	{
 		return new Rectangle(r.x + pad, r.y + pad, Math.max(1, r.width - pad * 2), Math.max(1, r.height - pad * 2));
 	}
 
+	/**
+	 * Binary-searches the largest title em size (down to {@link #BANDED_TITLE_EM_MIN}) that fits
+	 * {@code title} within {@code maxWidth} at the banded layout's title font.
+	 */
 	private static Font fitBandedTitleFont(Graphics2D g2, String title, int maxWidth, double scale)
 	{
 		String text = CardTextLayout.valueOrFallback(title, "");
@@ -620,6 +668,7 @@ public final class SharedCardRenderer
 		return CardFonts.title(scale, bestEm);
 	}
 
+	/** Draws {@code image} scaled to fit entirely within {@code rect} (letterboxed), centered, clipped to the rect. */
 	private static void drawFitCentered(Graphics2D g2, BufferedImage image, Rectangle rect)
 	{
 		int sourceWidth = image.getWidth();
@@ -645,6 +694,7 @@ public final class SharedCardRenderer
 		}
 	}
 
+	/** Draws {@code image} scaled to fully cover {@code rect} (cropped, not letterboxed), centered. Caller must clip if needed. */
 	private static void drawCoverCentered(Graphics2D g2, BufferedImage image, Rectangle rect)
 	{
 		int sourceWidth = image.getWidth();
@@ -661,6 +711,7 @@ public final class SharedCardRenderer
 		g2.drawImage(image, x, y, w, h, null);
 	}
 
+	/** Turns on antialiasing, bilinear interpolation, and pure stroke control for higher-quality rendering. */
 	private static void enableQuality(Graphics2D g2)
 	{
 		g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);

--- a/src/main/java/com/osrstcg/ui/SidebarRefresh.java
+++ b/src/main/java/com/osrstcg/ui/SidebarRefresh.java
@@ -2,16 +2,26 @@ package com.osrstcg.ui;
 
 import com.google.inject.ImplementedBy;
 
+/**
+ * Sidebar refresh callbacks exposed by {@link TcgPanel} to callers (e.g. {@code PackOpenCoordinator})
+ * that need to update the panel without depending on it directly. All methods mutate Swing state and
+ * must be called on the EDT.
+ */
 @ImplementedBy(TcgPanel.class)
 public interface SidebarRefresh
 {
+	/** Rebuilds/refreshes the currently visible tab's content. */
 	void refresh();
 
+	/** Refreshes just the displayed credits balance. */
 	void refreshCredits();
 
+	/** Freezes sidebar interaction while a pack reveal is in progress. */
 	void beginPackRevealSidebarFreeze();
 
+	/** Lifts the freeze applied by {@link #beginPackRevealSidebarFreeze()}. */
 	void clearPackRevealSidebarFreeze();
 
+	/** Refreshes the sidebar after a pack reveal overlay closes. */
 	void refreshAfterPackRevealClose();
 }

--- a/src/main/java/com/osrstcg/ui/TcgPanel.java
+++ b/src/main/java/com/osrstcg/ui/TcgPanel.java
@@ -73,12 +73,25 @@ import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
 
+/**
+ * RuneLite sidebar panel hosting the plugin's tabs (welcome, overview, collection, shop) plus the
+ * title bar, tab strip, and footer (account/trade/create-profile actions). Owns the Swing component
+ * tree for the sidebar and delegates per-tab content to {@link WelcomeTab}, {@link OverviewTab},
+ * {@link CollectionTab}, and {@link ShopTab}. Implements {@link SidebarRefresh} so other components
+ * (pack open flow, account/create-profile controllers) can trigger refreshes without depending on this
+ * class directly.
+ *
+ * <p>All Swing mutation must happen on the EDT. Public refresh methods accept calls from any thread and
+ * hop to the EDT via {@link SwingUtilities#invokeLater} when needed; most private helpers assume they
+ * are already running on the EDT.
+ */
 @Slf4j
 @Singleton
 public class TcgPanel extends PluginPanel implements SidebarRefresh
 {
 	private static final int MAIN_PANEL_INSET = SidebarLayout.MAIN_PANEL_INSET;
 
+	/** The four sidebar tabs, in display order, each carrying its button label. */
 	private enum Tab
 	{
 		WELCOME("Welcome"),
@@ -155,6 +168,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 	private final AccountPanelLauncher accountLauncher;
 	private final SidebarNoticeView sidebarNoticeView;
 
+	/** Wires collaborators, builds the full Swing component tree (title, tabs, footer), and installs the resize/visibility listener. */
 	@Inject
 	public TcgPanel(
 		TcgStateService stateService,
@@ -262,6 +276,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 
 		addComponentListener(new ComponentAdapter()
 		{
+			/** Marks the panel visible and forces a refresh whenever RuneLite shows the sidebar. */
 			@Override
 			public void componentShown(ComponentEvent e)
 			{
@@ -269,12 +284,14 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 				refresh();
 			}
 
+			/** Marks the panel hidden so refresh calls become no-ops until it's shown again. */
 			@Override
 			public void componentHidden(ComponentEvent e)
 			{
 				panelVisible = false;
 			}
 
+			/** Re-renders on a width change (content reflows), or just revalidates/repaints on a height-only change. */
 			@Override
 			public void componentResized(ComponentEvent e)
 			{
@@ -307,6 +324,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		panelVisible = isShowing();
 	}
 
+	/** Preferred size stretched to at least the parent's height so the panel fills the sidebar vertically. */
 	@Override
 	public Dimension getPreferredSize()
 	{
@@ -320,6 +338,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		return new Dimension(pref.width, height);
 	}
 
+	/** Minimum height of 0 so the panel can shrink freely; width matches the preferred width. */
 	@Override
 	public Dimension getMinimumSize()
 	{
@@ -327,6 +346,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		return new Dimension(pref.width, 0);
 	}
 
+	/** Unbounded maximum height so the panel can grow to fill available vertical space. */
 	@Override
 	public Dimension getMaximumSize()
 	{
@@ -334,6 +354,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		return new Dimension(pref.width, Integer.MAX_VALUE);
 	}
 
+	/** Registers the collection-change listener and does an initial refresh. Called by the plugin on startup. */
 	public void start()
 	{
 		stateService.addCollectionChangeListener(onCollectionChanged);
@@ -341,6 +362,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		refresh();
 	}
 
+	/** Unregisters listeners, cancels pending tab rebuilds, and clears tab content. Called by the plugin on shutdown. */
 	public void stop()
 	{
 		stateService.removeCollectionChangeListener(onCollectionChanged);
@@ -354,6 +376,10 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		mainPanel.repaint();
 	}
 
+	/**
+	 * Rebuilds/redisplays the currently selected tab. No-op while the panel isn't visible. Safe to call
+	 * from any thread; hops to the EDT (coalescing concurrent calls) when not already on it.
+	 */
 	@Override
 	public void refresh()
 	{
@@ -371,6 +397,11 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		refreshNow();
 	}
 
+	/**
+	 * Refreshes just the displayed credits balance on the overview and shop tabs. Skipped while a pack
+	 * reveal is showing its frozen snapshot. Safe to call from any thread; hops to the EDT (coalescing
+	 * with a pending full refresh or credits refresh) when not already on it.
+	 */
 	@Override
 	public void refreshCredits()
 	{
@@ -401,6 +432,13 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		shopTab.updateCredits(credits);
 	}
 
+	/**
+	 * Refreshes the sidebar once a pack reveal overlay closes: clears the reveal freeze, then
+	 * recomputes the overview/shop snapshot off the EDT (on the common {@link ForkJoinPool}) and applies
+	 * it back on the EDT, guarded by a generation counter so a stale async result can't clobber a newer
+	 * one. Falls back to a synchronous {@link #refresh()} if the async computation throws. Safe to call
+	 * from any thread.
+	 */
 	@Override
 	public void refreshAfterPackRevealClose()
 	{
@@ -443,6 +481,11 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		});
 	}
 
+	/**
+	 * Applies a snapshot computed off-EDT by {@link #refreshAfterPackRevealClose()}: hops to the EDT if
+	 * needed, discards the result if a newer generation has since started or the panel isn't visible,
+	 * then renders the selected tab with the precomputed data.
+	 */
 	private void applyPackCloseRefresh(long gen, PackCloseSnapshot snap, CloudSidebarCollectionStats metrics, List<BoosterShopRow> shopRows)
 	{
 		if (gen != packCloseRefreshGen.get())
@@ -466,12 +509,14 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		relayoutMainPanel();
 	}
 
+	/** Revalidates and repaints the main panel after content changes. Must be called on the EDT. */
 	private void relayoutMainPanel()
 	{
 		mainPanel.revalidate();
 		mainPanel.repaint();
 	}
 
+	/** Schedules a {@link #refresh()} on the EDT, coalescing with any already-queued call. */
 	private void queueRefreshOnEdt()
 	{
 		if (refreshQueued)
@@ -487,6 +532,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		});
 	}
 
+	/** EDT-side body of {@link #refresh()}: clears any stale reveal freeze, updates chrome, and renders the selected tab. */
 	private void refreshNow()
 	{
 		if (!packRevealService.isActive())
@@ -502,6 +548,11 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		relayoutMainPanel();
 	}
 
+	/**
+	 * Shows a full-panel blocking notice (logged out, account locked, restricted world) in place of tab
+	 * content when applicable; otherwise restores normal title/tab/footer chrome. Returns whether a
+	 * blocking notice was shown (and content rendering should be skipped).
+	 */
 	private boolean applySidebarChromeOrBlock()
 	{
 		if (shouldShowLoggedOutPrompt())
@@ -529,6 +580,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		return true;
 	}
 
+	/** Picks the initial tab (Welcome if no packs opened yet, else Overview) the first time chrome is applied. */
 	private void applyDefaultTabSelectionOnce()
 	{
 		if (defaultTabInitialized)
@@ -540,6 +592,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		selectedTab = openedPacks == 0 ? Tab.WELCOME : Tab.OVERVIEW;
 	}
 
+	/** Builds the footer's layout and adds its three stacked blocks (create-profile prompt, trade button, account button). */
 	private void populateFooterPanel()
 	{
 		footerPanel.setLayout(new BoxLayout(footerPanel, BoxLayout.Y_AXIS));
@@ -577,6 +630,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		updateFooterVisibility();
 	}
 
+	/** Returns whether to show the logged-out welcome screen: panel is showing but the client isn't in a game world. */
 	private boolean shouldShowLoggedOutPrompt()
 	{
 		if (!isShowing())
@@ -586,6 +640,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		return !isClientInGameWorld();
 	}
 
+	/** Forces the Welcome tab and renders it, used when the player isn't logged into a game world. */
 	private void showLoggedOutWelcome()
 	{
 		sidebarNoticeView.restoreAccountPanelToFooter();
@@ -597,6 +652,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		contentLayout.show(content, Tab.WELCOME.name());
 	}
 
+	/** Returns whether the RuneLite client is logged into a game world (checks game state, then local player as a fallback). */
 	private boolean isClientInGameWorld()
 	{
 		if (client.getGameState() == GameState.LOGGED_IN)
@@ -606,6 +662,10 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		return client.getLocalPlayer() != null;
 	}
 
+	/**
+	 * Builds the title panel: the top title row (Discord/Patreon links, "OSRS TCG" label, cloud status
+	 * indicator) and the tab strip below it. Sets {@link #titleTabWrapper} to the tab strip.
+	 */
 	private JPanel buildTitlePanel()
 	{
 		JPanel title = new JPanel();
@@ -710,6 +770,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		return title;
 	}
 
+	/** Paints the tab-rail underline beneath the active tab button, or no line if the active tab isn't showing/available. */
 	private void paintTabRailLine(JComponent strip, Graphics g)
 	{
 		JButton active = tabButtonFor(selectedTab);
@@ -720,6 +781,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		SidebarChrome.paintTabRailLine(strip, g, active);
 	}
 
+	/** Returns the {@link JButton} for the given tab, or {@code null} for a null tab. */
 	private JButton tabButtonFor(Tab tab)
 	{
 		if (tab == null)
@@ -741,6 +803,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		}
 	}
 
+	/** Repaints the cloud status indicator dot and its ancestor containers, then refreshes account/footer state that depends on it. */
 	public void updateCloudStatusIndicator()
 	{
 		SidebarChrome.updateCloudStatusIndicator(cloudStatusIndicator, cloudSessionService, stateService);
@@ -763,6 +826,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		updateFooterVisibility();
 	}
 
+	/** Best-effort footer content width for wrapping the create-profile prompt: footer width if laid out, else derived from the panel width. */
 	private int footerContentWidth()
 	{
 		int footerW = footerPanel.getWidth();
@@ -778,6 +842,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		return Math.max(80, PluginPanel.PANEL_WIDTH - 12);
 	}
 
+	/** Styles a tab button and wires its click handler to switch to {@code tab} (ignored if unavailable or already selected). */
 	private JButton configureTabButton(JButton button, Tab tab)
 	{
 		button.setFont(FontManager.getRunescapeSmallFont());
@@ -798,6 +863,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		return button;
 	}
 
+	/** Falls back to the Welcome tab if the current selection became unavailable, then restyles every tab button. */
 	private void updateTabStyles()
 	{
 		if (!isTabAvailable(selectedTab))
@@ -816,6 +882,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		updateFooterVisibility();
 	}
 
+	/** Welcome is always available; the other tabs require being in a game world with no account lock/restricted world. */
 	private boolean isTabAvailable(Tab tab)
 	{
 		if (tab == null)
@@ -831,6 +898,10 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 			&& !cloudSessionService.isAccountLocked();
 	}
 
+	/**
+	 * Recomputes which footer blocks (create-profile prompt, account panel, trade button) are visible
+	 * based on world/session/cloud state and the selected tab, plus the spacer gaps between them.
+	 */
 	private void updateFooterVisibility()
 	{
 		if (footerHiddenForBlockingState())
@@ -873,6 +944,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		SidebarLayout.lockFooterBlockHeight(tradeFooterWrap);
 	}
 
+	/** Builds the "Open trades" footer button, which opens the {@code /trades} web album page. */
 	private JButton createOpenTradesButton()
 	{
 		JButton button = new JButton(
@@ -883,6 +955,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		return button;
 	}
 
+	/** Applies enabled/active styling (colors, border, cursor, tooltip) to a single tab button. */
 	private void applyTabStyle(JButton button, Tab tab)
 	{
 		boolean available = isTabAvailable(tab);
@@ -923,6 +996,11 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		}
 	}
 
+	/**
+	 * How a tab is rendered: {@code NORMAL} builds fresh from live state; {@code FROZEN} reuses/builds
+	 * once against the pack-reveal snapshot and is cached per tab in {@link #revealTabBuilt} until the
+	 * freeze clears; {@code PACK_CLOSE} rebuilds from a precomputed snapshot right after a reveal closes.
+	 */
 	private enum TabRenderMode
 	{
 		NORMAL,
@@ -930,6 +1008,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		PACK_CLOSE
 	}
 
+	/** Renders the currently selected tab, using {@code FROZEN} mode while a pack reveal snapshot is active. */
 	private void renderSelectedTab()
 	{
 		TabRenderMode mode = packRevealService.isActive() && sidebarRevealSpoilerSnap != null
@@ -938,6 +1017,10 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		renderTab(selectedTab, mode, null, null, null);
 	}
 
+	/**
+	 * Builds (or, if already built for {@code FROZEN} mode, reuses) the given tab's content per
+	 * {@code mode}, then switches the visible card via {@link #showRenderedTab}.
+	 */
 	private void renderTab(Tab tab, TabRenderMode mode, PackCloseSnapshot snap,
 		CloudSidebarCollectionStats metrics, List<BoosterShopRow> shopRows)
 	{
@@ -986,6 +1069,11 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		showRenderedTab(tab, mode);
 	}
 
+	/**
+	 * Switches the visible content card for {@code tab}, going through {@link #showTabContent} (which
+	 * also revalidates scroll panes) except when frozen/pack-close mode should keep showing the
+	 * currently-visible card unchanged.
+	 */
 	private void showRenderedTab(Tab tab, TabRenderMode mode)
 	{
 		if (mode == TabRenderMode.NORMAL
@@ -1000,6 +1088,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		}
 	}
 
+	/** Switches the content {@link CardLayout} to {@code tab} and revalidates that tab's scroll pane (and shop chrome for the Shop tab). */
 	private void showTabContent(Tab tab)
 	{
 		contentLayout.show(content, tab.name());
@@ -1023,6 +1112,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		}
 	}
 
+	/** Builds a fresh {@link PackCloseSnapshot} from current state under the state service's lock. */
 	private PackCloseSnapshot buildPackCloseSnapshot()
 	{
 		synchronized (stateService)
@@ -1038,6 +1128,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		}
 	}
 
+	/** Returns the frozen reveal snapshot while a pack reveal is active, else builds a fresh one. */
 	private PackCloseSnapshot capturePackCloseSnapshot()
 	{
 		if (sidebarRevealSpoilerSnap != null && packRevealService.isActive())
@@ -1047,6 +1138,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		return buildPackCloseSnapshot();
 	}
 
+	/** Freezes the sidebar to a pre-reveal snapshot (so newly pulled cards don't spoil in the background) and resets built-tab caching. */
 	@Override
 	public void beginPackRevealSidebarFreeze()
 	{
@@ -1054,6 +1146,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		resetRevealTabBuilt();
 	}
 
+	/** Clears the reveal freeze so subsequent renders use live state, and resets built-tab caching. */
 	@Override
 	public void clearPackRevealSidebarFreeze()
 	{
@@ -1061,11 +1154,13 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		resetRevealTabBuilt();
 	}
 
+	/** Marks every tab as needing a rebuild under {@link TabRenderMode#FROZEN}. */
 	private void resetRevealTabBuilt()
 	{
 		Arrays.fill(revealTabBuilt, false);
 	}
 
+	/** Best-effort content width for tab layout: the widest tab scroll pane viewport if laid out, else a fallback derived from panel insets. */
 	private int liveSidebarContentWidth()
 	{
 		int viewportWidth = 0;
@@ -1088,6 +1183,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		return Math.max(80, raw - mainPanelHorizontalPad - SidebarLayout.TAB_SCROLLBAR_WIDTH);
 	}
 
+	/** Content width for the shop pack list: its scroll pane's viewport width if laid out, else {@link #liveSidebarContentWidth()}. */
 	private int liveShopPacksContentWidth()
 	{
 		int viewportWidth = shopPacksScrollPane.getViewport().getWidth();
@@ -1098,6 +1194,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		return liveSidebarContentWidth();
 	}
 
+	/** Builds the border for a tab button: flat outline when disabled, bottom-open outline when active, full outline otherwise. */
 	private Border tabBorder(boolean active, boolean enabled)
 	{
 		if (!enabled)
@@ -1120,23 +1217,27 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		);
 	}
 
+	/** Delegates to {@link WelcomeTab#render} with the current content width. */
 	private void renderWelcomeTab(JPanel target)
 	{
 		welcomeTab.render(target, liveSidebarContentWidth());
 	}
 
+	/** Captures a fresh (or frozen) snapshot and delegates to {@link OverviewTab#render} with its computed metrics. */
 	private void renderOverviewTab(JPanel target)
 	{
 		PackCloseSnapshot snap = capturePackCloseSnapshot();
 		overviewTab.render(target, snap, overviewMetrics(snap));
 	}
 
+	/** Computes overview stats (owned/roll-pool counts etc.) for a snapshot via {@link TcgPublicStatsCalculator}. */
 	private CloudSidebarCollectionStats overviewMetrics(PackCloseSnapshot snap)
 	{
 		List<CardDefinition> all = cardDatabase.getCards();
 		return TcgPublicStatsCalculator.resolveOverview(snap, all, RollPoolFilter.filterRollPool(all));
 	}
 
+	/** Returns all four tabs' scroll panes, used to probe for a laid-out viewport width. */
 	private JScrollPane[] tabScrollPanes()
 	{
 		return new JScrollPane[] {
@@ -1144,18 +1245,21 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		};
 	}
 
+	/** Returns whether the footer should be hidden entirely because the account is locked or the world is restricted. */
 	private boolean footerHiddenForBlockingState()
 	{
 		return isClientInGameWorld()
 			&& (cloudSessionService.isAccountLocked() || cloudSessionService.isRestrictedWorld());
 	}
 
+	/** Callback from {@link CollectionTab} once its (possibly async) rebuild finishes: shows it and relayouts. */
 	private void onCollectionTabRendered()
 	{
 		showTabContent(Tab.COLLECTION);
 		relayoutMainPanel();
 	}
 
+	/** Shows a full-panel blocking notice, hiding the title tab strip and footer via the callback passed to it. */
 	private void showSidebarBlockingNotice(Consumer<Runnable> show)
 	{
 		show.accept(() ->
@@ -1168,16 +1272,19 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		titlePanel.repaint();
 	}
 
+	/** Delegates to {@link AccountPanelLauncher#updateManageAccountState} to refresh the account/trades button state. */
 	private void updateManageAccountState()
 	{
 		accountLauncher.updateManageAccountState(openAccountPanelButton, openTradesButton);
 	}
 
+	/** Delegates to {@link CreateProfileController#updateButtonState} to refresh the create-profile button state. */
 	private void updateCreateProfileState()
 	{
 		createProfileController.updateButtonState(createProfileButton);
 	}
 
+	/** Switches to the Overview tab, used after a profile is created. */
 	private void selectOverviewAfterCreate()
 	{
 		if (selectedTab != Tab.OVERVIEW)
@@ -1187,6 +1294,7 @@ public class TcgPanel extends PluginPanel implements SidebarRefresh
 		}
 	}
 
+	/** Post-profile-creation UI refresh: create-profile button state, footer visibility, and cloud status indicator. */
 	private void afterCreateProfileUi()
 	{
 		updateCreateProfileState();

--- a/src/main/java/com/osrstcg/ui/account/AccountPanelLauncher.java
+++ b/src/main/java/com/osrstcg/ui/account/AccountPanelLauncher.java
@@ -16,6 +16,11 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.util.LinkBrowser;
 
+/**
+ * Opens the OSRS TCG website account page (signed in via a one-time web code) from the sidebar,
+ * and drives the enabled/disabled state of the account/trades buttons. Network calls run on the
+ * given scheduler; UI updates are marshalled back onto the Swing EDT.
+ */
 @Slf4j
 public final class AccountPanelLauncher
 {
@@ -26,6 +31,7 @@ public final class AccountPanelLauncher
 	private final Runnable updateButtonState;
 	private final AtomicBoolean inFlight = new AtomicBoolean(false);
 
+	/** @param updateButtonState invoked (on the EDT) whenever button-enabled state may have changed */
 	public AccountPanelLauncher(
 		CloudSessionService cloudSessionService,
 		CloudApiClient cloudApiClient,
@@ -40,6 +46,13 @@ public final class AccountPanelLauncher
 		this.updateButtonState = updateButtonState;
 	}
 
+	/**
+	 * Requests a login web-code from the cloud API and opens the resulting URL in the system browser.
+	 * No-ops if the world is restricted, the panel can't currently be opened, or a request is already
+	 * in flight. Runs the network call on {@link #scheduler} and browser launch on the EDT.
+	 *
+	 * @param next path to redirect to after web login; defaults to {@code /me} if blank
+	 */
 	public void open(String next)
 	{
 		if (cloudSessionService.isRestrictedWorld()
@@ -84,6 +97,7 @@ public final class AccountPanelLauncher
 		});
 	}
 
+	/** Refreshes enabled state and tooltips of the account panel and trades buttons from current cloud session state. */
 	public void updateManageAccountState(JButton openAccountPanelButton, JButton openTradesButton)
 	{
 		if (openAccountPanelButton == null)
@@ -110,6 +124,7 @@ public final class AccountPanelLauncher
 		}
 	}
 
+	/** Queues a chat message reporting that opening the account panel failed, with optional detail. */
 	private void queueOpenAccountPanelError(String detail)
 	{
 		String message = detail == null || detail.isBlank()
@@ -118,6 +133,7 @@ public final class AccountPanelLauncher
 		TcgPluginGameMessages.queuePrefixedGameMessage(chatMessageManager, message);
 	}
 
+	/** @return the {@code url} field from a web-code response, or {@code null} if absent/blank. */
 	public static String resolveWebLoginUrl(JsonObject response)
 	{
 		if (response != null && response.has("url") && !response.get("url").isJsonNull())
@@ -131,6 +147,7 @@ public final class AccountPanelLauncher
 		return null;
 	}
 
+	/** @return a {@code /login} URL for the web base with the code and redirect path encoded, or {@code null} if inputs are missing. */
 	public static String buildWebLoginUrl(String webBaseUrl, String code, String next)
 	{
 		if (code == null || code.isBlank() || webBaseUrl == null || webBaseUrl.isBlank())
@@ -143,6 +160,10 @@ public final class AccountPanelLauncher
 		return webBaseUrl + "/login?code=" + encodedCode + "&next=" + encodedNext;
 	}
 
+	/**
+	 * Prefers building a login URL from the response's one-time {@code code}; falls back to the
+	 * response's {@code url} rewritten onto the configured web base.
+	 */
 	private String resolveWebLoginUrlOrFallback(JsonObject response, String next)
 	{
 		if (response != null && response.has("code") && !response.get("code").isJsonNull())

--- a/src/main/java/com/osrstcg/ui/account/CreateProfileController.java
+++ b/src/main/java/com/osrstcg/ui/account/CreateProfileController.java
@@ -27,6 +27,11 @@ import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.util.LinkBrowser;
 
+/**
+ * Drives the sidebar "create profile" flow: shows a cloud-consent dialog, submits profile creation
+ * to the cloud service on a background thread, and updates the create-profile button/prompt UI.
+ * UI-touching methods must run on, and callback to, the Swing EDT.
+ */
 @Slf4j
 public final class CreateProfileController
 {
@@ -55,6 +60,13 @@ public final class CreateProfileController
 	private final Runnable afterUi;
 	private final AtomicBoolean inFlight = new AtomicBoolean(false);
 
+	/**
+	 * @param dialogParent parent component for the consent dialog
+	 * @param refreshUi rerun after profile creation finishes, regardless of outcome
+	 * @param onSuccessSelectOverview run (before {@code afterUi}) if creation succeeded
+	 * @param onSuccessOpenAlbum optional, run after {@code refreshUi} if creation succeeded
+	 * @param afterUi run once the create-profile flow has been dispatched or completed, to update UI state
+	 */
 	public CreateProfileController(
 		CloudSessionService cloudSessionService,
 		ScheduledExecutorService scheduler,
@@ -75,6 +87,11 @@ public final class CreateProfileController
 		this.afterUi = afterUi;
 	}
 
+	/**
+	 * Entry point for the "create profile" button. Skips straight to {@code afterUi} if consent
+	 * isn't needed (restricted world or already consented); otherwise shows the consent dialog and,
+	 * on acceptance, starts profile creation.
+	 */
 	public void createProfile()
 	{
 		if (cloudSessionService.isRestrictedWorld() || !cloudSessionService.needsCloudConsent())
@@ -89,6 +106,10 @@ public final class CreateProfileController
 		beginCreate();
 	}
 
+	/**
+	 * Submits {@link CloudSessionService#createProfile()} on {@link #scheduler}, guarded against
+	 * concurrent invocations, then marshals the success/failure callbacks back onto the EDT.
+	 */
 	private void beginCreate()
 	{
 		if (!inFlight.compareAndSet(false, true))
@@ -139,6 +160,7 @@ public final class CreateProfileController
 		});
 	}
 
+	/** Shows the cloud data-consent dialog and returns whether the user accepted. */
 	private boolean confirmConsent()
 	{
 		JPanel sections = new JPanel();
@@ -165,6 +187,7 @@ public final class CreateProfileController
 		return choice == JOptionPane.YES_OPTION;
 	}
 
+	/** Builds one titled, word-wrapped section of the consent dialog, optionally with a privacy-policy link. */
 	private JPanel buildConsentSection(String title, String body, boolean includePrivacyLink)
 	{
 		JLabel header = new JLabel(title);
@@ -198,6 +221,7 @@ public final class CreateProfileController
 		return section;
 	}
 
+	/** Fixes a consent-dialog text area's size to its wrapped-text preferred height at the given width. */
 	private static void sizeConsentText(JTextArea text, int width)
 	{
 		text.setBorder(null);
@@ -212,6 +236,7 @@ public final class CreateProfileController
 		text.setMaximumSize(new Dimension(Integer.MAX_VALUE, height));
 	}
 
+	/** Builds an underlined, clickable "Privacy policy" label that opens {@link #PRIVACY_URL} in the browser. */
 	private JLabel buildPrivacyLink()
 	{
 		Cursor hand = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR);
@@ -241,6 +266,7 @@ public final class CreateProfileController
 		return link;
 	}
 
+	/** Creates an empty, non-editable text pane styled for the "create profile" sidebar prompt. */
 	public static JTextPane createPromptPane()
 	{
 		JTextPane tp = new JTextPane();
@@ -254,6 +280,7 @@ public final class CreateProfileController
 		return tp;
 	}
 
+	/** Sets the prompt text and center-aligned yellow styling, then resizes the pane and its footer wrapper to fit at the given width. */
 	public void updatePromptLayout(JTextPane promptPane, JPanel footerWrap, int width)
 	{
 		if (promptPane == null)
@@ -287,6 +314,7 @@ public final class CreateProfileController
 		footerWrap.setMaximumSize(new Dimension(width, wrapH));
 	}
 
+	/** Enables the create-profile button only while consent is still pending and no request is in flight. */
 	public void updateButtonState(JButton createProfileButton)
 	{
 		if (createProfileButton == null)

--- a/src/main/java/com/osrstcg/ui/account/SidebarNoticeView.java
+++ b/src/main/java/com/osrstcg/ui/account/SidebarNoticeView.java
@@ -12,8 +12,14 @@ import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 import net.runelite.client.ui.FontManager;
 
+/**
+ * Sidebar card that replaces the normal tab content with a centered message (event-world
+ * unavailable, account locked/banned) and, when relevant, relocates the "open account panel"
+ * button into it. Swing component; must be built and updated on the EDT.
+ */
 public final class SidebarNoticeView
 {
+	/** CardLayout key this view is shown under. */
 	public static final String CARD = "SIDEBAR_NOTICE";
 	public static final String EVENT_WORLD_UNAVAILABLE = "OSRS TCG is not available on event worlds";
 
@@ -25,6 +31,11 @@ public final class SidebarNoticeView
 	private final CloudSessionService cloudSessionService;
 	private final Runnable onManageAccountStateUpdate;
 
+	/**
+	 * @param openAccountPanelButton shared button that gets reparented into this view when a notice needs it
+	 * @param albumFooterWrap the button's normal home, to restore it to when the notice is dismissed
+	 * @param onManageAccountStateUpdate invoked after the button is shown, to refresh its enabled state
+	 */
 	public SidebarNoticeView(
 		JButton openAccountPanelButton,
 		JPanel albumFooterWrap,
@@ -43,16 +54,19 @@ public final class SidebarNoticeView
 		sidebarNoticeContent.add(sidebarNoticeButtonWrap, BorderLayout.SOUTH);
 	}
 
+	/** @return the root panel for this notice, to be added under {@link #CARD} in a CardLayout. */
 	public JPanel content()
 	{
 		return sidebarNoticeContent;
 	}
 
+	/** Shows the event-worlds-unavailable message, with no account panel button. */
 	public void showEventWorldUnavailable(Runnable hideChrome)
 	{
 		showFullSidebarNotice(EVENT_WORLD_UNAVAILABLE, false, hideChrome);
 	}
 
+	/** Shows the account-banned or account-quarantined message (per current session state), with the account panel button. */
 	public void showAccountLockedNotice(Runnable hideChrome)
 	{
 		String message = cloudSessionService.isAccountBanned()
@@ -61,6 +75,10 @@ public final class SidebarNoticeView
 		showFullSidebarNotice(message, true, hideChrome);
 	}
 
+	/**
+	 * Renders the notice card: runs {@code hideChrome} to hide normal tab UI, sets the message text,
+	 * and either reparents the account panel button into this view or restores it to the footer.
+	 */
 	public void showFullSidebarNotice(String messageText, boolean showAccountPanelButton, Runnable hideChrome)
 	{
 		hideChrome.run();
@@ -91,6 +109,7 @@ public final class SidebarNoticeView
 		sidebarNoticeContent.repaint();
 	}
 
+	/** Moves the account panel button into {@code target} (a no-op if it's already there), revalidating both containers. */
 	public void reparentAccountPanelButton(JPanel target)
 	{
 		if (target == null || openAccountPanelButton == null)
@@ -113,6 +132,7 @@ public final class SidebarNoticeView
 		target.repaint();
 	}
 
+	/** Moves the account panel button back to its normal footer location. */
 	public void restoreAccountPanelToFooter()
 	{
 		if (openAccountPanelButton == null || albumFooterWrap == null)

--- a/src/main/java/com/osrstcg/ui/card/CardColorMath.java
+++ b/src/main/java/com/osrstcg/ui/card/CardColorMath.java
@@ -2,12 +2,16 @@ package com.osrstcg.ui.card;
 
 import java.awt.Color;
 
+/**
+ * Color helpers shared by card rendering/effects: brightening, blending, alpha, clamping, and HSLA conversion.
+ */
 public final class CardColorMath
 {
 	private CardColorMath()
 	{
 	}
 
+	/** Lifts each RGB channel toward white by 35%, preserving alpha; null input returns opaque white. */
 	public static Color brighterColor(Color color)
 	{
 		if (color == null)
@@ -17,11 +21,16 @@ public final class CardColorMath
 		return new Color(lift(color.getRed()), lift(color.getGreen()), lift(color.getBlue()), color.getAlpha());
 	}
 
+	/** Moves a single 0-255 channel 35% of the way toward 255. */
 	private static int lift(int channel)
 	{
 		return Math.min(255, (int) Math.round(channel + (255 - channel) * 0.35d));
 	}
 
+	/**
+	 * Linearly interpolates RGB from {@code base} toward {@code tint} by {@code amount} (clamped 0-1),
+	 * keeping {@code base}'s alpha. Falls back to whichever color is non-null if the other is null.
+	 */
 	public static Color blendColors(Color base, Color tint, double amount)
 	{
 		if (base == null)
@@ -40,16 +49,19 @@ public final class CardColorMath
 			base.getAlpha());
 	}
 
+	/** Linearly interpolates one 0-255 channel from {@code a} to {@code b} by {@code t}, clamped to 0-255. */
 	private static int mix(int a, int b, double t)
 	{
 		return clamp255((int) Math.round(a + (b - a) * t));
 	}
 
+	/** Clamps a value to the 0-255 byte range. */
 	public static int clamp255(int value)
 	{
 		return Math.max(0, Math.min(255, value));
 	}
 
+	/** Returns {@code c} (white if null) with alpha set from {@code a} (0-1, clamped). */
 	public static Color withAlpha(Color c, double a)
 	{
 		if (c == null)
@@ -60,6 +72,7 @@ public final class CardColorMath
 		return new Color(c.getRed(), c.getGreen(), c.getBlue(), av);
 	}
 
+	/** Converts CSS-style HSLA ({@code hueDeg} any value, {@code saturation}/{@code lightness}/{@code alpha} 0-1) to an RGBA {@link Color}. */
 	public static Color hsla(double hueDeg, double saturation, double lightness, double alpha)
 	{
 		double h = ((hueDeg % 360.0d) + 360.0d) % 360.0d / 360.0d;
@@ -91,6 +104,7 @@ public final class CardColorMath
 			clamp255((int) Math.round(Math.max(0.0d, Math.min(1.0d, alpha)) * 255.0d)));
 	}
 
+	/** Standard HSL-to-RGB helper: computes one channel from chroma bounds {@code p}/{@code q} at hue offset {@code t}. */
 	private static double hueToChannel(double p, double q, double t)
 	{
 		double tt = t;

--- a/src/main/java/com/osrstcg/ui/card/CardFaceDrawRequest.java
+++ b/src/main/java/com/osrstcg/ui/card/CardFaceDrawRequest.java
@@ -5,6 +5,10 @@ import java.awt.Color;
 import java.awt.image.BufferedImage;
 import lombok.Getter;
 
+/**
+ * Immutable, builder-constructed bundle of everything needed to render one card face: art, rarity color,
+ * labels/score, and the optional foil/wear effect state.
+ */
 @Getter
 public final class CardFaceDrawRequest
 {
@@ -19,6 +23,7 @@ public final class CardFaceDrawRequest
 	private final WearFx wear;
 	private final FoilFx foilFx;
 
+	/** Copies and normalizes builder fields: blanks artKey to null, defaults rarityColor to white, and drops foilFx when not foil. */
 	private CardFaceDrawRequest(Builder b)
 	{
 		this.card = b.card;
@@ -33,6 +38,7 @@ public final class CardFaceDrawRequest
 		this.foilFx = (!b.foil) ? null : b.foilFx;
 	}
 
+	/** True when this is a foil card with a full-art foil image path defined on {@link #card}. */
 	public boolean isFullArt()
 	{
 		if (!foil || card == null)
@@ -43,11 +49,13 @@ public final class CardFaceDrawRequest
 		return path != null && !path.isBlank();
 	}
 
+	/** Starts a new {@link Builder}. */
 	public static Builder builder()
 	{
 		return new Builder();
 	}
 
+	/** Fluent builder for {@link CardFaceDrawRequest}; every setter returns {@code this}. */
 	public static final class Builder
 	{
 		private CardDefinition card;
@@ -61,66 +69,77 @@ public final class CardFaceDrawRequest
 		private WearFx wear;
 		private FoilFx foilFx;
 
+		/** Sets the card definition being rendered. */
 		public Builder card(CardDefinition value)
 		{
 			this.card = value;
 			return this;
 		}
 
+		/** Sets the base card art image. */
 		public Builder art(BufferedImage value)
 		{
 			this.art = value;
 			return this;
 		}
 
+		/** Sets the cache key identifying this art variant (trimmed and null-if-blank on build). */
 		public Builder artKey(String value)
 		{
 			this.artKey = value;
 			return this;
 		}
 
+		/** Sets whether this card is foil. */
 		public Builder foil(boolean value)
 		{
 			this.foil = value;
 			return this;
 		}
 
+		/** Sets the rarity tier color (defaults to white if never set or set null). */
 		public Builder rarityColor(Color value)
 		{
 			this.rarityColor = value;
 			return this;
 		}
 
+		/** Sets the tier label text. */
 		public Builder tierLabel(String value)
 		{
 			this.tierLabel = value;
 			return this;
 		}
 
+		/** Sets the score value to display. */
 		public Builder displayScore(Long value)
 		{
 			this.displayScore = value;
 			return this;
 		}
 
+		/** Sets whether the displayed score is foil-adjusted; unset defaults to the {@link #foil} flag. */
 		public Builder useFoilAdjustedScore(boolean value)
 		{
 			this.useFoilAdjustedScore = value;
 			return this;
 		}
 
+		/** Sets the wear (condition damage) effect to render. */
 		public Builder wear(WearFx value)
 		{
 			this.wear = value;
 			return this;
 		}
 
+		/** Sets the foil sparkle effect to render (ignored on build unless {@link #foil} is set true). */
 		public Builder foilFx(FoilFx value)
 		{
 			this.foilFx = value;
 			return this;
 		}
 
+		/** Builds the immutable {@link CardFaceDrawRequest} from the accumulated fields. */
 		public CardFaceDrawRequest build()
 		{
 			return new CardFaceDrawRequest(this);

--- a/src/main/java/com/osrstcg/ui/card/CardFonts.java
+++ b/src/main/java/com/osrstcg/ui/card/CardFonts.java
@@ -7,6 +7,10 @@ import java.io.InputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Loads the plugin's bundled RuneScape-style fonts and derives sized variants used across card rendering,
+ * scaled from a fixed root size (falls back to SansSerif if a font resource is missing or fails to load).
+ */
 public final class CardFonts
 {
 	private static final Logger log = LoggerFactory.getLogger(CardFonts.class);
@@ -23,55 +27,65 @@ public final class CardFonts
 	{
 	}
 
+	/** Regular body font sized to {@code scale} of the root size. */
 	public static Font body(double scale)
 	{
 		return sized(REGULAR, ROOT_SIZE_PX * (float) Math.max(0.01d, scale));
 	}
 
+	/** Regular examine-text font sized to {@code scale} of the root size times {@code em}. */
 	public static Font examine(double scale, float em)
 	{
 		float clampedEm = Math.max(0.01f, em);
 		return sized(REGULAR, ROOT_SIZE_PX * clampedEm * (float) Math.max(0.01d, scale));
 	}
 
+	/** Bold title font sized to {@code scale} of the root size times {@code em}. */
 	public static Font title(double scale, float em)
 	{
 		float clampedEm = Math.max(0.01f, em);
 		return sized(BOLD, ROOT_SIZE_PX * clampedEm * (float) Math.max(0.01d, scale));
 	}
 
+	/** Bold font sized to {@code scale} of the root size. */
 	public static Font bold(double scale)
 	{
 		return sized(BOLD, ROOT_SIZE_PX * (float) Math.max(0.01d, scale));
 	}
 
+	/** Bold title font for full-art cards, sized with {@link #TITLE_EM} and rounded to a whole pixel size. */
 	public static Font fullArtTitle(double scale)
 	{
 		return sizedFullArt(BOLD, ROOT_SIZE_PX * TITLE_EM * (float) Math.max(0.01d, scale));
 	}
 
+	/** Bold examine-text font for full-art cards, sized with {@link #FULL_EXAMINE_EM} and rounded to a whole pixel size. */
 	public static Font fullArtExamine(double scale)
 	{
 		return sizedFullArt(BOLD, ROOT_SIZE_PX * FULL_EXAMINE_EM * (float) Math.max(0.01d, scale));
 	}
 
+	/** Bold score font for full-art cards, sized with {@link #FULL_SCORE_EM} and rounded to a whole pixel size. */
 	public static Font fullArtScore(double scale)
 	{
 		return sizedFullArt(BOLD, ROOT_SIZE_PX * FULL_SCORE_EM * (float) Math.max(0.01d, scale));
 	}
 
+	/** Derives {@code base} at {@code sizePx}, floored at 1px. */
 	private static Font sized(Font base, float sizePx)
 	{
 		float size = Math.max(1f, sizePx);
 		return base.deriveFont(size);
 	}
 
+	/** Derives {@code base} at {@code sizePx} rounded to the nearest whole pixel, floored at 1px. */
 	private static Font sizedFullArt(Font base, float sizePx)
 	{
 		float size = Math.max(1f, Math.round(sizePx));
 		return base.deriveFont(size);
 	}
 
+	/** Loads a TrueType font from the given classpath resource, falling back to SansSerif on any failure. */
 	private static Font load(String resourcePath, int fallbackStyle)
 	{
 		try (InputStream in = CardFonts.class.getResourceAsStream("/" + resourcePath))

--- a/src/main/java/com/osrstcg/ui/card/CardFxPainter.java
+++ b/src/main/java/com/osrstcg/ui/card/CardFxPainter.java
@@ -18,10 +18,16 @@ import java.awt.image.ConvolveOp;
 import java.awt.image.DataBufferInt;
 import java.awt.image.Kernel;
 
+/**
+ * Pixel-level renderer for card visual effects: foil sparkle animation and multi-layer wear (color wash,
+ * grime, edge shadows, scratches, spots) painted directly onto a card face image via custom Porter-Duff-style
+ * blend modes.
+ */
 public final class CardFxPainter
 {
 	private static final double BEZIER_K = 0.5522847498307936d;
 
+	/** Pixel compositing modes used to blend an effect layer onto the base card face. */
 	public enum BlendMode
 	{
 		MULTIPLY,
@@ -33,16 +39,19 @@ public final class CardFxPainter
 	{
 	}
 
+	/** Creates a transparent ARGB scratch layer of at least 1x1 pixels. */
 	private static BufferedImage newLayer(int width, int height)
 	{
 		return new BufferedImage(Math.max(1, width), Math.max(1, height), BufferedImage.TYPE_INT_ARGB);
 	}
 
+	/** Returns the backing int-ARGB pixel array of an image for direct read/write access. */
 	private static int[] pixels(BufferedImage img)
 	{
 		return ((DataBufferInt) img.getRaster().getDataBuffer()).getData();
 	}
 
+	/** Creates a {@link Graphics2D} for {@code img} with antialiasing and quality rendering hints enabled. */
 	static Graphics2D quality(BufferedImage img)
 	{
 		Graphics2D g = img.createGraphics();
@@ -52,6 +61,11 @@ public final class CardFxPainter
 		return g;
 	}
 
+	/**
+	 * Composites {@code layer} onto {@code base} in place using {@code mode}, scaled by {@code opacity} and
+	 * each source pixel's own alpha. No-ops on null images, non-positive opacity, or fully transparent pixels
+	 * on either side.
+	 */
 	private static void blend(BufferedImage base, BufferedImage layer, BlendMode mode, double opacity)
 	{
 		if (base == null || layer == null || opacity <= 0.0d)
@@ -95,6 +109,7 @@ public final class CardFxPainter
 		}
 	}
 
+	/** Computes the blended RGB (0-1 each) for base color ({@code br,bg,bb}) and source color ({@code sr,sg,sb}) under {@code mode}, written to {@code out}. */
 	private static void applyMode(BlendMode mode, double br, double bg, double bb, double sr, double sg, double sb,
 		double[] out)
 	{
@@ -115,6 +130,7 @@ public final class CardFxPainter
 		}
 	}
 
+	/** Standard "soft light" blend of backdrop {@code cb} and source {@code cs} channels (each 0-1). */
 	private static double softLight(double cb, double cs)
 	{
 		if (cs <= 0.5d)
@@ -125,11 +141,13 @@ public final class CardFxPainter
 		return cb + (2.0d * cs - 1.0d) * (d - cb);
 	}
 
+	/** Perceptual luminosity of an RGB color (0-1 each). */
 	private static double luminosity(double r, double g, double b)
 	{
 		return 0.3d * r + 0.59d * g + 0.11d * b;
 	}
 
+	/** Shifts {@code r,g,b} to have {@code targetLum} luminosity, then clips back into the 0-1 gamut, written to {@code out}. */
 	private static void setLuminosity(double r, double g, double b, double targetLum, double[] out)
 	{
 		double d = targetLum - luminosity(r, g, b);
@@ -159,12 +177,17 @@ public final class CardFxPainter
 		out[2] = nb;
 	}
 
+	/** Converts a 0-1 channel to a clamped 0-255 int. */
 	private static int to255(double v)
 	{
 		int i = (int) Math.round(v * 255.0d);
 		return i < 0 ? 0 : Math.min(i, 255);
 	}
 
+	/**
+	 * Desaturates, and slightly reduces contrast/brightness of, {@code base} in place, scaled by {@code fade}
+	 * (0-1). No-ops on a null image or non-positive fade.
+	 */
 	public static void applyWearFilter(BufferedImage base, double fade)
 	{
 		if (base == null || fade <= 0.0d)
@@ -210,6 +233,11 @@ public final class CardFxPainter
 		}
 	}
 
+	/**
+	 * Draws {@code fx}'s foil sparkles (clipped to a rounded-rect card outline at {@code x,y,w,h}) as radial
+	 * glow gradients, each sampled from {@link FoilSparkleAnimation} at {@code timeSec} for its current
+	 * opacity/scale. No-ops on a null graphics/fx or a degenerate (sub-2px) size.
+	 */
 	public static void drawAnimatedSparkles(Graphics2D g, int x, int y, int w, int h, double cornerRadius,
 		double scale, FoilFx fx, double timeSec)
 	{
@@ -254,6 +282,11 @@ public final class CardFxPainter
 		}
 	}
 
+	/**
+	 * Paints the full wear pipeline onto {@code face} in place: color wash, grime, edge shadows (skipped for
+	 * grades A/S), scratches, and dirt spots, each layer driven by {@code wear}'s grade and randomized detail.
+	 * No-ops on a null face or wear.
+	 */
 	public static void drawWear(BufferedImage face, double cornerRadius, WearFx wear)
 	{
 		if (face == null || wear == null)
@@ -275,6 +308,7 @@ public final class CardFxPainter
 		drawSpots(face, card, w, h, wear);
 	}
 
+	/** Blends a diagonal light-to-dark gradient over {@code face} (luminosity mode) to fade/darken the card by {@code fade}. */
 	private static void drawColorWash(BufferedImage face, Shape card, int w, int h, double fade)
 	{
 		Color light = new Color(255, 255, 255);
@@ -295,6 +329,7 @@ public final class CardFxPainter
 		blend(face, layer, BlendMode.LUMINOSITY, 0.35d + fade * 0.65d);
 	}
 
+	/** Multiply-blends three fixed dark radial patches onto {@code face} to simulate grime buildup, scaled by grade intensity and {@link WearFx#getDirtMix()}. */
 	private static void drawGrime(BufferedImage face, Shape card, int w, int h, WearFx wear)
 	{
 		double i = wear.getGrade().getIntensity();
@@ -318,6 +353,7 @@ public final class CardFxPainter
 		blend(face, layer, BlendMode.MULTIPLY, opacity);
 	}
 
+	/** Transform that squashes a circular gradient centered at {@code cx,cy} into an ellipse of radii {@code rx,ry}. */
 	private static AffineTransform ellipseScaleTx(double cx, double cy, double rx, double ry)
 	{
 		AffineTransform tx = new AffineTransform();
@@ -327,6 +363,7 @@ public final class CardFxPainter
 		return tx;
 	}
 
+	/** Fills the whole {@code w}x{@code h} canvas with an elliptical radial gradient (center/radii as percents) fading from {@code color} at {@code alpha} to transparent at {@code endStop}. */
 	private static void radialEllipse(Graphics2D g, int w, int h, double cxPct, double cyPct, double rxPct, double ryPct,
 		Color color, double alpha, double endStop)
 	{
@@ -344,6 +381,11 @@ public final class CardFxPainter
 		g.fill(new Rectangle2D.Double(0, 0, w, h));
 	}
 
+	/**
+	 * Darkens/lightens pixels near the card's border to simulate worn edges: a white highlight ring inside a
+	 * black drop-shadow, using distance-from-edge falloff LUTs from {@link #shadowFalloff}. Grade E adds an
+	 * extra thin ring. Intensity/opacity scale with grade intensity and {@link WearFx#getEdgeMix()}.
+	 */
 	private static void applyEdges(BufferedImage face, int w, int h, WearFx wear)
 	{
 		double i = wear.getGrade().getIntensity();
@@ -424,6 +466,7 @@ public final class CardFxPainter
 		}
 	}
 
+	/** Builds a sigmoid-falloff alpha lookup table (index = pixel distance from edge, 0..{@code size}-1) peaking at {@code peakAlpha} and softened by {@code blur}. */
 	private static double[] shadowFalloff(int size, double blur, double peakAlpha)
 	{
 		double[] lut = new double[size];
@@ -444,6 +487,7 @@ public final class CardFxPainter
 		return lut;
 	}
 
+	/** Soft-light blends each of {@code wear}'s scratches onto {@code face} as a rotated bar with a dark base and bright highlight streak. */
 	private static void drawScratches(BufferedImage face, Shape card, int w, int h, WearFx wear)
 	{
 		if (wear.getScratches().isEmpty())
@@ -494,6 +538,10 @@ public final class CardFxPainter
 		blend(face, layer, BlendMode.SOFT_LIGHT, 1.0d);
 	}
 
+	/**
+	 * Multiply-blends each of {@code wear}'s dirt spots onto {@code face}: blurred spots are painted on their
+	 * own layer and softened via {@link #softenLayer} before blending, while unblurred spots share one sharp layer.
+	 */
 	private static void drawSpots(BufferedImage face, Shape card, int w, int h, WearFx wear)
 	{
 		if (wear.getSpots().isEmpty())
@@ -535,6 +583,7 @@ public final class CardFxPainter
 		blend(face, sharp, BlendMode.MULTIPLY, 1.0d);
 	}
 
+	/** Fills one rotated, rounded-rect-clipped spot shape with its shape-specific gradient paint from {@link #spotPaint}. */
 	private static void paintSpot(Graphics2D g, int w, int h, WearFx.Spot spot)
 	{
 		double sw = Math.max(1.0d, spot.getW() / 100.0d * w);
@@ -563,6 +612,7 @@ public final class CardFxPainter
 		}
 	}
 
+	/** Returns the dirt-colored gradient paint appropriate to a spot's {@link WearFx.SpotShape}, sized to {@code w}x{@code h} and scaled by opacity {@code op}. */
 	private static java.awt.Paint spotPaint(WearFx.SpotShape shape, double w, double h, double op)
 	{
 		switch (shape)
@@ -601,6 +651,7 @@ public final class CardFxPainter
 		}
 	}
 
+	/** Elliptical (center/radii as percents of {@code w}x{@code h}) radial gradient paint from {@code inner} through {@code mid} to transparent. */
 	private static java.awt.Paint ellipseGradient(double w, double h, double cxPct, double cyPct, double rxPct, double ryPct,
 		Color inner, double innerAlpha, Color mid, double midAlpha, float midStop, float endStop)
 	{
@@ -617,6 +668,7 @@ public final class CardFxPainter
 			ellipseScaleTx(cx, cy, rx, ry));
 	}
 
+	/** Approximates a Gaussian blur by repeatedly applying a 3x3 box-weighted convolution kernel, {@code blurPx} passes (min 1). */
 	private static BufferedImage softenLayer(BufferedImage layer, double blurPx)
 	{
 		int passes = Math.max(1, (int) Math.round(Math.max(0.2d, blurPx)));
@@ -634,6 +686,7 @@ public final class CardFxPainter
 		return current;
 	}
 
+	/** Builds a {@link LinearGradientPaint} spanning the {@code w}x{@code h} canvas at CSS-style {@code angleDeg} (0 = top, clockwise). */
 	private static LinearGradientPaint cssLinearGradient(int w, int h, double angleDeg,
 		float[] fractions, Color[] colors)
 	{
@@ -649,6 +702,11 @@ public final class CardFxPainter
 			fractions, colors, MultipleGradientPaint.CycleMethod.NO_CYCLE);
 	}
 
+	/**
+	 * Builds a CSS-style rounded-rect path of size {@code w}x{@code h} from 8 per-corner radius percentages
+	 * (horizontal/vertical radius for each of top-left, top-right, bottom-right, bottom-left), scaling all
+	 * radii down proportionally if any pair would overlap.
+	 */
 	private static Shape borderRadiusShape(double w, double h, double[] radiiPercent)
 	{
 		double htl = radiiPercent[0] / 100.0d * w;
@@ -691,11 +749,13 @@ public final class CardFxPainter
 		return p;
 	}
 
+	/** Fraction by which paired corner radii must shrink to fit within {@code side}; 1.0 (no shrink) if {@code sum} is non-positive or already fits. */
 	private static double ratio(double side, double sum)
 	{
 		return sum <= 0.0d ? 1.0d : Math.min(1.0d, side / sum);
 	}
 
+	/** Shorthand for {@link CardColorMath#withAlpha}. */
 	public static Color alpha(Color c, double a)
 	{
 		return CardColorMath.withAlpha(c, a);

--- a/src/main/java/com/osrstcg/ui/card/CardGrade.java
+++ b/src/main/java/com/osrstcg/ui/card/CardGrade.java
@@ -1,5 +1,9 @@
 package com.osrstcg.ui.card;
 
+/**
+ * Card condition grade (S best to E worst), each carrying a wear-effect intensity and color-fade amount
+ * used to drive {@link WearFx} and {@link CardFxPainter}.
+ */
 public enum CardGrade
 {
 	S(0.0d, 0.0d),
@@ -12,22 +16,26 @@ public enum CardGrade
 	private final double intensity;
 	private final double fade;
 
+	/** Stores the wear intensity and color-fade amounts for this grade. */
 	CardGrade(double intensity, double fade)
 	{
 		this.intensity = intensity;
 		this.fade = fade;
 	}
 
+	/** Strength of scratch/dirt/edge wear effects for this grade (0 = none). */
 	public double getIntensity()
 	{
 		return intensity;
 	}
 
+	/** Amount of color desaturation/darkening applied for this grade (0 = none). */
 	public double getFade()
 	{
 		return fade;
 	}
 
+	/** Maps a 0-100 condition value to a grade band; returns null for a null/NaN/infinite condition. */
 	public static CardGrade gradeFromCondition(Double condition)
 	{
 		if (condition == null || condition.isNaN() || condition.isInfinite())
@@ -58,6 +66,7 @@ public enum CardGrade
 		return E;
 	}
 
+	/** Beta-migrated copies are always graded S regardless of condition; otherwise defers to {@link #gradeFromCondition}. */
 	public static CardGrade gradeFromVariant(boolean beta, Double condition)
 	{
 		if (beta)
@@ -67,6 +76,7 @@ public enum CardGrade
 		return gradeFromCondition(condition);
 	}
 
+	/** Formats a condition value to two decimal places, or null for a null/NaN/infinite input. */
 	public static String formatCondition(Double condition)
 	{
 		if (condition == null || condition.isNaN() || condition.isInfinite())

--- a/src/main/java/com/osrstcg/ui/card/ExamineTextLayout.java
+++ b/src/main/java/com/osrstcg/ui/card/ExamineTextLayout.java
@@ -5,6 +5,10 @@ import java.awt.FontMetrics;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Word-wraps card examine text to a pixel width (breaking mid-word if a single token overflows) and binary
+ * searches for the largest examine font size ({@link #EXAMINE_EM_MIN}-{@link #EXAMINE_EM_MAX}) that still fits a band.
+ */
 public final class ExamineTextLayout
 {
 	public static final float EXAMINE_EM_MAX = 1.18f;
@@ -16,11 +20,16 @@ public final class ExamineTextLayout
 	{
 	}
 
+	/** Line height in pixels for a given font size, using {@link #EXAMINE_LINE_HEIGHT}. */
 	public static int lineHeightPx(float fontSizePx)
 	{
 		return Math.max(1, Math.round(fontSizePx * EXAMINE_LINE_HEIGHT));
 	}
 
+	/**
+	 * Wraps {@code text} to {@code maxWidth} pixels, breaking on whitespace and splitting any single word
+	 * that still overflows the width. Normalizes line endings and preserves blank lines/paragraphs.
+	 */
 	public static List<String> wrapBreakWord(FontMetrics fm, String text, int maxWidth)
 	{
 		List<String> lines = new ArrayList<>();
@@ -48,6 +57,7 @@ public final class ExamineTextLayout
 		return lines;
 	}
 
+	/** Greedily packs whitespace-split tokens of one paragraph onto lines no wider than {@code width}, appending to {@code lines}. */
 	private static void wrapParagraphBreakWord(
 		FontMetrics fm, String paragraph, int width, List<String> lines)
 	{
@@ -93,6 +103,11 @@ public final class ExamineTextLayout
 		}
 	}
 
+	/**
+	 * Binary-searches (over {@link #EXAMINE_FIT_STEPS} steps) for the largest em size in
+	 * [{@link #EXAMINE_EM_MIN}, {@link #EXAMINE_EM_MAX}] at which the wrapped text fits within
+	 * {@code maxWidth} x {@code bandHeight}. Blank text is replaced with a placeholder before measuring.
+	 */
 	public static float fitExamineEm(FontMetricsFactory metrics, double scale, String text, int maxWidth, int bandHeight)
 	{
 		String examine = text == null || text.trim().isEmpty() ? "No examine text." : text.trim();
@@ -123,6 +138,7 @@ public final class ExamineTextLayout
 		return Math.round(best * 1000f) / 1000f;
 	}
 
+	/** Whether {@code text}, wrapped at {@code em} size, fits within {@code maxWidth} x {@code bandHeight} (with 0.5px slack). */
 	public static boolean fits(
 		FontMetricsFactory metrics, double scale, String text, int maxWidth, int bandHeight, float em)
 	{
@@ -133,12 +149,18 @@ public final class ExamineTextLayout
 		return lines.size() * lineH <= bandHeight + 0.5f;
 	}
 
+	/** Supplies {@link FontMetrics} for a given font, so layout can be measured without a live graphics context. */
 	@FunctionalInterface
 	public interface FontMetricsFactory
 	{
 		FontMetrics metricsFor(Font font);
 	}
 
+	/**
+	 * Splits a single overflowing word into width-limited chunks appended to {@code lines}, leaving the
+	 * final chunk in {@code current} for the caller to keep accumulating. Respects surrogate pairs so
+	 * multi-char code points are never split.
+	 */
 	private static void breakTokenAcrossLines(
 		FontMetrics fm, String token, int maxWidth, List<String> lines, StringBuilder current)
 	{

--- a/src/main/java/com/osrstcg/ui/card/FoilFx.java
+++ b/src/main/java/com/osrstcg/ui/card/FoilFx.java
@@ -8,11 +8,16 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Value;
 
+/**
+ * Deterministic foil sparkle layout for a card: a seeded set of {@link Sparkle}s (position, size, timing,
+ * color) generated from the pull identity so the same card always renders the same foil pattern.
+ */
 @Getter
 public final class FoilFx
 {
 	public static final int DEFAULT_SPARKLE_COUNT = 22;
 
+	/** One sparkle's position (percent of card), size, animation timing, and HSL color. */
 	@Value
 	public static class Sparkle
 	{
@@ -29,12 +34,18 @@ public final class FoilFx
 	private final int seed;
 	private final List<Sparkle> sparkles;
 
+	/** Stores the seed and wraps the sparkle list as unmodifiable. */
 	private FoilFx(int seed, List<Sparkle> sparkles)
 	{
 		this.seed = seed;
 		this.sparkles = Collections.unmodifiableList(sparkles);
 	}
 
+	/**
+	 * Builds a {@link FoilFx} for a pulled card: seeds a PRNG from the pull identity ({@code cardName}/{@code pulledAt}),
+	 * derives a base hue from the card's rarity tier (silver/near-white sparkles for commons, hue-tinted for
+	 * everything else), and generates {@code count} randomly placed and timed sparkles.
+	 */
 	public static FoilFx foilFxFromPulledAt(
 		Long pulledAt, int count, String cardName, String tierLabel, Color tierColor)
 	{
@@ -75,6 +86,11 @@ public final class FoilFx
 		return new FoilFx(seed, sparkles);
 	}
 
+	/**
+	 * Resolves the rarity tier to drive sparkle color: prefers a valid {@code tierLabel}; otherwise falls back
+	 * to common unless {@code tierColor} carries a distinguishable hue, in which case its hue is used via
+	 * {@link #foilBaseHue}.
+	 */
 	static RarityMath.Tier resolveTier(String tierLabel, Color tierColor)
 	{
 		RarityMath.Tier fromLabel = RarityMath.tierFromLabel(tierLabel == null ? "" : tierLabel);
@@ -90,6 +106,7 @@ public final class FoilFx
 		return fromLabel;
 	}
 
+	/** Fixed sparkle hue per known rarity tier; for common or any unlisted tier, derives hue from {@code tierColor} instead (0 if none). */
 	static double foilBaseHue(RarityMath.Tier tier, Color tierColor)
 	{
 		if (tier == null || tier == RarityMath.Tier.COMMON)
@@ -116,6 +133,7 @@ public final class FoilFx
 		}
 	}
 
+	/** Extracts the HSV hue (0-360) from an RGB color, or null if the color is too close to gray to have a meaningful hue. */
 	static Double hueFromColor(Color color)
 	{
 		if (color == null)
@@ -153,6 +171,7 @@ public final class FoilFx
 		return h;
 	}
 
+	/** Wraps a hue value into the [0, 360) range. */
 	static double wrapHue(double hue)
 	{
 		double h = hue % 360.0d;

--- a/src/main/java/com/osrstcg/ui/card/FoilSparkleAnimation.java
+++ b/src/main/java/com/osrstcg/ui/card/FoilSparkleAnimation.java
@@ -1,5 +1,9 @@
 package com.osrstcg.ui.card;
 
+/**
+ * Computes a single sparkle's animated opacity and scale at a point in time, looping a fade-in/hold/fade-out
+ * cycle (via a cubic-bezier ease) over each sparkle's delay and duration.
+ */
 public final class FoilSparkleAnimation
 {
 	private static final double EASE_X1 = 0.42d;
@@ -7,22 +11,26 @@ public final class FoilSparkleAnimation
 	private static final double EASE_X2 = 0.58d;
 	private static final double EASE_Y2 = 1.0d;
 
+	/** Opacity and scale of a sparkle at a sampled point in its animation cycle. */
 	public static final class Sample
 	{
 		private final double opacity;
 		private final double scale;
 
+		/** Stores the sampled opacity and scale. */
 		Sample(double opacity, double scale)
 		{
 			this.opacity = opacity;
 			this.scale = scale;
 		}
 
+		/** Sparkle opacity (0-1) at this sample point. */
 		public double getOpacity()
 		{
 			return opacity;
 		}
 
+		/** Sparkle size multiplier at this sample point. */
 		public double getScale()
 		{
 			return scale;
@@ -33,6 +41,11 @@ public final class FoilSparkleAnimation
 	{
 	}
 
+	/**
+	 * Samples a sparkle's animation at {@code timeSec}, given its {@code delaySec} start offset and cycle
+	 * {@code durationSec}. Before the delay elapses, or when duration is non-positive, returns the invisible
+	 * resting state; otherwise loops the elapsed time into a 0-1 phase and delegates to {@link #samplePhase}.
+	 */
 	public static Sample sample(double delaySec, double durationSec, double timeSec)
 	{
 		if (durationSec <= 0.0d)
@@ -52,6 +65,11 @@ public final class FoilSparkleAnimation
 		return samplePhase(phase);
 	}
 
+	/**
+	 * Maps a 0-1 cycle phase to opacity/scale: eased fade-in and grow (0-0.40), a brief hold near full
+	 * opacity/scale (0.40-0.55), an eased shrink (0.55-0.70), then an eased fade-out and further shrink
+	 * (0.70-1.0). Phase outside (0, 1) is treated as fully invisible.
+	 */
 	static Sample samplePhase(double phase)
 	{
 		double p = phase;
@@ -77,11 +95,13 @@ public final class FoilSparkleAnimation
 		return lerp(0.2d, 0.7d, 0.0d, 0.4d, u);
 	}
 
+	/** Linearly interpolates opacity and scale between two endpoints by {@code u} (0-1). */
 	private static Sample lerp(double o0, double s0, double o1, double s1, double u)
 	{
 		return new Sample(o0 + (o1 - o0) * u, s0 + (s1 - s0) * u);
 	}
 
+	/** Clamps {@code t} to 0-1 and applies the class's cubic-bezier ease curve. */
 	static double easeInOut(double t)
 	{
 		double x = Math.max(0.0d, Math.min(1.0d, t));
@@ -96,6 +116,7 @@ public final class FoilSparkleAnimation
 		return cubicBezierY(EASE_X1, EASE_Y1, EASE_X2, EASE_Y2, x);
 	}
 
+	/** Solves for parametric {@code t} where the cubic-bezier's x-coordinate equals {@code x} (Newton's method), then returns its y. */
 	private static double cubicBezierY(double x1, double y1, double x2, double y2, double x)
 	{
 		double t = x;
@@ -113,12 +134,14 @@ public final class FoilSparkleAnimation
 		return bezierCoord(t, y1, y2);
 	}
 
+	/** Evaluates a cubic bezier with control points at 0, {@code p1}, {@code p2}, 1 at parameter {@code t}. */
 	private static double bezierCoord(double t, double p1, double p2)
 	{
 		double u = 1.0d - t;
 		return 3.0d * u * u * t * p1 + 3.0d * u * t * t * p2 + t * t * t;
 	}
 
+	/** Derivative of {@link #bezierCoord} with respect to {@code t}. */
 	private static double bezierDerivative(double t, double p1, double p2)
 	{
 		double u = 1.0d - t;

--- a/src/main/java/com/osrstcg/ui/card/WearFx.java
+++ b/src/main/java/com/osrstcg/ui/card/WearFx.java
@@ -7,9 +7,15 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Value;
 
+/**
+ * Deterministic wear (condition damage) layout for a card: a seeded set of scratches and dirt spots plus
+ * dirt/edge mix ratios, generated from the card's grade and pull identity so the same card always renders
+ * the same wear pattern. Consumed by {@link CardFxPainter#drawWear}.
+ */
 @Getter
 public final class WearFx
 {
+	/** Silhouette used to render one dirt {@link Spot}. */
 	public enum SpotShape
 	{
 		ROUND,
@@ -19,15 +25,18 @@ public final class WearFx
 		SPLOTCH
 	}
 
+	/** Seeded Mulberry32 PRNG producing doubles in [0, 1), used for deterministic wear generation. */
 	public static final class Mulberry32
 	{
 		private int a;
 
+		/** Seeds the generator; a zero seed is replaced with a fixed non-zero constant. */
 		public Mulberry32(int seed)
 		{
 			this.a = seed == 0 ? 0x9E3779B9 : seed;
 		}
 
+		/** Advances the generator and returns the next pseudo-random value in [0, 1). */
 		public double next()
 		{
 			a = a + 0x6D2B79F5;
@@ -37,6 +46,7 @@ public final class WearFx
 		}
 	}
 
+	/** A single scratch mark: position (percent), length (percent of width), rotation angle, and opacity. */
 	@Value
 	public static class Scratch
 	{
@@ -47,6 +57,7 @@ public final class WearFx
 		double opacity;
 	}
 
+	/** A single dirt spot: position/size (percent), rotation, per-corner border radius, blur amount, shape, and opacity. */
 	@Value
 	public static class Spot
 	{
@@ -61,6 +72,7 @@ public final class WearFx
 		SpotShape shape;
 		double opacity;
 
+		/** Defensive copy of the 8-element per-corner border radius array. */
 		public double[] getBorderRadius()
 		{
 			return borderRadius.clone();
@@ -74,6 +86,7 @@ public final class WearFx
 	private final List<Scratch> scratches;
 	private final List<Spot> spots;
 
+	/** Stores the seed, grade, mix ratios, and wraps the scratch/spot lists as unmodifiable. */
 	private WearFx(int seed, CardGrade grade, double dirtMix, double edgeMix, List<Scratch> scratches, List<Spot> spots)
 	{
 		this.seed = seed;
@@ -84,6 +97,7 @@ public final class WearFx
 		this.spots = Collections.unmodifiableList(spots);
 	}
 
+	/** FNV-1a hash of a string to a 32-bit seed value. */
 	public static int hashStringToSeed(String str)
 	{
 		int h = 0x811C9DC5;
@@ -99,6 +113,11 @@ public final class WearFx
 		return h;
 	}
 
+	/**
+	 * Derives a wear seed by hashing the card name, puller, and pull time together, so wear stays stable
+	 * across renders of the same pulled copy. Falls back to {@code fallback} (or 1) when all three are empty/zero;
+	 * a zero hash result is also mapped to 1 (a valid Mulberry32 seed).
+	 */
 	public static int wearSeedFromPull(String cardName, String pulledBy, Long pulledAt, int fallback)
 	{
 		String name = cardName == null ? "" : cardName.trim();
@@ -112,6 +131,12 @@ public final class WearFx
 		return h == 0 ? 1 : h;
 	}
 
+	/**
+	 * Builds a {@link WearFx} for a card copy from its condition/beta status and pull identity. Returns null
+	 * for a grade with zero intensity and fade (i.e. mint/beta condition needs no wear effect). Seeds a PRNG
+	 * from the pull identity and, for grades below A, generates randomized scratches; all non-mint grades get
+	 * randomized dirt spots (fewer/gentler for grade A, scaled by intensity otherwise).
+	 */
 	public static WearFx wearFxFromCondition(Double condition, Long pulledAt, boolean beta, String cardName, String pulledBy)
 	{
 		CardGrade grade = CardGrade.gradeFromVariant(beta, condition);
@@ -187,6 +212,7 @@ public final class WearFx
 		return new WearFx(seed, grade, dirtMix, edgeMix, scratches, spots);
 	}
 
+	/** Derives a fallback seed from the raw condition value (scaled to an int) when no pull identity is available; never returns 0. */
 	private static int conditionFallbackSeed(Double condition)
 	{
 		if (condition == null || condition.isNaN() || condition.isInfinite())
@@ -201,6 +227,7 @@ public final class WearFx
 		return (int) v;
 	}
 
+	/** Intermediate geometry (shape, size, rotation, border radii, blur) for one dirt spot before wrapping in a {@link Spot}. */
 	private static final class SpotGeom
 	{
 		final SpotShape shape;
@@ -210,6 +237,7 @@ public final class WearFx
 		final double[] borderRadius;
 		final double blur;
 
+		/** Stores the computed spot geometry fields verbatim. */
 		SpotGeom(SpotShape shape, double w, double h, double rotate, double[] borderRadius, double blur)
 		{
 			this.shape = shape;
@@ -221,6 +249,7 @@ public final class WearFx
 		}
 	}
 
+	/** Random per-corner border radii (8 values, 22-80%) for an organic (blob/splotch) spot outline. */
 	private static double[] organicBorderRadius(Mulberry32 rand)
 	{
 		double[] corners = new double[8];
@@ -231,6 +260,7 @@ public final class WearFx
 		return corners;
 	}
 
+	/** All 8 border-radius corners set to the same percentage (used for round/ellipse/smear spots). */
 	private static double[] uniformRadius(double percent)
 	{
 		double[] corners = new double[8];
@@ -241,6 +271,7 @@ public final class WearFx
 		return corners;
 	}
 
+	/** Randomly picks a spot shape (weighted round/ellipse/smear/blob/splotch) and generates its size, rotation, border radii, and blur. */
 	private static SpotGeom spotGeometry(Mulberry32 rand, double baseSize)
 	{
 		double pick = rand.next();

--- a/src/main/java/com/osrstcg/ui/collection/CollectionFilterOptions.java
+++ b/src/main/java/com/osrstcg/ui/collection/CollectionFilterOptions.java
@@ -5,17 +5,20 @@ import com.osrstcg.catalog.RarityMath;
 import java.util.List;
 import javax.swing.DefaultComboBoxModel;
 
+/** Builds the {@link DefaultComboBoxModel} contents (and resolves the current selection) for the collection tab's pack and rarity filter dropdowns. */
 public final class CollectionFilterOptions
 {
 	private CollectionFilterOptions()
 	{
 	}
 
+	/** A populated pack-filter combo model plus the option that should be selected. */
 	public static final class PackComboModel
 	{
 		public final DefaultComboBoxModel<PackFilterOption> model;
 		public final PackFilterOption selected;
 
+		/** Stores the built model and resolved selection verbatim. */
 		PackComboModel(DefaultComboBoxModel<PackFilterOption> model, PackFilterOption selected)
 		{
 			this.model = model;
@@ -23,11 +26,13 @@ public final class CollectionFilterOptions
 		}
 	}
 
+	/** A populated rarity-filter combo model plus the option that should be selected. */
 	public static final class RarityComboModel
 	{
 		public final DefaultComboBoxModel<RarityFilterOption> model;
 		public final RarityFilterOption selected;
 
+		/** Stores the built model and resolved selection verbatim. */
 		RarityComboModel(DefaultComboBoxModel<RarityFilterOption> model, RarityFilterOption selected)
 		{
 			this.model = model;
@@ -35,6 +40,10 @@ public final class CollectionFilterOptions
 		}
 	}
 
+	/**
+	 * Builds a combo model with an "All" option followed by one option per non-null pack, and resolves
+	 * which option matches {@code selectedPack} by id.
+	 */
 	public static PackComboModel packComboModel(List<BoosterPackDefinition> packs, BoosterPackDefinition selectedPack)
 	{
 		DefaultComboBoxModel<PackFilterOption> model = new DefaultComboBoxModel<>();
@@ -57,6 +66,10 @@ public final class CollectionFilterOptions
 		return new PackComboModel(model, selected);
 	}
 
+	/**
+	 * Builds a combo model with an "All" option followed by one option per {@link RarityMath.Tier},
+	 * and resolves which option matches {@code selectedTier}.
+	 */
 	public static RarityComboModel rarityComboModel(RarityMath.Tier selectedTier)
 	{
 		DefaultComboBoxModel<RarityFilterOption> model = new DefaultComboBoxModel<>();
@@ -74,22 +87,26 @@ public final class CollectionFilterOptions
 		return new RarityComboModel(model, selected);
 	}
 
+	/** A single pack-filter combo entry; a null {@link #packId} represents the "All" option. */
 	public static final class PackFilterOption
 	{
 		private final String packId;
 		private final String label;
 
+		/** Stores the collection key and display label verbatim. */
 		private PackFilterOption(String packId, String label)
 		{
 			this.packId = packId;
 			this.label = label;
 		}
 
+		/** The "All" (no filter) option. */
 		public static PackFilterOption all()
 		{
 			return new PackFilterOption(null, "All");
 		}
 
+		/** Builds the option for one pack, preferring its collection name over its own name/id as the label. */
 		public static PackFilterOption of(BoosterPackDefinition pack)
 		{
 			String key = pack.getCollectionKey();
@@ -106,11 +123,13 @@ public final class CollectionFilterOptions
 			return new PackFilterOption(key, label == null ? "Pack" : label);
 		}
 
+		/** The pack's collection key, or {@code null} for the "All" option. */
 		public String getPackId()
 		{
 			return packId;
 		}
 
+		/** The combo box's rendered label. */
 		@Override
 		public String toString()
 		{
@@ -118,32 +137,38 @@ public final class CollectionFilterOptions
 		}
 	}
 
+	/** A single rarity-filter combo entry; a null {@link #tier} represents the "All" option. */
 	public static final class RarityFilterOption
 	{
 		private final RarityMath.Tier tier;
 		private final String label;
 
+		/** Stores the tier and display label verbatim. */
 		private RarityFilterOption(RarityMath.Tier tier, String label)
 		{
 			this.tier = tier;
 			this.label = label;
 		}
 
+		/** The "All" (no filter) option. */
 		public static RarityFilterOption all()
 		{
 			return new RarityFilterOption(null, "All");
 		}
 
+		/** Builds the option for one rarity tier, using the tier's own label. */
 		public static RarityFilterOption of(RarityMath.Tier tier)
 		{
 			return new RarityFilterOption(tier, tier.getLabel());
 		}
 
+		/** The filtered rarity tier, or {@code null} for the "All" option. */
 		public RarityMath.Tier getTier()
 		{
 			return tier;
 		}
 
+		/** The combo box's rendered label. */
 		@Override
 		public String toString()
 		{

--- a/src/main/java/com/osrstcg/ui/collection/CollectionListModel.java
+++ b/src/main/java/com/osrstcg/ui/collection/CollectionListModel.java
@@ -15,8 +15,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+/** Builds and sorts the filtered {@link Row} list shown by the Collection tab's card list, off the EDT. */
 public final class CollectionListModel
 {
+	/** Ordering applied to the collection row list; the trailing label is also the combo box display text. */
 	public enum SortMode
 	{
 		SCORE_DESC("Score (high → low)"),
@@ -28,11 +30,13 @@ public final class CollectionListModel
 
 		private final String label;
 
+		/** Stores the combo box display label. */
 		SortMode(String label)
 		{
 			this.label = label;
 		}
 
+		/** The combo box display label. */
 		public String getLabel()
 		{
 			return label;
@@ -45,6 +49,7 @@ public final class CollectionListModel
 		}
 	}
 
+	/** One owned card/foil entry ready for display: display fields plus the values sort modes compare on. */
 	public static final class Row
 	{
 		private final String name;
@@ -53,6 +58,7 @@ public final class CollectionListModel
 		private final long score;
 		private final long pulledAtEpochMs;
 
+		/** Normalizes nulls/negatives (blank name, {@link RarityMath.Tier#COMMON} default, clamped score/timestamp). */
 		public Row(String name, boolean foil, RarityMath.Tier tier, long score, long pulledAtEpochMs)
 		{
 			this.name = name == null ? "" : name;
@@ -82,6 +88,7 @@ public final class CollectionListModel
 			return score;
 		}
 
+		/** Most recent pull timestamp across owned copies of this name/foil combination; 0 if unknown. */
 		public long getPulledAtEpochMs()
 		{
 			return pulledAtEpochMs;
@@ -92,6 +99,10 @@ public final class CollectionListModel
 	{
 	}
 
+	/**
+	 * Aggregates the player's non-beta owned cards into one {@link Row} per name/foil combination, applies
+	 * the pack-eligibility, rarity, and name filters, then sorts by {@code sortMode}. Safe to call off the EDT.
+	 */
 	public static List<Row> buildRows(
 		CollectionState collection,
 		Map<String, CardDefinition> cardsByLowerName,
@@ -148,6 +159,7 @@ public final class CollectionListModel
 		return rows;
 	}
 
+	/** Whether the card's key name or catalog display name contains {@code queryLower} (already lowercased). */
 	private static boolean nameMatchesQuery(String cardName, CardDefinition def, String queryLower)
 	{
 		if (cardName != null && cardName.toLowerCase(Locale.ROOT).contains(queryLower))
@@ -162,6 +174,10 @@ public final class CollectionListModel
 		return false;
 	}
 
+	/**
+	 * Names eligible for a booster's set-completion tracking: cards matching its category filters, or the
+	 * whole roll pool when it has none.
+	 */
 	public static Set<String> eligibleNamesForPack(
 		BoosterPackDefinition booster,
 		List<CardDefinition> allCards,
@@ -192,6 +208,7 @@ public final class CollectionListModel
 		return eligible;
 	}
 
+	/** Indexes card definitions by trimmed, lowercased name for case-insensitive lookup; first match wins on duplicates. */
 	public static Map<String, CardDefinition> indexByLowerName(List<CardDefinition> cards)
 	{
 		Map<String, CardDefinition> map = new HashMap<>();
@@ -210,6 +227,7 @@ public final class CollectionListModel
 		return map;
 	}
 
+	/** Fills {@code maxPulledAtOut} with the latest pull timestamp per name/foil key, skipping beta copies. */
 	private static void aggregateOwnedExcludingBeta(
 		CollectionState collection,
 		Map<CardCollectionKey, Long> maxPulledAtOut)
@@ -229,6 +247,7 @@ public final class CollectionListModel
 		}
 	}
 
+	/** Row comparator for {@code mode}; every mode uses name and foil status as tiebreakers. */
 	private static Comparator<Row> comparatorFor(SortMode mode)
 	{
 		Comparator<Row> byName = Comparator.comparing(r -> r.getName().toLowerCase(Locale.ROOT));

--- a/src/main/java/com/osrstcg/ui/collection/CollectionRowRenderer.java
+++ b/src/main/java/com/osrstcg/ui/collection/CollectionRowRenderer.java
@@ -15,6 +15,11 @@ import javax.swing.border.EmptyBorder;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 
+/**
+ * Renders one {@link CollectionListModel.Row} in the Collection tab's card {@link JList}: card name
+ * (tier-colored, foil-starred) on the left, compact score on the right. Reused as a shared cell renderer,
+ * so all mutation happens on the Swing EDT inside {@link #getListCellRendererComponent}.
+ */
 public final class CollectionRowRenderer extends JPanel
 	implements ListCellRenderer<CollectionListModel.Row>
 {
@@ -22,6 +27,7 @@ public final class CollectionRowRenderer extends JPanel
 	private final JLabel score = new JLabel();
 	private final IntSupplier contentWidth;
 
+	/** Builds the fixed name/score label layout; {@code contentWidth} supplies the list's current cell width. */
 	public CollectionRowRenderer(IntSupplier contentWidth)
 	{
 		this.contentWidth = contentWidth;
@@ -36,6 +42,7 @@ public final class CollectionRowRenderer extends JPanel
 		add(score, BorderLayout.EAST);
 	}
 
+	/** Updates the shared row panel's text/color for {@code value} and clamps it to the list's current width. */
 	@Override
 	public Component getListCellRendererComponent(
 		JList<? extends CollectionListModel.Row> list,

--- a/src/main/java/com/osrstcg/ui/collection/CollectionTab.java
+++ b/src/main/java/com/osrstcg/ui/collection/CollectionTab.java
@@ -49,10 +49,17 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 
+/**
+ * Collection tab controller: owns the filter/sort/search toolbar and the card list, and rebuilds the row
+ * list on a background executor so filtering/sorting large collections doesn't block the EDT. All Swing
+ * mutation is dispatched back onto the EDT via {@link SwingUtilities#invokeLater}.
+ */
 @Slf4j
 public final class CollectionTab
 {
+	/** {@link CardLayout} key for the card-list panel when it has rows to show. */
 	public static final String LIST_CARD = "list";
+	/** {@link CardLayout} key for the placeholder panel shown when the filtered list is empty. */
 	public static final String EMPTY_CARD = "empty";
 	private static final int ROW_HEIGHT = 24;
 
@@ -77,6 +84,7 @@ public final class CollectionTab
 	private CollectionListModel.SortMode collectionSortMode = CollectionListModel.SortMode.SCORE_DESC;
 	private String collectionSearchQuery = "";
 
+	/** Wires the collaborators and the pre-built Swing components this controller drives. */
 	public CollectionTab(
 		CardDatabase cardDatabase,
 		PackCatalogService packCatalogService,
@@ -106,6 +114,11 @@ public final class CollectionTab
 		this.collectionSearchField = createCollectionSearchField();
 	}
 
+	/**
+	 * One-time setup of the card list's appearance and behavior: styling, fixed row height, the shared row
+	 * renderer, a no-op selection model (the list is display-only), and width sync on scroll pane resize.
+	 * Must be called on the EDT.
+	 */
 	public void configureList()
 	{
 		collectionEmptyLabel.setForeground(new Color(0xAAAAAA));
@@ -118,11 +131,13 @@ public final class CollectionTab
 		collectionList.setCellRenderer(new CollectionRowRenderer(contentWidth));
 		collectionList.setSelectionModel(new DefaultListSelectionModel()
 		{
+			/** No-op: the collection list is not selectable. */
 			@Override
 			public void setSelectionInterval(int index0, int index1)
 			{
 			}
 
+			/** No-op: the collection list is not selectable. */
 			@Override
 			public void addSelectionInterval(int index0, int index1)
 			{
@@ -133,6 +148,7 @@ public final class CollectionTab
 		syncCellWidth();
 		collectionListScrollPane.addComponentListener(new ComponentAdapter()
 		{
+			/** Keeps the list's fixed cell width matched to the scroll pane's current viewport width. */
 			@Override
 			public void componentResized(ComponentEvent e)
 			{
@@ -141,16 +157,19 @@ public final class CollectionTab
 		});
 	}
 
+	/** Bumps the build generation so any in-flight background row rebuild discards its result once done. */
 	public void cancelPendingRebuilds()
 	{
 		buildGen.incrementAndGet();
 	}
 
+	/** Clears the visible list data without touching filters or triggering a rebuild. */
 	public void clearList()
 	{
 		collectionList.setListData(new CollectionListModel.Row[0]);
 	}
 
+	/** Applies {@link #contentWidth} to the list's fixed cell width if it has changed. */
 	private void syncCellWidth()
 	{
 		int w = contentWidth.getAsInt();
@@ -160,6 +179,10 @@ public final class CollectionTab
 		}
 	}
 
+	/**
+	 * Rebuilds the toolbar and swaps it plus the list host into {@link #collectionContent}, then kicks off
+	 * an async rebuild of the row list for the current filters. Must be called on the EDT.
+	 */
 	public void render()
 	{
 		PackCloseSnapshot snap = snapshotSupplier.get();
@@ -178,6 +201,7 @@ public final class CollectionTab
 		scheduleCollectionListRebuild(snap, allCards, selectedPack);
 	}
 
+	/** Looks up the current pack filter in {@code packs}; clears the filter if it no longer matches any pack. */
 	private BoosterPackDefinition resolveSelectedPack(List<BoosterPackDefinition> packs)
 	{
 		BoosterPackDefinition selected = PackCatalogService.findById(packs, collectionPackFilterId);
@@ -189,6 +213,11 @@ public final class CollectionTab
 		return selected;
 	}
 
+	/**
+	 * Snapshots the current filter/sort state and schedules the row build on {@link #scheduler}, applying
+	 * the result back on the EDT only if no newer rebuild has been started ({@link #buildGen} check) and
+	 * falling back to an empty list on failure.
+	 */
 	private void scheduleCollectionListRebuild(
 		PackCloseSnapshot snap,
 		List<CardDefinition> allCards,
@@ -231,6 +260,7 @@ public final class CollectionTab
 		});
 	}
 
+	/** Pushes a completed row build into the list and flips the {@link CardLayout} between empty/list cards. Must run on the EDT. */
 	private void applyCollectionRows(long gen, List<CollectionListModel.Row> rows)
 	{
 		if (gen != buildGen.get())
@@ -254,6 +284,7 @@ public final class CollectionTab
 		collectionListHost.repaint();
 	}
 
+	/** Builds the search field, pack/rarity/sort combo rows, and the progress label above the list. */
 	private JPanel buildCollectionToolbar(
 		List<BoosterPackDefinition> packs,
 		BoosterPackDefinition selectedPack,
@@ -317,6 +348,10 @@ public final class CollectionTab
 		return toolbar;
 	}
 
+	/**
+	 * Builds the "X: owned / total (pct%)" label: overall collection stats when no pack filter is active,
+	 * or that pack's set-completion progress otherwise.
+	 */
 	private JLabel buildCollectionProgressLabel(
 		BoosterPackDefinition selectedPack,
 		PackCloseSnapshot snap,
@@ -355,12 +390,14 @@ public final class CollectionTab
 		return progressLabel;
 	}
 
+	/** Re-renders the tab after a filter change, then notifies the host panel via {@link #onRendered}. */
 	private void refreshCollectionTabUi()
 	{
 		render();
 		onRendered.run();
 	}
 
+	/** Visible boosters that have category filters and a distinct collection key, deduplicated by that key. */
 	private List<BoosterPackDefinition> collectionFilterPacks()
 	{
 		List<BoosterPackDefinition> out = new ArrayList<>();
@@ -381,6 +418,7 @@ public final class CollectionTab
 		return out;
 	}
 
+	/** Wraps a filter control with a left-aligned text label. */
 	private JPanel labeledCollectionFilter(String labelText, JComponent field)
 	{
 		JPanel row = new JPanel(new BorderLayout(6, 0));
@@ -393,6 +431,7 @@ public final class CollectionTab
 		return row;
 	}
 
+	/** Builds the styled search text field, wiring its document listener to {@link #onCollectionSearchEdited}. */
 	private JTextField createCollectionSearchField()
 	{
 		JTextField field = new JTextField();
@@ -405,6 +444,7 @@ public final class CollectionTab
 		return field;
 	}
 
+	/** Stores the new search text and, while the tab is active, schedules a row rebuild for it (without a full re-render). */
 	private void onCollectionSearchEdited()
 	{
 		String next = collectionSearchField.getText() == null ? "" : collectionSearchField.getText();
@@ -424,6 +464,7 @@ public final class CollectionTab
 			resolveSelectedPack(packs));
 	}
 
+	/** Adapts a {@link DocumentListener}'s three callbacks onto a single {@code onChange} callback. */
 	private static DocumentListener documentListener(Runnable onChange)
 	{
 		return new DocumentListener()
@@ -448,6 +489,10 @@ public final class CollectionTab
 		};
 	}
 
+	/**
+	 * Wires a combo box so selecting a genuinely different item (per {@code unchanged}) applies it via
+	 * {@code apply} and triggers a full tab re-render.
+	 */
 	private <T> void wireFilterCombo(JComboBox<T> combo, Predicate<T> unchanged, Consumer<T> apply)
 	{
 		combo.addActionListener(e ->
@@ -463,6 +508,7 @@ public final class CollectionTab
 		});
 	}
 
+	/** Applies the common font/color/focus styling shared by the collection tab's filter combo boxes. */
 	private static <T> JComboBox<T> styleCollectionCombo(JComboBox<T> combo)
 	{
 		combo.setFont(FontManager.getRunescapeSmallFont());

--- a/src/main/java/com/osrstcg/ui/layout/PackCloseSnapshot.java
+++ b/src/main/java/com/osrstcg/ui/layout/PackCloseSnapshot.java
@@ -17,6 +17,7 @@ public final class PackCloseSnapshot
 	/** Cloud or local overview captured with this snapshot (null → compute locally). */
 	public final CloudSidebarCollectionStats collectionStats;
 
+	/** Defensively copies/normalizes nullable inputs (empty map, {@link CollectionState#empty()}) into an immutable snapshot. */
 	public PackCloseSnapshot(
 		Map<CardCollectionKey, Integer> owned,
 		CollectionState collectionState,

--- a/src/main/java/com/osrstcg/ui/layout/SidebarChrome.java
+++ b/src/main/java/com/osrstcg/ui/layout/SidebarChrome.java
@@ -21,6 +21,11 @@ public final class SidebarChrome
 	{
 	}
 
+	/**
+	 * Builds the small colored status dot shown in the sidebar title row. Its fill color and tooltip are
+	 * driven later by {@link #updateCloudStatusIndicator} via client properties; starts red/"disconnected".
+	 * Must be called on the EDT.
+	 */
 	public static JComponent createCloudStatusIndicator()
 	{
 		final Color liveGreen = new Color(0x2E, 0xC4, 0x5A);
@@ -28,6 +33,7 @@ public final class SidebarChrome
 		final Color errorRed = new Color(0xE0, 0x4B, 0x4B);
 		JComponent dot = new JComponent()
 		{
+			/** Paints a filled circle using the color stashed in the {@code cloudIndicatorColor} client property. */
 			@Override
 			protected void paintComponent(Graphics g)
 			{
@@ -53,18 +59,21 @@ public final class SidebarChrome
 				}
 			}
 
+			/** Fixed 8x8 dot size. */
 			@Override
 			public Dimension getPreferredSize()
 			{
 				return new Dimension(8, 8);
 			}
 
+			/** Same as {@link #getPreferredSize()}; the dot never shrinks. */
 			@Override
 			public Dimension getMinimumSize()
 			{
 				return getPreferredSize();
 			}
 
+			/** Same as {@link #getPreferredSize()}; the dot never grows. */
 			@Override
 			public Dimension getMaximumSize()
 			{
@@ -80,6 +89,11 @@ public final class SidebarChrome
 		return dot;
 	}
 
+	/**
+	 * Paints the horizontal divider under the tab rail: a full-width medium-gray line, with a dark-gray
+	 * segment punched out under the currently active tab button so it reads as connected to its content
+	 * below. Must be called from a component's {@code paintComponent}, on the EDT.
+	 */
 	public static void paintTabRailLine(JComponent strip, Graphics g, JButton active)
 	{
 		Color line = ColorScheme.MEDIUM_GRAY_COLOR;
@@ -109,6 +123,11 @@ public final class SidebarChrome
 		}
 	}
 
+	/**
+	 * Resolves the cloud status dot's color and tooltip from current session state (account lock, RS login,
+	 * restricted world, pending consent, connection state) in that priority order, then repaints it. Must
+	 * be called on the EDT.
+	 */
 	public static void updateCloudStatusIndicator(
 		JComponent cloudStatusIndicator,
 		CloudSessionService cloudSessionService,

--- a/src/main/java/com/osrstcg/ui/layout/SidebarLayout.java
+++ b/src/main/java/com/osrstcg/ui/layout/SidebarLayout.java
@@ -28,6 +28,11 @@ import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.LinkBrowser;
 
+/**
+ * Shared layout/styling helpers for the plugin sidebar panels: sizing constants, scroll pane and button
+ * styling, text formatting utilities, and Swing width-clamping helpers used across the tab controllers.
+ * All component-mutating methods must be called on the EDT.
+ */
 public final class SidebarLayout
 {
 	public static final int MAIN_PANEL_INSET = 6;
@@ -43,11 +48,13 @@ public final class SidebarLayout
 	{
 	}
 
+	/** Usable content width inside the RuneLite plugin panel, after its border and the tab scrollbar, floored at 160px. */
 	public static int sidebarInnerWidth()
 	{
 		return Math.max(160, PluginPanel.PANEL_WIDTH - 2 * PluginPanel.BORDER_OFFSET - TAB_SCROLLBAR_WIDTH);
 	}
 
+	/** Applies the sidebar's standard scroll pane chrome: no horizontal scroll, borderless/transparent, styled thin thumb. */
 	public static void configureTabScrollPane(JScrollPane scrollPane)
 	{
 		scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
@@ -74,6 +81,7 @@ public final class SidebarLayout
 		});
 	}
 
+	/** Revalidates and repaints a tab scroll pane and its viewport after content changes size. */
 	public static void revalidateTabScrollPane(JScrollPane scrollPane)
 	{
 		scrollPane.getViewport().revalidate();
@@ -81,6 +89,7 @@ public final class SidebarLayout
 		scrollPane.repaint();
 	}
 
+	/** Configures a tab's content panel as a transparent, left-aligned vertical stack. */
 	public static void initializeTabContentPanel(JPanel panel)
 	{
 		panel.setLayout(new javax.swing.BoxLayout(panel, javax.swing.BoxLayout.Y_AXIS));
@@ -88,6 +97,7 @@ public final class SidebarLayout
 		panel.setAlignmentX(JComponent.LEFT_ALIGNMENT);
 	}
 
+	/** Transparent fixed-width spacer used at each end of the tab rail to mirror {@link #MAIN_PANEL_INSET}. */
 	public static JComponent tabRailWing()
 	{
 		JPanel wing = new JPanel();
@@ -97,6 +107,7 @@ public final class SidebarLayout
 		return wing;
 	}
 
+	/** Applies the sidebar's primary (bold, outlined, dark) footer button styling. */
 	public static void stylePrimaryFooterButton(JButton button)
 	{
 		button.setFont(FontManager.getRunescapeBoldFont());
@@ -106,6 +117,7 @@ public final class SidebarLayout
 		styleOutlinedButton(button, ColorScheme.LIGHT_GRAY_COLOR.darker(), 10, 14, 10, 14);
 	}
 
+	/** Sets a 1px matte border in {@code borderColor} with the given padding inside it. */
 	public static void styleOutlinedButton(JComponent component, Color borderColor,
 		int top, int left, int bottom, int right)
 	{
@@ -115,6 +127,7 @@ public final class SidebarLayout
 		));
 	}
 
+	/** Clamps a footer block's max height to its current preferred height, so it can't be stretched by its parent layout. No-op if invisible. */
 	public static void lockFooterBlockHeight(JComponent block)
 	{
 		if (block == null || !block.isVisible())
@@ -127,6 +140,10 @@ public final class SidebarLayout
 		block.setMaximumSize(new Dimension(Integer.MAX_VALUE, Math.max(1, preferred.height)));
 	}
 
+	/**
+	 * Builds a clickable icon label that opens {@code url} in the default browser; returns {@code null}
+	 * if the classpath image resource can't be loaded.
+	 */
 	public static JComponent createTitleLinkButton(String imageClasspath, String tooltip, String url)
 	{
 		BufferedImage image = ImageUtil.loadImageResource(SidebarLayout.class, imageClasspath);
@@ -147,12 +164,14 @@ public final class SidebarLayout
 		link.setMaximumSize(size);
 		link.addMouseListener(new java.awt.event.MouseAdapter()
 		{
+			/** Re-asserts the hand cursor on re-entry. */
 			@Override
 			public void mouseEntered(java.awt.event.MouseEvent e)
 			{
 				link.setCursor(hand);
 			}
 
+			/** Opens {@code url} in the default browser on left-click. */
 			@Override
 			public void mouseClicked(java.awt.event.MouseEvent e)
 			{
@@ -165,11 +184,13 @@ public final class SidebarLayout
 		return link;
 	}
 
+	/** Delegates to {@link NumberFormatting#format(long)} for the sidebar's standard number display format. */
 	public static String format(long value)
 	{
 		return NumberFormatting.format(value);
 	}
 
+	/** Escapes {@code &amp;}, {@code &lt;}, {@code &gt;} for safe use inside a Swing HTML label; null becomes {@code ""}. */
 	public static String htmlEscape(String value)
 	{
 		if (value == null)
@@ -179,6 +200,7 @@ public final class SidebarLayout
 		return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
 	}
 
+	/** Truncates {@code value} to {@code maxLen} characters, appending "..." when it was longer (short limits truncate without ellipsis). */
 	public static String shorten(String value, int maxLen)
 	{
 		if (value == null || value.length() <= maxLen)
@@ -192,6 +214,7 @@ public final class SidebarLayout
 		return value.substring(0, maxLen - 3) + "...";
 	}
 
+	/** Applies the sidebar's standard stat label styling: white, small font, vertically centered. */
 	public static void applySidebarStatLabelStyle(JLabel label)
 	{
 		label.setForeground(Color.WHITE);
@@ -199,10 +222,12 @@ public final class SidebarLayout
 		label.setFont(FontManager.getRunescapeSmallFont());
 	}
 
+	/** Builds a styled label that re-applies {@link #applySidebarStatLabelStyle} after any Look-and-Feel change. */
 	public static JLabel textPanel(String text)
 	{
 		JLabel label = new JLabel(text)
 		{
+			/** Re-applies the stat label style after a Look-and-Feel change resets it. */
 			@Override
 			public void updateUI()
 			{
@@ -214,6 +239,7 @@ public final class SidebarLayout
 		return label;
 	}
 
+	/** Left-aligns the panel and clamps its max height to its current preferred height (unbounded width). */
 	public static void clampPanelWidth(JPanel panel)
 	{
 		panel.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -221,6 +247,7 @@ public final class SidebarLayout
 		panel.setMaximumSize(new Dimension(Integer.MAX_VALUE, preferred.height));
 	}
 
+	/** Left-aligns the component and pins its width to a fixed value, keeping its current preferred height. */
 	public static void clampFixedWidth(JComponent component, int width)
 	{
 		component.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -231,6 +258,7 @@ public final class SidebarLayout
 		component.setMinimumSize(new Dimension(0, h));
 	}
 
+	/** Resolves the welcome panel's font: bold RuneScape font when {@code bold}, else regular or small by {@code fontSize} threshold. */
 	public static Font resolveWelcomeFont(boolean bold, int fontSize)
 	{
 		if (bold)

--- a/src/main/java/com/osrstcg/ui/overview/OverviewTab.java
+++ b/src/main/java/com/osrstcg/ui/overview/OverviewTab.java
@@ -22,6 +22,11 @@ import javax.swing.border.EmptyBorder;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 
+/**
+ * Renders the sidebar's Overview tab: a credits row plus a two-column grid of collection stat tiles
+ * (unique/foil counts, completion percentages, opened packs, collection score), optionally annotated
+ * with hiscores ranks. Swing component; {@link #render} and {@link #updateCredits} must run on the EDT.
+ */
 public final class OverviewTab
 {
 	private static final int STAT_GRID_GAP = 6;
@@ -32,6 +37,7 @@ public final class OverviewTab
 	private final Class<?> imageResourceClass;
 	private JLabel creditsValueLabel;
 
+	/** @param imageResourceClass class whose classloader resolves stat icon resource paths */
 	public OverviewTab(
 		OsrsTcgConfig config,
 		TcgStateService stateService,
@@ -44,6 +50,7 @@ public final class OverviewTab
 		this.imageResourceClass = imageResourceClass;
 	}
 
+	/** Builds and adds the credits panel and the stat tile grid to {@code target}, using {@code snap}/{@code m} for values and optional hiscores ranks. */
 	public void render(JPanel target, PackCloseSnapshot snap, CloudSidebarCollectionStats m)
 	{
 		int[] ranks = config.showSidebarRanks() ? stateService.getSidebarRanks() : null;
@@ -74,6 +81,7 @@ public final class OverviewTab
 		), STAT_GRID_GAP));
 	}
 
+	/** Updates the already-rendered credits value label in place, if the tab has been rendered. */
 	public void updateCredits(long credits)
 	{
 		if (creditsValueLabel != null)
@@ -82,6 +90,7 @@ public final class OverviewTab
 		}
 	}
 
+	/** Builds a full-width row panel: an icon (if the resource resolves) and label on the left, value on the right. */
 	public JPanel imageStatPanel(String labelText, String valueText, String imagePath)
 	{
 		JPanel panel = new JPanel(new BorderLayout(8, 0));
@@ -114,6 +123,7 @@ public final class OverviewTab
 		return panel;
 	}
 
+	/** @return the rank at {@code index}, or {@code null} if not shown, the array is missing, the index is out of range, or the rank is non-positive. */
 	private static Integer rankAt(int[] ranks, int index, boolean show)
 	{
 		if (!show || ranks == null || index < 0 || index >= ranks.length)
@@ -124,6 +134,7 @@ public final class OverviewTab
 		return rank > 0 ? rank : null;
 	}
 
+	/** @return {@code "#<rank>"}, or {@code "#<n>k"} for ranks of 1000 or more. */
 	static String formatHiscoresRank(int rank)
 	{
 		if (rank < 1000)
@@ -133,6 +144,7 @@ public final class OverviewTab
 		return "#" + (rank / 1000) + "k";
 	}
 
+	/** @return a tiered color for a hiscores rank (gold/pink/red/purple/blue/green/white by threshold), dimmed once rank exceeds 1000. */
 	static Color colorHiscoresRank(int rank)
 	{
 		Color base;
@@ -167,6 +179,7 @@ public final class OverviewTab
 		return rank > 1000 ? dimHiscoresRankColor(base) : base;
 	}
 
+	/** Scales down a color's RGB channels to indicate a lower-priority hiscores rank. */
 	private static Color dimHiscoresRankColor(Color color)
 	{
 		final float factor = 0.62f;
@@ -176,11 +189,17 @@ public final class OverviewTab
 			Math.round(color.getBlue() * factor));
 	}
 
+	/** {@link #statBoxPanel(String, String, Integer, boolean)} with no rank row. */
 	private JPanel statBoxPanel(String labelText, String valueText)
 	{
 		return statBoxPanel(labelText, valueText, null, false);
 	}
 
+	/**
+	 * Builds a single stat tile: centered label, bold value, and an optional rank line beneath. When
+	 * {@code hiscoresRank} is null but {@code reserveRankRow} is true, a blank rank line is still
+	 * reserved so tiles in the same row stay the same height.
+	 */
 	private JPanel statBoxPanel(String labelText, String valueText, Integer hiscoresRank, boolean reserveRankRow)
 	{
 		JPanel panel = new JPanel();
@@ -226,12 +245,14 @@ public final class OverviewTab
 		return panel;
 	}
 
+	/** @return the width of one stat tile in a two-column grid, given the available content width. */
 	private int overviewStatBoxWidth()
 	{
 		int inner = contentWidth.getAsInt();
 		return Math.max(96, (inner - STAT_GRID_GAP) / 2);
 	}
 
+	/** Lays out {@code tiles} two-per-row, centered horizontally, with {@code gap} pixels between tiles and rows. */
 	private JPanel twoColumnGridPanel(List<JPanel> tiles, int gap)
 	{
 		JPanel grid = new JPanel();

--- a/src/main/java/com/osrstcg/ui/shop/BoosterBuyButtonFactory.java
+++ b/src/main/java/com/osrstcg/ui/shop/BoosterBuyButtonFactory.java
@@ -28,6 +28,10 @@ final class BoosterBuyButtonFactory
 	{
 	}
 
+	/**
+	 * Builds one shop booster tile: title, optional pack icon (swapped for a grayscale version when the
+	 * button is disabled), price, progress bar, owned/total counts, and a buy action. Must be called on the EDT.
+	 */
 	static JButton create(
 		BoosterPackDefinition booster,
 		int progressOwn,
@@ -104,10 +108,12 @@ final class BoosterBuyButtonFactory
 		return button;
 	}
 
+	/** Centered, white, small-font label used for the booster tile's title/price/progress text rows. */
 	static JLabel shopBoosterTextLabel(String text)
 	{
 		JLabel label = new JLabel(text, SwingConstants.CENTER)
 		{
+			/** Re-applies the label style after a Look-and-Feel change resets it. */
 			@Override
 			public void updateUI()
 			{
@@ -119,6 +125,7 @@ final class BoosterBuyButtonFactory
 		return label;
 	}
 
+	/** Applies the shared alignment/color/font styling for booster tile text labels. */
 	private static void applyBoostBtnLabelStyle(JLabel label)
 	{
 		label.setAlignmentX(Component.CENTER_ALIGNMENT);

--- a/src/main/java/com/osrstcg/ui/shop/BoosterShopRow.java
+++ b/src/main/java/com/osrstcg/ui/shop/BoosterShopRow.java
@@ -2,6 +2,7 @@ package com.osrstcg.ui.shop;
 
 import com.osrstcg.catalog.BoosterPackDefinition;
 
+/** One shop tile's precomputed data: a booster definition plus its set-completion progress counts. */
 public final class BoosterShopRow
 {
 	public final BoosterPackDefinition booster;
@@ -9,6 +10,7 @@ public final class BoosterShopRow
 	public final int progressFoilOwn;
 	public final int progressTotal;
 
+	/** Stores the booster and progress counts verbatim. */
 	public BoosterShopRow(BoosterPackDefinition booster, int progressOwn, int progressFoilOwn, int progressTotal)
 	{
 		this.booster = booster;

--- a/src/main/java/com/osrstcg/ui/shop/ShopPackProgressBar.java
+++ b/src/main/java/com/osrstcg/ui/shop/ShopPackProgressBar.java
@@ -7,6 +7,11 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import javax.swing.JPanel;
 
+/**
+ * Fixed-size dual-segment progress bar for a shop tile: a green fill for standard-owned cards overlaid
+ * with a yellow fill for foil-owned cards, both as a percentage of the set total. Immutable once
+ * constructed; must be built and painted on the EDT.
+ */
 public final class ShopPackProgressBar extends JPanel
 {
 	public static final int WIDTH_PX = 75;
@@ -21,6 +26,7 @@ public final class ShopPackProgressBar extends JPanel
 	private final int standardFillPx;
 	private final int foilFillPx;
 
+	/** Precomputes fill widths (clamped to 0-100%) from the owned/total counts for painting. */
 	public ShopPackProgressBar(int barWidthPx, int standardOwn, int foilOwn, int total)
 	{
 		this.barWidthPx = barWidthPx;
@@ -38,6 +44,7 @@ public final class ShopPackProgressBar extends JPanel
 		setAlignmentX(Component.CENTER_ALIGNMENT);
 	}
 
+	/** Paints the bordered track, then the standard and foil fill segments over it. */
 	@Override
 	protected void paintComponent(Graphics g)
 	{

--- a/src/main/java/com/osrstcg/ui/shop/ShopProgress.java
+++ b/src/main/java/com/osrstcg/ui/shop/ShopProgress.java
@@ -12,6 +12,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Computes per-booster set-completion progress (owned / foil-owned / total) for the shop and collection
+ * tabs, caching each pack's eligible-name set keyed on the current card/roll-pool list identity.
+ */
 public final class ShopProgress
 {
 	private static final Object ELIGIBLE_LOCK = new Object();
@@ -23,6 +27,7 @@ public final class ShopProgress
 	{
 	}
 
+	/** Names of cards owned as a foil (positive quantity, non-blank name), from an owned-card count map. */
 	public static Set<String> foilCollectedNamesFromOwned(Map<CardCollectionKey, Integer> owned)
 	{
 		Set<String> foilNames = new HashSet<>();
@@ -48,6 +53,10 @@ public final class ShopProgress
 		return foilNames;
 	}
 
+	/**
+	 * Counts owned/foil-owned/total for a booster's eligible card set.
+	 * @return {@code {own, foilOwn, total}}
+	 */
 	public static int[] ownedTotal(
 		BoosterPackDefinition booster,
 		List<CardDefinition> allCards,
@@ -74,6 +83,10 @@ public final class ShopProgress
 		return new int[] { own, foilOwn, total };
 	}
 
+	/**
+	 * Looks up (or computes and caches) the eligible-name set for a booster. The cache is invalidated
+	 * whenever the {@code allCards}/{@code rollPool} list identity changes.
+	 */
 	private static Set<String> eligibleNames(
 		BoosterPackDefinition booster,
 		List<CardDefinition> allCards,
@@ -99,6 +112,7 @@ public final class ShopProgress
 		}
 	}
 
+	/** Cache key for a booster: its id, or its category filters when the id is missing/blank. */
 	private static String packEligibleKey(BoosterPackDefinition booster)
 	{
 		if (booster == null)
@@ -113,6 +127,7 @@ public final class ShopProgress
 		return String.valueOf(booster.getCategoryFilters());
 	}
 
+	/** Delegates to {@link CollectionListModel#eligibleNamesForPack} to compute a booster's eligible names. */
 	private static Set<String> computeEligible(
 		BoosterPackDefinition booster,
 		List<CardDefinition> allCards,
@@ -121,6 +136,7 @@ public final class ShopProgress
 		return CollectionListModel.eligibleNamesForPack(booster, allCards, rollPool);
 	}
 
+	/** Builds one {@link BoosterShopRow} per non-null booster, with progress computed against {@code snap.owned}. */
 	public static List<BoosterShopRow> computeRows(
 		PackCloseSnapshot snap,
 		List<CardDefinition> allCards,

--- a/src/main/java/com/osrstcg/ui/shop/ShopTab.java
+++ b/src/main/java/com/osrstcg/ui/shop/ShopTab.java
@@ -33,6 +33,11 @@ import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import net.runelite.client.ui.ColorScheme;
 
+/**
+ * Shop tab controller: renders the credits header and the booster tile grid, keeps buy-button enabled
+ * state in sync with credits/reveal/consent state, and routes buy clicks through {@link PackOpenCoordinator}.
+ * All rendering methods mutate Swing components and must run on the EDT.
+ */
 public final class ShopTab
 {
 	private static final int BOOSTER_GRID_GAP = 6;
@@ -59,6 +64,7 @@ public final class ShopTab
 	private final List<JButton> buyButtons = new ArrayList<>();
 	private final List<Integer> buyPrices = new ArrayList<>();
 
+	/** Wires the collaborators and the pre-built Swing panels this controller drives. */
 	public ShopTab(
 		TcgStateService stateService,
 		CardDatabase cardDatabase,
@@ -95,6 +101,7 @@ public final class ShopTab
 		this.packsContent = packsContent;
 	}
 
+	/** Empties the header and pack panels and drops cached buy-button/price/credits-label state. */
 	public void clear()
 	{
 		shopHeaderPanel.removeAll();
@@ -104,6 +111,7 @@ public final class ShopTab
 		creditsValueLabel = null;
 	}
 
+	/** Computes fresh set-completion progress from the current state and renders the shop from it. */
 	public void render()
 	{
 		PackCloseSnapshot displaySnap = snapshotSupplier.get();
@@ -113,6 +121,10 @@ public final class ShopTab
 		renderFromPackClose(displaySnap, shopRows);
 	}
 
+	/**
+	 * Renders the shop from an already-computed snapshot and row list (used right after a pack close, when
+	 * progress was already recalculated): preloads thumbnails, rebuilds the header, and rebuilds the tile grid.
+	 */
 	public void renderFromPackClose(PackCloseSnapshot snap, List<BoosterShopRow> shopRows)
 	{
 		preloadShopPackThumbnails(shopRows);
@@ -135,6 +147,7 @@ public final class ShopTab
 		applyBuyButtonEnabledState(credits);
 	}
 
+	/** Computes set-completion progress rows for the currently visible boosters against {@code snap}. */
 	public List<BoosterShopRow> computeRows(PackCloseSnapshot snap)
 	{
 		return ShopProgress.computeRows(
@@ -142,6 +155,7 @@ public final class ShopTab
 			shopVisibleBoosters());
 	}
 
+	/** Kicks off async prefetch of hosted booster thumbnail images, skipped in compact mode. */
 	private void preloadShopPackThumbnails(List<BoosterShopRow> shopRows)
 	{
 		if (config.compactShop() || shopRows == null || imageCacheService == null)
@@ -167,6 +181,7 @@ public final class ShopTab
 		}
 	}
 
+	/** Rebuilds the credits stat panel and caches its value label for later in-place updates via {@link #updateCredits}. */
 	private void rebuildShopHeader(long credits)
 	{
 		shopHeaderPanel.removeAll();
@@ -179,6 +194,7 @@ public final class ShopTab
 		shopHeaderPanel.repaint();
 	}
 
+	/** Lays the booster tiles out as a two-column grid (or an info message when there are none), sized to {@link #shopWidth}. */
 	private JPanel boosterShopPanelFromPrecalc(long credits, List<BoosterShopRow> rows)
 	{
 		JPanel outer = new JPanel();
@@ -250,6 +266,7 @@ public final class ShopTab
 		return outer;
 	}
 
+	/** Enables each buy button only when no reveal is in progress, cloud consent isn't pending, and credits cover its price. */
 	private void applyBuyButtonEnabledState(long credits)
 	{
 		boolean consentPending = cloudSessionService.needsCloudConsent();
@@ -271,17 +288,20 @@ public final class ShopTab
 		}
 	}
 
+	/** Mutable copy of the currently visible boosters from the catalog service. */
 	private List<BoosterPackDefinition> shopVisibleBoosters()
 	{
 		return new ArrayList<>(packCatalogService.getVisibleBoosters());
 	}
 
+	/** Width of one booster tile: half the shop width (minus the grid gap), floored at 96px. */
 	private int shopBoosterButtonWidth()
 	{
 		int inner = shopWidth.getAsInt();
 		return Math.max(96, (inner - BOOSTER_GRID_GAP) / 2);
 	}
 
+	/** Builds a simple bordered panel showing a status/info message (e.g. "no boosters available"). */
 	private JPanel infoPanel(String message)
 	{
 		JPanel panel = new JPanel(new BorderLayout());
@@ -294,6 +314,7 @@ public final class ShopTab
 		return panel;
 	}
 
+	/** Cached thumbnail icon for a booster, or {@code null} if it has no hosted thumbnail or it's not yet cached. */
 	private ImageIcon shopPackIcon(BoosterPackDefinition booster)
 	{
 		String thumbnail = booster == null ? null : booster.getThumbnail();
@@ -305,6 +326,7 @@ public final class ShopTab
 		return remote != null ? new ImageIcon(remote) : null;
 	}
 
+	/** Builds one booster's buy button, wiring its click to open the pack via {@link #packOpenCoordinator}. */
 	private JButton createBoosterBuyButton(BoosterPackDefinition booster, int progressOwn, int progressFoilOwn, int progressTotal,
 		int buttonWidth)
 	{

--- a/src/main/java/com/osrstcg/ui/tip/CardInfoTipModel.java
+++ b/src/main/java/com/osrstcg/ui/tip/CardInfoTipModel.java
@@ -12,6 +12,11 @@ import java.util.Collections;
 import java.util.List;
 import lombok.Value;
 
+/**
+ * Data and layout math for the card-hover tooltip: builds the label/value/action rows for a card and
+ * computes where the tooltip should sit relative to the cursor or canvas. Pure/static; no Swing state
+ * of its own — {@link CardInfoTipPainter} does the actual rendering.
+ */
 public final class CardInfoTipModel
 {
 	public static final int DELAY_MS = 180;
@@ -22,6 +27,7 @@ public final class CardInfoTipModel
 	public static final String ACTION_INSPECT = "inspect";
 	public static final String ACTION_OPEN_WIKI = "open-wiki";
 
+	/** One tooltip line: either a label/value detail pair, or a clickable action (when {@link #actionId} is set). */
 	@Value
 	public static class Row
 	{
@@ -30,11 +36,13 @@ public final class CardInfoTipModel
 		String actionId;
 		Color valueColor;
 
+		/** Detail row with default value color. */
 		public Row(String label, String value)
 		{
 			this(label, value, null, null);
 		}
 
+		/** Detail row with an explicit value color. */
 		public Row(String label, String value, Color valueColor)
 		{
 			this(label, value, null, valueColor);
@@ -48,17 +56,20 @@ public final class CardInfoTipModel
 			this.valueColor = valueColor;
 		}
 
+		/** Creates a clickable action row (no value) identified by {@code actionId}. */
 		public static Row action(String label, String actionId)
 		{
 			return new Row(label, "", actionId, null);
 		}
 
+		/** @return true if this is a clickable action row rather than a detail row. */
 		public boolean isAction()
 		{
 			return actionId != null;
 		}
 	}
 
+	/** Immutable tooltip content: a title plus an ordered list of {@link Row}s. */
 	@Value
 	public static class Content
 	{
@@ -76,6 +87,10 @@ public final class CardInfoTipModel
 	{
 	}
 
+	/**
+	 * Positions the tooltip near the cursor, flipping to the opposite side when it would overflow the
+	 * canvas edge, then clamps fully inside the canvas (padded by {@link #CLAMP_PAD_PX}).
+	 */
 	public static Point position(int cursorX, int cursorY, int tipW, int tipH, int canvasW, int canvasH)
 	{
 		int w = Math.max(1, tipW);
@@ -96,6 +111,7 @@ public final class CardInfoTipModel
 		return new Point(left, top);
 	}
 
+	/** Positions the tooltip pinned to the canvas's top-right corner (padded), used when no cursor position applies. */
 	public static Point topRight(int tipW, int tipH, int canvasW, int canvasH)
 	{
 		int w = Math.max(1, tipW);
@@ -110,11 +126,16 @@ public final class CardInfoTipModel
 		return new Point(left, top);
 	}
 
+	/** {@link #forPackRevealCard(PackRevealService.RevealCard, boolean)} without action rows. */
 	public static Content forPackRevealCard(PackRevealService.RevealCard card)
 	{
 		return forPackRevealCard(card, false);
 	}
 
+	/**
+	 * Builds tooltip content for a pack-reveal card: title, grade/condition row, artist row (when the
+	 * card has a foil image and artist name), and optionally "Inspect"/"Open wiki page" action rows.
+	 */
 	public static Content forPackRevealCard(PackRevealService.RevealCard card, boolean includeContextActions)
 	{
 		if (card == null)
@@ -143,6 +164,7 @@ public final class CardInfoTipModel
 		return new Content(title, rows);
 	}
 
+	/** Appends an "Artist" row if the definition has both a foil image and a non-blank artist name. */
 	static void appendArtistRow(List<Row> rows, CardDefinition def)
 	{
 		if (rows == null || def == null)
@@ -162,6 +184,7 @@ public final class CardInfoTipModel
 		rows.add(new Row("Artist", name, normalizeArtistColor(def.getArtistColor())));
 	}
 
+	/** Parses a {@code #RRGGBB} or {@code #RGB} hex string into a {@link Color}; returns {@code null} if unparsable. */
 	static Color normalizeArtistColor(String raw)
 	{
 		if (raw == null)
@@ -197,6 +220,7 @@ public final class CardInfoTipModel
 		return null;
 	}
 
+	/** @return the pulled card's instance id, or {@code null} if the card has no pull or no id. */
 	public static String instanceIdFor(PackRevealService.RevealCard card)
 	{
 		if (card == null)
@@ -211,6 +235,7 @@ public final class CardInfoTipModel
 		return null;
 	}
 
+	/** @return the wiki page for this card, preferring the pull's own page over the card definition's. */
 	public static String wikiPageFor(PackRevealService.RevealCard card)
 	{
 		if (card == null)
@@ -230,6 +255,7 @@ public final class CardInfoTipModel
 		return null;
 	}
 
+	/** Builds a single "Grade"/"Condition" row from a pull's condition value, preferring the combined grade+condition form. */
 	static List<Row> packRevealRows(Double condition)
 	{
 		List<Row> rows = new ArrayList<>();
@@ -250,6 +276,7 @@ public final class CardInfoTipModel
 		return rows;
 	}
 
+	/** @return the tooltip title for a card definition/pull pair. */
 	static String tipTitle(CardDefinition def, PackCardResult pull)
 	{
 		return CardDisplayNames.titleForDefinition(def, pull);

--- a/src/main/java/com/osrstcg/ui/tip/CardInfoTipPainter.java
+++ b/src/main/java/com/osrstcg/ui/tip/CardInfoTipPainter.java
@@ -14,6 +14,11 @@ import java.util.List;
 import java.util.Map;
 import net.runelite.client.ui.FontManager;
 
+/**
+ * Stateless renderer for the card-hover tooltip: measures the rounded-rect panel size for a given
+ * {@link Content}, then paints it (title, detail rows, action rows with hover highlight) onto a
+ * {@link Graphics2D}. Must be called from the Swing paint thread (EDT).
+ */
 public final class CardInfoTipPainter
 {
 	private static final Color BG = new Color(18, 18, 18, 245);
@@ -35,6 +40,7 @@ public final class CardInfoTipPainter
 	{
 	}
 
+	/** Computes the pixel size of the tooltip panel needed to fit the title and rows of {@code content}. */
 	public static Dimension measure(Graphics2D g, Content content)
 	{
 		Font titleFont = tipTitleFont();
@@ -119,6 +125,11 @@ public final class CardInfoTipPainter
 		return new Dimension(width, height);
 	}
 
+	/**
+	 * Paints the tooltip panel at {@code (x, y + yOffset)}, with title/border/rows faded by {@code alpha}.
+	 * When {@code hoverX}/{@code hoverY} fall inside an action row, that row is highlighted; each action
+	 * row's screen bounds are recorded into {@code outActionBounds} (keyed by action id) if provided.
+	 */
 	public static void paint(Graphics2D g, int x, int y, Content content, Color titleColor, float alpha, float yOffset,
 		Integer hoverX, Integer hoverY, Map<String, Rectangle> outActionBounds)
 	{
@@ -225,21 +236,25 @@ public final class CardInfoTipPainter
 		}
 	}
 
+	/** {@link #paint(Graphics2D, int, int, Content, Color, float, float, Integer, Integer, Map)} with no hover/action-bounds tracking. */
 	public static void paint(Graphics2D g, int x, int y, Content content, Color titleColor, float alpha, float yOffset)
 	{
 		paint(g, x, y, content, titleColor, alpha, yOffset, null, null, null);
 	}
 
+	/** @return the font used for the tooltip title. */
 	private static Font tipTitleFont()
 	{
 		return FontManager.getRunescapeBoldFont();
 	}
 
+	/** @return the font used for tooltip detail/action rows. */
 	private static Font tipRowFont()
 	{
 		return FontManager.getRunescapeSmallFont();
 	}
 
+	/** Truncates {@code text} with a trailing ellipsis so it fits within {@code maxWidth} pixels under {@code fm}. */
 	private static String ellipsize(String text, FontMetrics fm, int maxWidth)
 	{
 		String value = text == null ? "" : text;

--- a/src/main/java/com/osrstcg/ui/welcome/WelcomeContent.java
+++ b/src/main/java/com/osrstcg/ui/welcome/WelcomeContent.java
@@ -36,11 +36,16 @@ public class WelcomeContent
 	{
 	}
 
+	/** @return the fixed list of welcome-tab paragraphs, in display order. */
 	public List<WelcomeParagraph> getParagraphs()
 	{
 		return PARAGRAPHS;
 	}
 
+	/**
+	 * Resolves a paragraph's color string: a handful of named colors, otherwise a hex string
+	 * (with or without a leading {@code #}), falling back to {@link #DEFAULT_COLOR} if blank or unparsable.
+	 */
 	public static Color resolveColor(String raw)
 	{
 		if (raw == null || raw.isBlank())
@@ -76,6 +81,7 @@ public class WelcomeContent
 		}
 	}
 
+	/** @return true only if {@code bold} is non-null and {@code true}. */
 	public static boolean isBold(Boolean bold)
 	{
 		return Boolean.TRUE.equals(bold);

--- a/src/main/java/com/osrstcg/ui/welcome/WelcomeParagraph.java
+++ b/src/main/java/com/osrstcg/ui/welcome/WelcomeParagraph.java
@@ -10,6 +10,11 @@ public final class WelcomeParagraph
 	private final Integer size;
 	private final Boolean bold;
 
+	/**
+	 * @param color raw color string, resolved via {@link WelcomeContent#resolveColor(String)}
+	 * @param size point size, or {@code null} to keep the base font size (see {@link WelcomeContent#resolveFontSize(Integer)})
+	 * @param bold whether the paragraph renders bold; {@code null} treated as false (see {@link WelcomeContent#isBold(Boolean)})
+	 */
 	public WelcomeParagraph(String text, String color, Integer size, Boolean bold)
 	{
 		this.text = text;
@@ -18,21 +23,25 @@ public final class WelcomeParagraph
 		this.bold = bold;
 	}
 
+	/** @return the paragraph's raw text. */
 	public String getText()
 	{
 		return text;
 	}
 
+	/** @return the paragraph's raw (unresolved) color string. */
 	public String getColor()
 	{
 		return color;
 	}
 
+	/** @return the paragraph's raw (unresolved) font size. */
 	public Integer getSize()
 	{
 		return size;
 	}
 
+	/** @return the paragraph's raw (unresolved) bold flag. */
 	public Boolean getBold()
 	{
 		return bold;

--- a/src/main/java/com/osrstcg/ui/welcome/WelcomeTab.java
+++ b/src/main/java/com/osrstcg/ui/welcome/WelcomeTab.java
@@ -13,6 +13,10 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 
+/**
+ * Renders the sidebar's first-run Welcome tab: a stack of styled, centered paragraphs sourced from
+ * {@link WelcomeContent}. Swing component; must be built on the EDT.
+ */
 public final class WelcomeTab
 {
 	private final WelcomeContent catalog;
@@ -22,11 +26,13 @@ public final class WelcomeTab
 		this.catalog = catalog;
 	}
 
+	/** Adds the paragraph stack to {@code target}'s north region, wrapped to {@code contentMaxW}. */
 	public void render(JPanel target, int contentMaxW)
 	{
 		target.add(buildBlurb(contentMaxW), java.awt.BorderLayout.NORTH);
 	}
 
+	/** Builds a vertical stack of styled {@link javax.swing.JTextPane}s, one per paragraph, sized to fit {@code contentMaxW}. */
 	private JPanel buildBlurb(int contentMaxW)
 	{
 		int w = Math.max(1, contentMaxW);
@@ -55,6 +61,7 @@ public final class WelcomeTab
 		return wrap;
 	}
 
+	/** Builds a single non-editable, center-aligned, word-wrapped paragraph text pane sized to its rendered height at {@code contentMaxW}. */
 	private static JTextPane buildTextArea(
 		int contentMaxW, String text, int topGap, Color foreground, boolean bold, int fontSize)
 	{

--- a/src/main/java/com/osrstcg/util/AtomicFiles.java
+++ b/src/main/java/com/osrstcg/util/AtomicFiles.java
@@ -10,10 +10,15 @@ import java.nio.file.StandardCopyOption;
 /** Temp-file write then atomic replace. */
 public final class AtomicFiles
 {
+	/** No instances. */
 	private AtomicFiles()
 	{
 	}
 
+	/**
+	 * Writes {@code bytes} to a sibling {@code .tmp} file, then atomically moves it onto {@code target}.
+	 * Cleans up the temp file on failure. Creates parent directories as needed.
+	 */
 	public static void writeBytes(Path target, byte[] bytes) throws IOException
 	{
 		Path dir = target.getParent();
@@ -42,11 +47,13 @@ public final class AtomicFiles
 		}
 	}
 
+	/** Encodes {@code content} with {@code charset} and writes it via {@link #writeBytes}. */
 	public static void writeString(Path target, String content, Charset charset) throws IOException
 	{
 		writeBytes(target, content.getBytes(charset));
 	}
 
+	/** Moves {@code source} onto {@code target}, replacing any existing file, falling back to a non-atomic move if the filesystem doesn't support atomic rename. */
 	public static void moveReplace(Path source, Path target) throws IOException
 	{
 		try

--- a/src/main/java/com/osrstcg/util/CardDisplayNames.java
+++ b/src/main/java/com/osrstcg/util/CardDisplayNames.java
@@ -3,12 +3,15 @@ package com.osrstcg.util;
 import com.osrstcg.catalog.CardDefinition;
 import com.osrstcg.state.PackCardResult;
 
+/** Picks the best display name for a card out of several possibly-blank candidate sources. */
 public final class CardDisplayNames
 {
+	/** No instances. */
 	private CardDisplayNames()
 	{
 	}
 
+	/** @return the first non-null, non-blank, trimmed value in {@code values}, or {@code null} if none qualify (including a null array). */
 	public static String firstNonBlank(String... values)
 	{
 		if (values == null)
@@ -25,6 +28,10 @@ public final class CardDisplayNames
 		return null;
 	}
 
+	/**
+	 * Best title for a pulled card, preferring the pull's own display name, then the catalog
+	 * definition's display name/name, then the pull's raw card name; falls back to "Unknown Card".
+	 */
 	public static String titleForPull(PackCardResult pull, CardDefinition catalog)
 	{
 		String pullDisplay = pull == null ? null : pull.getDisplayName();
@@ -35,6 +42,10 @@ public final class CardDisplayNames
 		return title == null || title.isBlank() ? "Unknown Card" : title;
 	}
 
+	/**
+	 * Best title for a catalog definition, preferring the definition's own display name/name, then
+	 * the pull's display name/card name; falls back to "Card".
+	 */
 	public static String titleForDefinition(CardDefinition def, PackCardResult pull)
 	{
 		String defDisplay = def == null ? null : def.getDisplayName();

--- a/src/main/java/com/osrstcg/util/HtmlEntities.java
+++ b/src/main/java/com/osrstcg/util/HtmlEntities.java
@@ -9,10 +9,16 @@ public final class HtmlEntities
 	private static final Pattern DECIMAL_REF = Pattern.compile("&#(\\d+);");
 	private static final Pattern HEX_REF = Pattern.compile("&#x([0-9a-fA-F]+);", Pattern.CASE_INSENSITIVE);
 
+	/** No instances. */
 	private HtmlEntities()
 	{
 	}
 
+	/**
+	 * Decodes {@code &amp;}/{@code &lt;}/{@code &gt;}/{@code &quot;}/{@code &apos;} and numeric
+	 * (decimal and hex) character references in {@code value}. Returns {@code value} unchanged if
+	 * it's {@code null}, empty, or contains no {@code &}.
+	 */
 	public static String decode(String value)
 	{
 		if (value == null || value.isEmpty() || value.indexOf('&') < 0)
@@ -30,6 +36,7 @@ public final class HtmlEntities
 		return s;
 	}
 
+	/** Replaces every match of {@code pattern} (a numeric char-ref pattern) with the character it encodes, parsed in {@code radix}. */
 	private static String replaceRefs(String input, Pattern pattern, int radix)
 	{
 		Matcher matcher = pattern.matcher(input);

--- a/src/main/java/com/osrstcg/util/NumberFormatting.java
+++ b/src/main/java/com/osrstcg/util/NumberFormatting.java
@@ -2,27 +2,36 @@ package com.osrstcg.util;
 
 import java.util.Locale;
 
+/** Formats numbers for display: thousands-space-separated, or compact with k/M suffixes. */
 public final class NumberFormatting
 {
+	/** No instances. */
 	private NumberFormatting()
 	{
 	}
 
+	/** @return {@code value} with a space every three digits, e.g. {@code "1 234 567"}. */
 	public static String format(long value)
 	{
 		return formatWithSpaces(value);
 	}
 
+	/** @return space-grouped {@code value}, or {@code "-"} if {@code value} is {@code null}. */
 	public static String format(Long value)
 	{
 		return value == null ? "-" : formatWithSpaces(value);
 	}
 
+	/** @return {@code value} with a space every three digits. */
 	public static String format(int value)
 	{
 		return formatWithSpaces((long) value);
 	}
 
+	/**
+	 * Compact form: {@code "1.2M"} at or above one million, {@code "123k"} at or above 100,000,
+	 * otherwise the same space-grouped format as {@link #format(long)}.
+	 */
 	public static String formatCompact(long value)
 	{
 		long abs = Math.abs(value);
@@ -39,6 +48,7 @@ public final class NumberFormatting
 		return formatWithSpaces(value);
 	}
 
+	/** @return {@code value} as decimal digits with a space inserted every three digits from the right; keeps the sign. */
 	private static String formatWithSpaces(long value)
 	{
 		String sign = value < 0 ? "-" : "";

--- a/src/main/java/com/osrstcg/util/OsrsWiki.java
+++ b/src/main/java/com/osrstcg/util/OsrsWiki.java
@@ -2,14 +2,21 @@ package com.osrstcg.util;
 
 import java.nio.charset.StandardCharsets;
 
+/** Builds Old School RuneScape Wiki article URLs from a page title. */
 public final class OsrsWiki
 {
 	private static final String WIKI_BASE = "https://oldschool.runescape.wiki/w/";
 
+	/** No instances. */
 	private OsrsWiki()
 	{
 	}
 
+	/**
+	 * Builds the wiki URL for {@code page}: spaces become underscores, {@code /} is kept
+	 * literal (wiki subpage separator), and every other non-URL-safe character is percent-encoded.
+	 * @return {@code null} if {@code page} is {@code null} or blank after trimming.
+	 */
 	public static String url(String page)
 	{
 		if (page == null)
@@ -47,6 +54,7 @@ public final class OsrsWiki
 		return WIKI_BASE + encoded;
 	}
 
+	/** @return true if {@code cp} does not need percent-encoding (mirrors JS {@code encodeURIComponent} safe set). */
 	private static boolean isEncodeUriComponentSafe(int cp)
 	{
 		return (cp >= 'A' && cp <= 'Z')

--- a/src/main/java/com/osrstcg/util/PackRevealZoomUtil.java
+++ b/src/main/java/com/osrstcg/util/PackRevealZoomUtil.java
@@ -2,18 +2,22 @@ package com.osrstcg.util;
 
 import java.util.function.DoublePredicate;
 
+/** Discrete zoom-level math for the pack reveal view: snapping, stepping, and pixel scaling across the fixed {@link #LEVELS} set. */
 public final class PackRevealZoomUtil
 {
 	public static final double NATIVE = 1.0d;
 	public static final double ONE_AND_HALF = 1.5d;
 	public static final double DOUBLE = 2.0d;
 
+	/** Ascending supported zoom levels. */
 	public static final double[] LEVELS = {NATIVE, ONE_AND_HALF, DOUBLE};
 
+	/** No instances. */
 	private PackRevealZoomUtil()
 	{
 	}
 
+	/** @return the nearest value in {@link #LEVELS} to {@code value}; {@link #NATIVE} for NaN/infinite input. */
 	public static double clamp(double value)
 	{
 		if (Double.isNaN(value) || Double.isInfinite(value))
@@ -34,6 +38,10 @@ public final class PackRevealZoomUtil
 		return best;
 	}
 
+	/**
+	 * Steps {@code current} (snapped first) one entry along {@link #LEVELS} per mouse-wheel notch:
+	 * negative rotation (wheel up) zooms in, positive zooms out. No-op if {@code wheelRotation} is 0.
+	 */
 	public static double nudge(double current, int wheelRotation)
 	{
 		if (wheelRotation == 0)
@@ -52,6 +60,10 @@ public final class PackRevealZoomUtil
 		return LEVELS[idx];
 	}
 
+	/**
+	 * Largest level that is at most {@code preferred} (snapped) and satisfies {@code fits}, e.g. a
+	 * viewport-size check. @return {@link #NATIVE} if no level (other than native) satisfies {@code fits}.
+	 */
 	public static double largestFittingAtMost(double preferred, DoublePredicate fits)
 	{
 		double pref = clamp(preferred);
@@ -70,6 +82,7 @@ public final class PackRevealZoomUtil
 		return best;
 	}
 
+	/** @return {@code nativePx} scaled by the zoom level nearest {@code mul}, rounded and floored at 1. */
 	public static int scalePx(int nativePx, double mul)
 	{
 		double level = clamp(mul);
@@ -84,6 +97,7 @@ public final class PackRevealZoomUtil
 		return Math.max(1, nativePx);
 	}
 
+	/** @return index of {@code level} in {@link #LEVELS}, or 0 if not present (should always be an exact level). */
 	private static int indexOf(double level)
 	{
 		for (int i = 0; i < LEVELS.length; i++)

--- a/src/main/java/com/osrstcg/util/TcgPluginGameMessages.java
+++ b/src/main/java/com/osrstcg/util/TcgPluginGameMessages.java
@@ -8,24 +8,33 @@ import net.runelite.client.chat.ChatMessageBuilder;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 
+/**
+ * Builds and queues the plugin's game-message chat lines: the "[OSRS TCG]"/"[TCG DEBUG]" prefixes,
+ * collection-pickup announcements, and de-duplication of already-prefixed text before re-queueing.
+ */
 public final class TcgPluginGameMessages
 {
+	/** Default gold color for the "OSRS TCG"/"TCG DEBUG" bracket text. */
 	public static final Color DEFAULT_PREFIX_COLOR = new Color(0xC4, 0x94, 0x1A);
 
+	/** Current color used for the "OSRS TCG"/"TCG DEBUG" bracket text; configurable via {@link #setPrefixColor}. */
 	public static Color PREFIX_COLOR = DEFAULT_PREFIX_COLOR;
 
 	private static final String PLAIN_PREFIX = "[OSRS TCG] ";
 	private static final String PLAIN_DEBUG_PREFIX = "[TCG DEBUG] ";
 
+	/** No instances. */
 	private TcgPluginGameMessages()
 	{
 	}
 
+	/** @return the plain-text (non-colored) message prefix, e.g. for the {@code value} field of a {@link QueuedMessage}. */
 	public static String plainPrefix()
 	{
 		return PLAIN_PREFIX;
 	}
 
+	/** @return a new {@link ChatMessageBuilder} pre-loaded with the colored "[OSRS TCG] " prefix. */
 	public static ChatMessageBuilder prefixBuilder()
 	{
 		return new ChatMessageBuilder()
@@ -36,6 +45,7 @@ public final class TcgPluginGameMessages
 			.append("] ");
 	}
 
+	/** @return a new {@link ChatMessageBuilder} pre-loaded with the colored "[TCG DEBUG] " prefix. */
 	private static ChatMessageBuilder debugPrefixBuilder()
 	{
 		return new ChatMessageBuilder()
@@ -46,11 +56,13 @@ public final class TcgPluginGameMessages
 			.append("] ");
 	}
 
+	/** Sets {@link #PREFIX_COLOR}, falling back to {@link #DEFAULT_PREFIX_COLOR} if {@code color} is {@code null}. */
 	public static void setPrefixColor(Color color)
 	{
 		PREFIX_COLOR = color == null ? DEFAULT_PREFIX_COLOR : color;
 	}
 
+	/** @return {@code body} (empty if {@code null}) rendered with the colored "OSRS TCG" prefix, as a RuneLite-formatted string. */
 	public static String withPrefix(String body)
 	{
 		if (body == null)
@@ -63,6 +75,7 @@ public final class TcgPluginGameMessages
 			.build();
 	}
 
+	/** @return {@code body} (empty if {@code null}) rendered with the colored "TCG DEBUG" prefix, as a RuneLite-formatted string. */
 	public static String withDebugPrefix(String body)
 	{
 		if (body == null)
@@ -75,6 +88,7 @@ public final class TcgPluginGameMessages
 			.build();
 	}
 
+	/** @return {@code message} with a leading plain "[OSRS TCG] "/"[TCG DEBUG]" prefix (with or without trailing space) removed; {@code ""} for null/empty input; unchanged if no prefix matches. */
 	public static String stripLeadingPluginPrefix(String message)
 	{
 		if (message == null || message.isEmpty())
@@ -100,6 +114,7 @@ public final class TcgPluginGameMessages
 		return message;
 	}
 
+	/** @return {@code cardName} (or "Unknown card" if blank), with " (foil)" appended when {@code foil} is true. */
 	public static String announcedCardLabel(String cardName, boolean foil)
 	{
 		String n = cardName == null ? "" : cardName.trim();
@@ -110,6 +125,7 @@ public final class TcgPluginGameMessages
 		return foil ? n + " (foil)" : n;
 	}
 
+	/** @return colored, RuneLite-formatted "{who} just added [duplicate] {card} to their collection!" message. */
 	public static String formatSomeoneAddedCollection(
 		String who, String cardName, boolean newForCollection, boolean foil, Color rarityColor)
 	{
@@ -126,6 +142,7 @@ public final class TcgPluginGameMessages
 			.build();
 	}
 
+	/** @return plain-text version of {@link #formatSomeoneAddedCollection}, for the {@link QueuedMessage} value field. */
 	public static String plainSomeoneAddedCollection(
 		String who, String cardName, boolean newForCollection, boolean foil)
 	{
@@ -133,6 +150,7 @@ public final class TcgPluginGameMessages
 			+ announcedCardLabel(cardName, foil) + " to their collection!";
 	}
 
+	/** @return colored, RuneLite-formatted "You just added [duplicate] {card} to your collection!" message. */
 	public static String formatYouAddedCollection(
 		String cardName, boolean newForCollection, boolean foil, Color rarityColor)
 	{
@@ -147,12 +165,20 @@ public final class TcgPluginGameMessages
 			.build();
 	}
 
+	/** @return plain-text version of {@link #formatYouAddedCollection}, for the {@link QueuedMessage} value field. */
 	public static String plainYouAddedCollection(String cardName, boolean newForCollection, boolean foil)
 	{
 		return PLAIN_PREFIX + "You just added " + duplicatePrefix(newForCollection)
 			+ announcedCardLabel(cardName, foil) + " to your collection!";
 	}
 
+	/**
+	 * Queues a game message on {@code chatMessageManager}, ensuring both the formatted and plain
+	 * text carry a plugin prefix (normal or debug) before they're sent. If either string is missing
+	 * its expected prefix, strips any partial/malformed prefix from the body and re-applies a clean
+	 * one, matching debug-vs-normal styling from whichever of {@code formatted}/{@code plain}
+	 * indicates it. No-op if {@code chatMessageManager} is {@code null}.
+	 */
 	public static void queueFormattedGameMessage(ChatMessageManager chatMessageManager, String formatted, String plain)
 	{
 		if (chatMessageManager == null)
@@ -202,6 +228,7 @@ public final class TcgPluginGameMessages
 			.build());
 	}
 
+	/** @return {@code formatted} with a leading (optionally {@code <col=...>}-wrapped) "OSRS TCG"/"TCG DEBUG" bracket tag, or a plain prefix, stripped; {@code ""} for null/empty input. */
 	static String stripFormattedPluginPrefix(String formatted)
 	{
 		if (formatted == null || formatted.isEmpty())
@@ -222,6 +249,7 @@ public final class TcgPluginGameMessages
 		return s;
 	}
 
+	/** Queues {@code body} (any existing plugin prefix stripped first) as a normal, prefixed game message. */
 	public static void queuePrefixedGameMessage(ChatMessageManager chatMessageManager, String body)
 	{
 		if (body == null)
@@ -232,6 +260,7 @@ public final class TcgPluginGameMessages
 		queueFormattedGameMessage(chatMessageManager, withPrefix(body), PLAIN_PREFIX + body);
 	}
 
+	/** Schedules {@link #queuePrefixedGameMessage} to run on the client thread. No-op if {@code clientThread} or {@code body} is null, or {@code body} is empty. */
 	public static void queueOnClientThread(ClientThread clientThread, ChatMessageManager chatMessageManager, String body)
 	{
 		if (clientThread == null || body == null || body.isEmpty())
@@ -241,6 +270,7 @@ public final class TcgPluginGameMessages
 		clientThread.invokeLater(() -> queuePrefixedGameMessage(chatMessageManager, body));
 	}
 
+	/** Queues {@code body} (any existing plugin prefix stripped first) as a debug-prefixed game message. */
 	public static void queueDebugGameMessage(ChatMessageManager chatMessageManager, String body)
 	{
 		if (body == null)
@@ -251,6 +281,7 @@ public final class TcgPluginGameMessages
 		queueFormattedGameMessage(chatMessageManager, withDebugPrefix(body), PLAIN_DEBUG_PREFIX + body);
 	}
 
+	/** @return {@code "duplicate "} when the card isn't new for the collection, else {@code ""}. */
 	private static String duplicatePrefix(boolean newForCollection)
 	{
 		return newForCollection ? "" : "duplicate ";


### PR DESCRIPTION
Add Javadoc across the entire plugin, so that class responsibilities, method contracts, and threading/lifecycle constraints surface via IDE hover/LSP instead of requiring a full read-through to understand.

What's included

- Class/interface/enum-level Javadoc on every type describing its responsibility, and — where it matters — its threading model (client thread vs. EDT vs. background scheduler), lifecycle (registered/unregistered with RuneLite's OverlayManager/EventBus), or persistence semantics (disk-cached, serialized state, etc.).
- Method-level Javadoc on every method in every file — public, package-private, and private — not just the public API surface, so navigating into implementation details is still self-documenting.
- Domain-specific packages (cloud/attest, cloud/session, pack, credit) got extra care to spell out non-obvious terms (e.g. "attest" = reporting earned credits to the cloud backend, "coalescer" = batches queued attests before flushing) and to flag blocking network calls vs. async ones.
- Config schema (OsrsTcgConfig.java) got a one-line Javadoc per option mirroring its @ConfigItem description, for IDE hover on config accessors.

What's explicitly out of scope

- No package-info.java files added.
- No logic, formatting, or import changes — diff is comment-only (verified via git diff --stat: insertions only, zero deletions).
- src/test/java untouched.

Verification

- ./gradlew build (full compile + test suite) passes.