### PR TITLE
Credit Magic XP earned in the Magic Training Arena via server-configured region XP rules

### DIFF
--- a/src/main/java/com/osrstcg/cloud/activity/ActivityConfigModels.java
+++ b/src/main/java/com/osrstcg/cloud/activity/ActivityConfigModels.java
@@ -23,6 +23,24 @@ public final class ActivityConfigModels
 		public NpcExclusionsDto npcExclusions = new NpcExclusionsDto();
 /** Per-NPC-id optimistic kill credit multipliers; JSON keys are NPC id strings. */
 		public Map<String, KillCreditMultiplierDto> killCreditMultipliers = new HashMap<>();
+/** Region-gated XP rules that credit XP for a skill whose XP is otherwise ignored (e.g. Magic in the Magic Training Arena). */
+		public List<XpRegionRuleDto> xpRegionRules = new ArrayList<>();
+	}
+/**
+	 * One region-gated XP-to-credits rule. While the local player stands in any of {@code regionIds}, XP gained
+	 * in {@code skill} is pooled and every {@code xpPerChunk} XP is attested as an {@code activity} event worth
+	 * {@code credits}. Lets combat-classed skills earn credits from non-combat minigames such as the MTA.
+	 */
+	public static final class XpRegionRuleDto
+	{
+		public String activityId;
+/** Skill display name, e.g. {@code Magic}; case-insensitive. */
+		public String skill;
+/** Map region ids (see {@code WorldPoint#getRegionID()}) where the rule applies. */
+		public List<Integer> regionIds = new ArrayList<>();
+		public long xpPerChunk;
+		public long credits;
+		public String label;
 	}
 /** Multiplier applied to combat-level optimistic credits for a specific NPC id. */
 	public static final class KillCreditMultiplierDto

--- a/src/main/java/com/osrstcg/cloud/activity/ActivityConfigService.java
+++ b/src/main/java/com/osrstcg/cloud/activity/ActivityConfigService.java
@@ -7,6 +7,7 @@ import com.osrstcg.cloud.activity.ActivityConfigModels.ActivityChatRuleDto;
 import com.osrstcg.cloud.activity.ActivityConfigModels.ActivityConfigDto;
 import com.osrstcg.cloud.activity.ActivityConfigModels.KillCreditMultiplierDto;
 import com.osrstcg.cloud.activity.ActivityConfigModels.NpcExclusionsDto;
+import com.osrstcg.cloud.activity.ActivityConfigModels.XpRegionRuleDto;
 import com.osrstcg.cloud.api.CloudApiClient;
 import com.osrstcg.cloud.api.CloudApiException;
 import com.osrstcg.util.AtomicFiles;
@@ -33,9 +34,10 @@ import java.util.regex.PatternSyntaxException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Skill;
 /**
- * Fetches, caches, and compiles the server-driven activity config (chat-based credit rules and NPC
- * exclusions) used to award activity credits. Holds the current {@link CompiledActivityConfig} in an
+ * Fetches, caches, and compiles the server-driven activity config (chat-based credit rules, NPC
+ * exclusions, kill multipliers and region-gated XP rules) used to award activity credits. Holds the current {@link CompiledActivityConfig} in an
  * {@link AtomicReference} for lock-free reads; network refreshes run asynchronously on {@link #scheduler}
  * and never block callers of the getters. A copy is persisted to disk so the last-good config survives
  * restarts and cloud API failures.
@@ -272,8 +274,8 @@ public final class ActivityConfigService
 	}
 /**
 	 * Converts a raw {@link ActivityConfigDto} into an immutable {@link CompiledActivityConfig}: compiles
-	 * each chat rule (dropping invalid ones), expands NPC exclusion ids/ranges into a flat id set, and
-	 * parses per-NPC kill credit multipliers.
+	 * each chat rule (dropping invalid ones), expands NPC exclusion ids/ranges into a flat id set, parses
+	 * per-NPC kill credit multipliers, and compiles region-gated XP rules (dropping invalid ones).
 	 */
 	static CompiledActivityConfig compile(ActivityConfigDto dto)
 	{
@@ -350,8 +352,73 @@ public final class ActivityConfigService
 			}
 		}
 
+		List<CompiledActivityConfig.CompiledXpRegionRule> regionRules = new ArrayList<>();
+		if (dto.xpRegionRules != null)
+		{
+			for (XpRegionRuleDto rule : dto.xpRegionRules)
+			{
+				CompiledActivityConfig.CompiledXpRegionRule compiledRule = compileXpRegionRule(rule);
+				if (compiledRule != null)
+				{
+					regionRules.add(compiledRule);
+				}
+			}
+		}
+
 		String version = dto.version == null ? "" : dto.version.trim();
-		return new CompiledActivityConfig(version, rules, npcIds, killMultipliers);
+		return new CompiledActivityConfig(version, rules, npcIds, killMultipliers, regionRules);
+	}
+/**
+	 * Compiles one raw region-gated XP rule, or returns null if it's missing an activity id, names an
+	 * unknown skill, has no region ids, or has a non-positive chunk size.
+	 */
+	private static CompiledActivityConfig.CompiledXpRegionRule compileXpRegionRule(XpRegionRuleDto rule)
+	{
+		if (rule == null || rule.activityId == null || rule.activityId.isBlank() || rule.xpPerChunk <= 0L)
+		{
+			return null;
+		}
+		Skill skill = skillByName(rule.skill);
+		if (skill == null)
+		{
+			log.warn("Skipping xp region rule {} with unknown skill '{}'", rule.activityId, rule.skill);
+			return null;
+		}
+		Set<Integer> regionIds = new HashSet<>();
+		if (rule.regionIds != null)
+		{
+			for (Integer id : rule.regionIds)
+			{
+				if (id != null)
+				{
+					regionIds.add(id);
+				}
+			}
+		}
+		if (regionIds.isEmpty())
+		{
+			log.warn("Skipping xp region rule {} with no region ids", rule.activityId);
+			return null;
+		}
+		return new CompiledActivityConfig.CompiledXpRegionRule(
+			rule.activityId.trim(), skill, regionIds, rule.xpPerChunk, rule.credits, rule.label);
+	}
+/** Looks up a {@link Skill} by its display name (case-insensitive), or {@code null} if not found. */
+	private static Skill skillByName(String name)
+	{
+		if (name == null || name.isBlank())
+		{
+			return null;
+		}
+		String wanted = name.trim();
+		for (Skill skill : Skill.values())
+		{
+			if (wanted.equalsIgnoreCase(skill.getName()))
+			{
+				return skill;
+			}
+		}
+		return null;
 	}
 /**
 	 * Compiles one raw chat rule, or returns null if it's missing required fields or (for a regex rule)

--- a/src/main/java/com/osrstcg/cloud/activity/CompiledActivityConfig.java
+++ b/src/main/java/com/osrstcg/cloud/activity/CompiledActivityConfig.java
@@ -4,9 +4,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import net.runelite.api.Skill;
 /**
  * Immutable, thread-safe snapshot of activity config for chat matching, NPC id exclusions,
- * and per-NPC kill credit multipliers.
+ * per-NPC kill credit multipliers, and region-gated XP rules.
  */
 public final class CompiledActivityConfig
 {
@@ -15,23 +16,27 @@ public final class CompiledActivityConfig
 		"",
 		List.of(),
 		Set.of(),
-		Map.of());
+		Map.of(),
+		List.of());
 
 	private final String version;
 	private final List<CompiledChatRule> chatRules;
 	private final Set<Integer> excludedNpcIds;
 	private final Map<Integer, Double> killCreditMultipliers;
+	private final List<CompiledXpRegionRule> xpRegionRules;
 /** Normalizes nulls to empty and defensively copies the collections into immutable ones. */
 	CompiledActivityConfig(
 		String version,
 		List<CompiledChatRule> chatRules,
 		Set<Integer> excludedNpcIds,
-		Map<Integer, Double> killCreditMultipliers)
+		Map<Integer, Double> killCreditMultipliers,
+		List<CompiledXpRegionRule> xpRegionRules)
 	{
 		this.version = version == null ? "" : version;
 		this.chatRules = chatRules == null ? List.of() : List.copyOf(chatRules);
 		this.excludedNpcIds = excludedNpcIds == null ? Set.of() : Set.copyOf(excludedNpcIds);
 		this.killCreditMultipliers = killCreditMultipliers == null ? Map.of() : Map.copyOf(killCreditMultipliers);
+		this.xpRegionRules = xpRegionRules == null ? List.of() : List.copyOf(xpRegionRules);
 	}
 /** Opaque version string this config was compiled from; empty for {@link #EMPTY}. */
 	public String getVersion()
@@ -55,6 +60,88 @@ public final class CompiledActivityConfig
 	{
 		Double multiplier = killCreditMultipliers.get(npcId);
 		return multiplier == null ? 1.0 : multiplier;
+	}
+
+	public List<CompiledXpRegionRule> getXpRegionRules()
+	{
+		return xpRegionRules;
+	}
+/** First region-gated XP rule covering {@code skill} in map region {@code regionId}, or {@code null} if none. */
+	public CompiledXpRegionRule findXpRegionRule(Skill skill, int regionId)
+	{
+		if (skill == null)
+		{
+			return null;
+		}
+		for (CompiledXpRegionRule rule : xpRegionRules)
+		{
+			if (rule.matches(skill, regionId))
+			{
+				return rule;
+			}
+		}
+		return null;
+	}
+/** Precompiled region-gated XP rule: credits {@code skill} XP gained inside any of {@code regionIds}. */
+	public static final class CompiledXpRegionRule
+	{
+		private final String activityId;
+		private final Skill skill;
+		private final Set<Integer> regionIds;
+		private final long xpPerChunk;
+		private final long creditsPerChunk;
+		private final String label;
+/** Normalizes nulls and clamps credits to non-negative; callers must supply a non-null skill, non-empty regions and a positive chunk size. */
+		CompiledXpRegionRule(
+			String activityId,
+			Skill skill,
+			Set<Integer> regionIds,
+			long xpPerChunk,
+			long creditsPerChunk,
+			String label)
+		{
+			this.activityId = activityId == null ? "" : activityId;
+			this.skill = skill;
+			this.regionIds = regionIds == null ? Set.of() : Set.copyOf(regionIds);
+			this.xpPerChunk = Math.max(1L, xpPerChunk);
+			this.creditsPerChunk = Math.max(0L, creditsPerChunk);
+			this.label = label == null ? "" : label;
+		}
+/** True if this rule credits {@code skill} XP while the player is in map region {@code regionId}. */
+		public boolean matches(Skill skill, int regionId)
+		{
+			return this.skill == skill && regionIds.contains(regionId);
+		}
+
+		public String getActivityId()
+		{
+			return activityId;
+		}
+
+		public Skill getSkill()
+		{
+			return skill;
+		}
+
+		public Set<Integer> getRegionIds()
+		{
+			return regionIds;
+		}
+
+		public long getXpPerChunk()
+		{
+			return xpPerChunk;
+		}
+
+		public long getCreditsPerChunk()
+		{
+			return creditsPerChunk;
+		}
+
+		public String getLabel()
+		{
+			return label;
+		}
 	}
 /** Precompiled chat-message match rule: literal prefix or regex, mutually exclusive. */
 	public static final class CompiledChatRule

--- a/src/main/java/com/osrstcg/credit/CreditAwardService.java
+++ b/src/main/java/com/osrstcg/credit/CreditAwardService.java
@@ -1,6 +1,8 @@
 package com.osrstcg.credit;
 
 import com.google.gson.JsonObject;
+import com.osrstcg.cloud.activity.ActivityConfigService;
+import com.osrstcg.cloud.activity.CompiledActivityConfig;
 import com.osrstcg.cloud.session.CloudSessionCoordinator;
 import com.osrstcg.cloud.session.CloudSessionService;
 import com.osrstcg.cloud.attest.CreditAttestCoalescer;
@@ -18,7 +20,10 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
 import net.runelite.api.GameState;
+import net.runelite.api.Player;
 import net.runelite.api.Skill;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.FakeXpDrop;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
@@ -29,7 +34,9 @@ import com.osrstcg.state.TcgStateService;
 /**
  * Central coordinator for awarding credits from XP gains and level-ups. Tracks per-skill XP/level baselines,
  * converts XP into credit chunks (with a separate, cheaper Slayer conversion), and enqueues optimistic
- * credit attest events via {@link CreditAttestQueue}. Also enforces a short cooldown after login/world-hop
+ * credit attest events via {@link CreditAttestQueue}. Combat-skill XP is normally ignored (kills are credited
+ * instead), except where a server-configured region XP rule covers the player's current map region, e.g.
+ * Magic XP inside the Magic Training Arena. Also enforces a short cooldown after login/world-hop
  * so transient stat resyncs (e.g. temporary boosts settling) don't get credited as real gains. Most XP/level
  * entry points ({@link #onStatChanged}, {@link #onFakeXpDrop}) are called directly from the plugin's event
  * handlers; {@link #onGameTick} is the only RuneLite-subscribed method here.
@@ -43,7 +50,10 @@ public class CreditAwardService
 	static final int CREDIT_COOLDOWN_TICKS = 3;
 /** Extra settle window after hopping off a restricted/event world (temp max stats). */
 	static final int RESTRICTED_WORLD_EXIT_SETTLE_TICKS = 12;
-/** Combat skills excluded from XP-based credit awards (XP here comes from combat, not standalone training). */
+/**
+	 * Combat skills excluded from XP-based credit awards (XP here comes from combat, not standalone training),
+	 * unless a region XP rule from {@link ActivityConfigService} covers the player's current region.
+	 */
 	private static final Set<Skill> COMBAT_SKILLS = EnumSet.of(
 		Skill.ATTACK,
 		Skill.DEFENCE,
@@ -58,6 +68,7 @@ public class CreditAwardService
 	private final CreditAttestQueue attestQueue;
 	private final ChatMessageManager chatMessageManager;
 	private final Provider<CloudSessionCoordinator> sessionCoordinator;
+	private final ActivityConfigService activityConfigService;
 	private final SkillCreditSession skills = new SkillCreditSession();
 	private boolean creditCooldownActive;
 	private int creditCooldownUntilTick;
@@ -69,7 +80,7 @@ public class CreditAwardService
 	@Inject
 	public CreditAwardService(Client client, TcgStateService stateService, CloudSessionService session,
 		CreditAttestQueue attestQueue, ChatMessageManager chatMessageManager,
-		Provider<CloudSessionCoordinator> sessionCoordinator)
+		Provider<CloudSessionCoordinator> sessionCoordinator, ActivityConfigService activityConfigService)
 	{
 		this.client = client;
 		this.stateService = stateService;
@@ -77,6 +88,7 @@ public class CreditAwardService
 		this.attestQueue = attestQueue;
 		this.chatMessageManager = chatMessageManager;
 		this.sessionCoordinator = sessionCoordinator;
+		this.activityConfigService = activityConfigService;
 	}
 /** Resets in-memory tracking and restores the uncredited XP pool from the persisted baseline, if any. */
 	public void resetExperienceCreditBaseline()
@@ -398,8 +410,9 @@ public class CreditAwardService
 	}
 /**
 	 * Updates the previous-XP baseline for {@code skill} and, if XP increased while not on cooldown, routes
-	 * the gain to the appropriate credit path (ignored for combat skills, Hitpoints attested without credit
-	 * bucketing, others accumulated toward an XP chunk). XP drops (e.g. from a stat reset) are ignored.
+	 * the gain to the appropriate credit path (combat skills ignored unless a region XP rule applies, Hitpoints
+	 * attested without credit bucketing, others accumulated toward an XP chunk). XP drops (e.g. from a stat
+	 * reset) are ignored.
 	 *
 	 * @return true if this call caused an XP chunk to be credited
 	 */
@@ -436,9 +449,7 @@ public class CreditAwardService
 			long xpGained = (long) currentXp - previousXp;
 			if (isCombatSkill(skill))
 			{
-				debugAward(String.format(
-					"Ignored +%s combat skill XP (%s)",
-					NumberFormatting.format(xpGained), skill.getName()));
+				xpChunkAwarded = trackCombatSkillXpGain(skill, xpGained);
 			}
 			else if (!isCreditAwardOnCooldown())
 			{
@@ -454,6 +465,109 @@ public class CreditAwardService
 		}
 		skills.previousSkillXp[skillIndex] = currentXp;
 		return xpChunkAwarded;
+	}
+/**
+	 * Handles a combat-skill XP gain: ignored unless a configured region XP rule covers {@code skill} in the
+	 * player's current map region (e.g. Magic in the Magic Training Arena), in which case the XP is pooled
+	 * under that rule and completed chunks are attested as {@code activity} events.
+	 *
+	 * @return true if this call caused an XP chunk to be credited
+	 */
+	private boolean trackCombatSkillXpGain(Skill skill, long xpGained)
+	{
+		int regionId = currentRegionId();
+		CompiledActivityConfig.CompiledXpRegionRule rule = regionId < 0
+			? null
+			: activityConfigService.getCompiled().findXpRegionRule(skill, regionId);
+		if (rule == null)
+		{
+			debugAward(String.format(
+				"Ignored +%s combat skill XP (%s)",
+				NumberFormatting.format(xpGained), skill.getName()));
+			return false;
+		}
+		if (isCreditAwardOnCooldown())
+		{
+			return false;
+		}
+		return applyRegionXpGain(rule, skill, regionId, xpGained);
+	}
+/**
+	 * Pools {@code xpGained} under {@code rule}'s activity id and, if attests can currently be collected,
+	 * converts completed {@code xpPerChunk} chunks to credits and enqueues one {@code activity} attest carrying
+	 * the credited XP, skill and region as evidence. If the cloud session is offline, the XP stays pooled.
+	 *
+	 * @return true if this call caused credit to be awarded
+	 */
+	private boolean applyRegionXpGain(CompiledActivityConfig.CompiledXpRegionRule rule, Skill skill,
+		int regionId, long xpGained)
+	{
+		if (rule == null || skill == null || xpGained <= 0L)
+		{
+			return false;
+		}
+
+		String activityId = rule.getActivityId();
+		String label = rule.getLabel().isBlank() ? activityId : rule.getLabel();
+		long pooled = skills.addRegionXp(activityId, xpGained);
+		debugAward(String.format("Registered +%s XP (%s, %s) -> %s / %s",
+			NumberFormatting.format(xpGained), skill.getName(), label,
+			NumberFormatting.format(pooled), NumberFormatting.format(rule.getXpPerChunk())));
+
+		long chunks = pooled / rule.getXpPerChunk();
+		if (chunks <= 0L)
+		{
+			return false;
+		}
+
+		long xpCredited = chunks * rule.getXpPerChunk();
+		long credits = chunks * rule.getCreditsPerChunk();
+		if (!session.canCollectAttests())
+		{
+			debugAward(String.format("Cloud offline; +%s XP (%s) pending until reconnected",
+				NumberFormatting.format(xpCredited), label));
+			return false;
+		}
+
+		JsonObject evidence = new JsonObject();
+		evidence.addProperty("activityId", activityId);
+		evidence.addProperty("skill", skill.getName());
+		evidence.addProperty("xpDelta", xpCredited);
+		evidence.addProperty("regionId", regionId);
+		if (!attestQueue.enqueue(CreditAttestCoalescer.TYPE_ACTIVITY, evidence, credits))
+		{
+			return false;
+		}
+
+		skills.subtractRegionXp(activityId, xpCredited);
+		debugAward(String.format("XP drop +%s (%s) -> +%s credits (total %s)",
+			NumberFormatting.format(xpCredited), label,
+			NumberFormatting.format(credits), NumberFormatting.format(stateService.getCredits())));
+		return credits > 0L;
+	}
+/**
+	 * Map region id of the local player's current tile, or -1 if unavailable. Instance-aware: inside an
+	 * instanced area this resolves to the template map region (the same value RuneLite's Ground Markers
+	 * record), and elsewhere it equals the ordinary world-location region.
+	 */
+	private int currentRegionId()
+	{
+		if (client == null)
+		{
+			return -1;
+		}
+		Player player = client.getLocalPlayer();
+		if (player == null)
+		{
+			return -1;
+		}
+		LocalPoint local = player.getLocalLocation();
+		if (local == null)
+		{
+			return -1;
+		}
+		WorldPoint location = WorldPoint.fromLocalInstance(client, local);
+		return location == null ? -1 : location.getRegionID();
 	}
 /**
 	 * Applies a positive XP gain (xp) for {@code skill}: routes Slayer XP through its own chunk conversion,

--- a/src/main/java/com/osrstcg/credit/SkillCreditSession.java
+++ b/src/main/java/com/osrstcg/credit/SkillCreditSession.java
@@ -3,6 +3,7 @@ package com.osrstcg.credit;
 import com.osrstcg.state.SkillCreditBaseline;
 import java.util.Arrays;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import net.runelite.api.Client;
@@ -25,6 +26,11 @@ final class SkillCreditSession
 	long pendingSlayerXpToAttest;
 /** Slayer XP short of a full {@link XpCreditMath#SLAYER_XP_PER_CHUNK} chunk, carried to the next gain. */
 	long slayerXpRemainder;
+/**
+	 * XP earned under a region-gated XP rule (e.g. Magic in the MTA) but short of a full chunk, keyed by the
+	 * rule's activity id. Session-only: not persisted, so at most one partial chunk is lost on logout.
+	 */
+	final Map<String, Long> uncreditedRegionXpByActivity = new HashMap<>();
 /** Clears level/XP baselines so the next snapshot re-establishes them from the client. */
 	void resetTracking()
 	{
@@ -33,12 +39,52 @@ final class SkillCreditSession
 		skillXpInitialized = false;
 		Arrays.fill(previousSkillXp, 0);
 	}
-/** Discards all pending uncredited XP (main pool and Slayer pending/remainder). */
+/** Discards all pending uncredited XP (main pool, Slayer pending/remainder, and region-rule pools). */
 	void clearUncreditedXpPool()
 	{
 		Arrays.fill(uncreditedXpBySkill, 0L);
 		pendingSlayerXpToAttest = 0L;
 		slayerXpRemainder = 0L;
+		uncreditedRegionXpByActivity.clear();
+	}
+/** Adds {@code xp} XP to the region rule's pool for {@code activityId} and returns the new pool total. */
+	long addRegionXp(String activityId, long xp)
+	{
+		if (activityId == null || activityId.isEmpty() || xp <= 0L)
+		{
+			return regionXpFor(activityId);
+		}
+
+		long next = regionXpFor(activityId) + xp;
+		uncreditedRegionXpByActivity.put(activityId, next);
+		return next;
+	}
+/** Currently uncredited XP pooled for the region rule {@code activityId} (0 if unknown/null). */
+	long regionXpFor(String activityId)
+	{
+		if (activityId == null || activityId.isEmpty())
+		{
+			return 0L;
+		}
+		Long pooled = uncreditedRegionXpByActivity.get(activityId);
+		return pooled == null ? 0L : pooled;
+	}
+/** Removes {@code xp} XP from the region rule's pool (clamped at 0), typically after crediting a chunk. */
+	void subtractRegionXp(String activityId, long xp)
+	{
+		if (activityId == null || activityId.isEmpty() || xp <= 0L)
+		{
+			return;
+		}
+		long remaining = Math.max(0L, regionXpFor(activityId) - xp);
+		if (remaining == 0L)
+		{
+			uncreditedRegionXpByActivity.remove(activityId);
+		}
+		else
+		{
+			uncreditedRegionXpByActivity.put(activityId, remaining);
+		}
 	}
 /** Replaces the uncredited XP pool with a persisted baseline (e.g. restored after a profile reload). */
 	void restoreUncreditedXp(SkillCreditBaseline saved)
@@ -46,6 +92,7 @@ final class SkillCreditSession
 		Arrays.fill(uncreditedXpBySkill, 0L);
 		pendingSlayerXpToAttest = 0L;
 		slayerXpRemainder = 0L;
+		uncreditedRegionXpByActivity.clear();
 
 		if (saved == null || !saved.isPresent())
 		{

--- a/src/test/java/com/osrstcg/cloud/activity/ActivityConfigServiceTest.java
+++ b/src/test/java/com/osrstcg/cloud/activity/ActivityConfigServiceTest.java
@@ -1,0 +1,132 @@
+package com.osrstcg.cloud.activity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.osrstcg.cloud.activity.ActivityConfigModels.ActivityConfigDto;
+import com.osrstcg.cloud.activity.ActivityConfigModels.XpRegionRuleDto;
+import java.util.Arrays;
+import java.util.List;
+import net.runelite.api.Skill;
+import org.junit.Test;
+
+public class ActivityConfigServiceTest
+{
+	/** Map region of the Enchanting Chamber, Creature Graveyard and Alchemists' Playground (planes 0-2). */
+	private static final int MTA_ROOMS_REGION = 13462;
+	/** Map region of the Telekinetic Theatre mazes (planes 0-2), directly north of the main rooms. */
+	private static final int MTA_TELEKINETIC_REGION = 13463;
+	/** Surface region of the arena entrance hall with the room portals; not a training area. */
+	private static final int MTA_LOBBY_REGION = 13363;
+	private static final List<Integer> MTA_REGIONS = List.of(MTA_ROOMS_REGION, MTA_TELEKINETIC_REGION);
+
+	@Test
+	public void compilesXpRegionRuleAndMatchesSkillInEveryListedRegion()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.version = "v1";
+		dto.xpRegionRules = List.of(rule("mta_magic", "Magic", MTA_REGIONS, 1000L, 100L));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertEquals(1, compiled.getXpRegionRules().size());
+		for (int region : MTA_REGIONS)
+		{
+			CompiledActivityConfig.CompiledXpRegionRule matched = compiled.findXpRegionRule(Skill.MAGIC, region);
+			assertNotNull(matched);
+			assertEquals("mta_magic", matched.getActivityId());
+			assertEquals(Skill.MAGIC, matched.getSkill());
+			assertEquals(1000L, matched.getXpPerChunk());
+			assertEquals(100L, matched.getCreditsPerChunk());
+		}
+	}
+
+	@Test
+	public void xpRegionRuleDoesNotMatchOtherRegionOrSkill()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.xpRegionRules = List.of(rule("mta_magic", "Magic", MTA_REGIONS, 1000L, 100L));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertNull(compiled.findXpRegionRule(Skill.MAGIC, MTA_LOBBY_REGION));
+		assertNull(compiled.findXpRegionRule(Skill.MAGIC, MTA_TELEKINETIC_REGION + 1));
+		assertNull(compiled.findXpRegionRule(Skill.RANGED, MTA_ROOMS_REGION));
+		assertNull(compiled.findXpRegionRule(null, MTA_ROOMS_REGION));
+	}
+
+	@Test
+	public void skillNameIsCaseInsensitive()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.xpRegionRules = List.of(rule("mta_magic", "mAgIc", MTA_REGIONS, 1000L, 100L));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertNotNull(compiled.findXpRegionRule(Skill.MAGIC, MTA_ROOMS_REGION));
+	}
+
+	@Test
+	public void invalidXpRegionRulesAreDropped()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.xpRegionRules = Arrays.asList(
+			null,
+			rule("", "Magic", MTA_REGIONS, 1000L, 100L),
+			rule("unknown_skill", "Not a skill", MTA_REGIONS, 1000L, 100L),
+			rule("no_regions", "Magic", List.of(), 1000L, 100L),
+			rule("null_region_only", "Magic", Arrays.asList((Integer) null), 1000L, 100L),
+			rule("zero_chunk", "Magic", MTA_REGIONS, 0L, 100L),
+			rule("valid", "Magic", MTA_REGIONS, 500L, 50L));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertEquals(1, compiled.getXpRegionRules().size());
+		assertEquals("valid", compiled.getXpRegionRules().get(0).getActivityId());
+	}
+
+	@Test
+	public void negativeCreditsClampToZero()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.xpRegionRules = List.of(rule("mta_magic", "Magic", MTA_REGIONS, 1000L, -5L));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertEquals(0L, compiled.getXpRegionRules().get(0).getCreditsPerChunk());
+	}
+
+	@Test
+	public void missingXpRegionRulesCompilesToEmptyList()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.xpRegionRules = null;
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertTrue(compiled.getXpRegionRules().isEmpty());
+		assertNull(compiled.findXpRegionRule(Skill.MAGIC, MTA_ROOMS_REGION));
+	}
+
+	@Test
+	public void emptyConfigHasNoXpRegionRules()
+	{
+		assertTrue(CompiledActivityConfig.EMPTY.getXpRegionRules().isEmpty());
+		assertNull(CompiledActivityConfig.EMPTY.findXpRegionRule(Skill.MAGIC, MTA_ROOMS_REGION));
+	}
+
+	private static XpRegionRuleDto rule(String activityId, String skill, List<Integer> regionIds,
+		long xpPerChunk, long credits)
+	{
+		XpRegionRuleDto dto = new XpRegionRuleDto();
+		dto.activityId = activityId;
+		dto.skill = skill;
+		dto.regionIds = regionIds;
+		dto.xpPerChunk = xpPerChunk;
+		dto.credits = credits;
+		dto.label = "Magic Training Arena";
+		return dto;
+	}
+}

--- a/src/test/java/com/osrstcg/credit/SkillCreditSessionTest.java
+++ b/src/test/java/com/osrstcg/credit/SkillCreditSessionTest.java
@@ -115,4 +115,62 @@ public class SkillCreditSessionTest
 		assertEquals(0L, session.pendingSlayerXpToAttest);
 		assertEquals(0L, session.slayerXpRemainder);
 	}
+
+	@Test
+	public void regionXpPoolsAccumulatePerActivity()
+	{
+		SkillCreditSession session = new SkillCreditSession();
+
+		assertEquals(0L, session.regionXpFor("mta_magic"));
+		assertEquals(400L, session.addRegionXp("mta_magic", 400L));
+		assertEquals(900L, session.addRegionXp("mta_magic", 500L));
+		assertEquals(250L, session.addRegionXp("other_rule", 250L));
+
+		assertEquals(900L, session.regionXpFor("mta_magic"));
+		assertEquals(250L, session.regionXpFor("other_rule"));
+	}
+
+	@Test
+	public void regionXpChunkSubtractionKeepsRemainder()
+	{
+		SkillCreditSession session = new SkillCreditSession();
+		long pooled = session.addRegionXp("mta_magic", 2350L);
+
+		long chunks = pooled / 1000L;
+		assertEquals(2L, chunks);
+		session.subtractRegionXp("mta_magic", chunks * 1000L);
+
+		assertEquals(350L, session.regionXpFor("mta_magic"));
+	}
+
+	@Test
+	public void regionXpIgnoresInvalidInput()
+	{
+		SkillCreditSession session = new SkillCreditSession();
+
+		assertEquals(0L, session.addRegionXp(null, 100L));
+		assertEquals(0L, session.addRegionXp("", 100L));
+		assertEquals(0L, session.addRegionXp("mta_magic", 0L));
+		assertEquals(0L, session.addRegionXp("mta_magic", -5L));
+		assertEquals(0L, session.regionXpFor(null));
+
+		session.addRegionXp("mta_magic", 100L);
+		session.subtractRegionXp("mta_magic", 500L);
+		assertEquals(0L, session.regionXpFor("mta_magic"));
+		assertFalse(session.uncreditedRegionXpByActivity.containsKey("mta_magic"));
+	}
+
+	@Test
+	public void clearAndRestoreDropRegionXpPools()
+	{
+		SkillCreditSession session = new SkillCreditSession();
+		session.addRegionXp("mta_magic", 600L);
+		session.clearUncreditedXpPool();
+		assertEquals(0L, session.regionXpFor("mta_magic"));
+
+		session.addRegionXp("mta_magic", 600L);
+		session.restoreUncreditedXp(SkillCreditBaseline.of(Map.of("Woodcutting", 1000), Map.of("Woodcutting", 10L)));
+		assertEquals(0L, session.regionXpFor("mta_magic"));
+		assertEquals(10L, session.uncreditedXpFor(Skill.WOODCUTTING));
+	}
 }


### PR DESCRIPTION
## Problem

Training in the Magic Training Arena (MTA) earns no credits. The rooms award only Magic XP, and Magic is
classed as a combat skill whose XP is deliberately discarded so combat is rewarded through NPC kills instead.
Nothing dies in the MTA, so the kill tracker never fires either. The exclusion is enforced in three layers:

- `CreditAwardService` drops the gain before it reaches the XP pool
- `CreditAttestQueue.enqueue` rejects `xp_chunk` events for combat skills
- `CreditAttestCoalescer.mergeXp` drops combat-skill XP when batching

Only Magic level-ups land credits today.

## Approach

Add a new, server-driven section to the activity config: **region-gated XP rules**. A rule names a skill, a set of
map region ids, an XP chunk size and a credit amount per chunk. While the local player stands in one of those
regions, XP gained in that skill is pooled under the rule and each completed chunk is attested as an
`activity` event (not `xp_chunk`), so the two downstream combat filters stay untouched and the server keeps
control of both the rate and whether the activity is accepted at all.

The plugin change is inert until the server publishes a rule. Everything outside a configured region behaves
exactly as before.

Example config entry:

```json
"xpRegionRules": [
  {
    "activityId": "mta_magic",
    "skill": "Magic",
    "regionIds": [13462, 13463],
    "xpPerChunk": 1000,
    "credits": 100,
    "label": "Magic Training Arena"
  }
]
```

Region ids, verified against RuneLite's MTA plugin source and in-game Ground Marker exports:

| Room | Region | Plane |
|---|---|---|
| Enchanting Chamber | 13462 | 0 |
| Creature Graveyard | 13462 | 1 |
| Alchemists' Playground | 13462 | 2 |
| Telekinetic Theatre (all mazes) | 13463 | 0 to 2 |

The arena entrance hall with the portals is a surface region (13363) and is not included. The rule ignores plane,
so listing the two regions covers all four rooms.

Attest evidence emitted per chunk:

```json
{ "activityId": "mta_magic", "skill": "Magic", "xpDelta": 1000, "regionId": 13462 }
```

## Changes

- `ActivityConfigModels`: new `xpRegionRules` list and `XpRegionRuleDto`.
- `CompiledActivityConfig`: new `CompiledXpRegionRule`, `getXpRegionRules()` and `findXpRegionRule(skill, regionId)`.
- `ActivityConfigService.compile`: compiles region rules, dropping ones with a blank id, unknown skill, no regions or
  non-positive chunk size.
- `SkillCreditSession`: session-only per-activity XP pool (`addRegionXp` / `regionXpFor` / `subtractRegionXp`),
  cleared with the other pools.
- `CreditAwardService`: combat-skill XP now goes through `trackCombatSkillXpGain`, which looks up a matching rule
  for the player's current region and pools/attests via `applyRegionXpGain`. Existing cooldown, restricted-world
  and offline guards apply unchanged. Now injects `ActivityConfigService`. The region lookup uses
  `WorldPoint.fromLocalInstance`, so it resolves to the template region inside instanced areas and to the ordinary
  region elsewhere (the same value Ground Markers record).

## Tests

- New `ActivityConfigServiceTest` covering compile, matching, case-insensitive skill names, invalid-rule dropping,
  credit clamping and the empty config.
- `SkillCreditSessionTest` extended for the region pool: accumulation, chunk remainder, invalid input, clear/restore.

## Server-side work needed (outside this repo)

1. Publish the `xpRegionRules` section in `GET /config/activities` and bump the version.
2. Accept `activity` attests with `activityId = mta_magic` and validate the `xpDelta` / `regionId` evidence.
3. Suggested starting rate: same as regular skilling, 100 credits per 1,000 XP. It is config-driven, so it can be
   tuned later.

## Notes for review

- The three main rooms use the same region and plane values as RuneLite's MTA plugin. The Telekinetic Theatre is
  detected by widget in RuneLite, so its region (13463) was measured directly with Ground Marker exports across
  five maze layouts and cross-checked against the wiki's tile-marker data. Whether the theatre is instanced is not
  confirmed; the instance-aware lookup makes the rule correct either way.
- The region pool is intentionally not persisted, so at most one partial chunk (under 1,000 XP) is lost on logout.
  Persisting it would mean touching `SkillCreditBaseline` and the save codec, which felt out of scope.
- `FakeXpDrop` for combat skills is still ignored, so a player at 200m Magic XP inside the MTA still earns nothing.
  Edge case; happy to cover it if you'd like.
- This deliberately does not touch non-combat Magic training outside the MTA (alching, enchanting, plank make).
  That is a broader balance question and will come as a separate proposal.
