### PR TITLE
Credit non-combat Magic XP (alching, enchanting, teleports) via server-configured non-combat XP rules

### DIFF
--- a/src/main/java/com/osrstcg/OsrsTcgPlugin.java
+++ b/src/main/java/com/osrstcg/OsrsTcgPlugin.java
@@ -19,6 +19,7 @@ import com.osrstcg.overlay.CreditsInfoboxOverlay;
 import com.osrstcg.overlay.PackRevealInputListener;
 import com.osrstcg.overlay.PackRevealOverlay;
 import com.osrstcg.interop.OwnedCardNamesApiService;
+import com.osrstcg.credit.CombatEngagementTracker;
 import com.osrstcg.credit.CreditAwardService;
 import com.osrstcg.credit.CreditsRateTracker;
 import com.osrstcg.credit.GameMessageCreditTracker;
@@ -151,6 +152,8 @@ public class OsrsTcgPlugin extends Plugin
 	@Inject
 	private GameMessageCreditTracker gameMessageCreditTracker;
 	@Inject
+	private CombatEngagementTracker combatEngagementTracker;
+	@Inject
 	private CreditsRateTracker creditsRateTracker;
 	@Inject
 	private WSClient wsClient;
@@ -221,6 +224,7 @@ public class OsrsTcgPlugin extends Plugin
 		mouseManager.registerMouseListener(packRevealInputListener);
 		mouseManager.registerMouseWheelListener(packRevealInputListener);
 		keyManager.registerKeyListener(packRevealInputListener);
+		eventBus.register(combatEngagementTracker);
 		eventBus.register(creditAwardService);
 		creditAwardService.onPluginStarted();
 		eventBus.register(creditsRateTracker);
@@ -275,6 +279,8 @@ public class OsrsTcgPlugin extends Plugin
 			navigationButton = null;
 		}
 		eventBus.unregister(creditAwardService);
+		eventBus.unregister(combatEngagementTracker);
+		combatEngagementTracker.reset();
 		eventBus.unregister(creditsRateTracker);
 		eventBus.unregister(npcKillCreditTracker);
 		eventBus.unregister(gameMessageCreditTracker);

--- a/src/main/java/com/osrstcg/cloud/activity/ActivityConfigModels.java
+++ b/src/main/java/com/osrstcg/cloud/activity/ActivityConfigModels.java
@@ -23,6 +23,24 @@ public final class ActivityConfigModels
 		public NpcExclusionsDto npcExclusions = new NpcExclusionsDto();
 /** Per-NPC-id optimistic kill credit multipliers; JSON keys are NPC id strings. */
 		public Map<String, KillCreditMultiplierDto> killCreditMultipliers = new HashMap<>();
+/** Region-gated XP rules that credit XP for a skill whose XP is otherwise ignored (e.g. Magic in the Magic Training Arena). */
+		public List<XpRegionRuleDto> xpRegionRules = new ArrayList<>();
+	}
+/**
+	 * One region-gated XP-to-credits rule. While the local player stands in any of {@code regionIds}, XP gained
+	 * in {@code skill} is pooled and every {@code xpPerChunk} XP is attested as an {@code activity} event worth
+	 * {@code credits}. Lets combat-classed skills earn credits from non-combat minigames such as the MTA.
+	 */
+	public static final class XpRegionRuleDto
+	{
+		public String activityId;
+/** Skill display name, e.g. {@code Magic}; case-insensitive. */
+		public String skill;
+/** Map region ids (see {@code WorldPoint#getRegionID()}) where the rule applies. */
+		public List<Integer> regionIds = new ArrayList<>();
+		public long xpPerChunk;
+		public long credits;
+		public String label;
 	}
 /** Multiplier applied to combat-level optimistic credits for a specific NPC id. */
 	public static final class KillCreditMultiplierDto

--- a/src/main/java/com/osrstcg/cloud/activity/ActivityConfigModels.java
+++ b/src/main/java/com/osrstcg/cloud/activity/ActivityConfigModels.java
@@ -25,6 +25,25 @@ public final class ActivityConfigModels
 		public Map<String, KillCreditMultiplierDto> killCreditMultipliers = new HashMap<>();
 /** Region-gated XP rules that credit XP for a skill whose XP is otherwise ignored (e.g. Magic in the Magic Training Arena). */
 		public List<XpRegionRuleDto> xpRegionRules = new ArrayList<>();
+/** Rules that credit a combat-classed skill's XP whenever it is gained outside combat (e.g. alching or enchanting). */
+		public List<NonCombatXpRuleDto> nonCombatXpRules = new ArrayList<>();
+	}
+/**
+	 * One non-combat XP-to-credits rule. XP gained in {@code skill} while the player is not in combat (not
+	 * interacting with an actor, no recent hitsplats or Hitpoints XP) is pooled and every {@code xpPerChunk} XP
+	 * is attested as an {@code activity} event worth {@code credits}. Intended for Magic, whose non-combat
+	 * spells (alchemy, enchanting, superheat, teleports) otherwise earn nothing.
+	 */
+	public static final class NonCombatXpRuleDto
+	{
+		public String activityId;
+/** Skill display name, e.g. {@code Magic}; case-insensitive. */
+		public String skill;
+		public long xpPerChunk;
+		public long credits;
+		public String label;
+/** Ticks after the last combat signal during which XP is still treated as combat; null uses the client default. */
+		public Integer combatLockoutTicks;
 	}
 /**
 	 * One region-gated XP-to-credits rule. While the local player stands in any of {@code regionIds}, XP gained

--- a/src/main/java/com/osrstcg/cloud/activity/ActivityConfigService.java
+++ b/src/main/java/com/osrstcg/cloud/activity/ActivityConfigService.java
@@ -7,6 +7,7 @@ import com.osrstcg.cloud.activity.ActivityConfigModels.ActivityChatRuleDto;
 import com.osrstcg.cloud.activity.ActivityConfigModels.ActivityConfigDto;
 import com.osrstcg.cloud.activity.ActivityConfigModels.KillCreditMultiplierDto;
 import com.osrstcg.cloud.activity.ActivityConfigModels.NpcExclusionsDto;
+import com.osrstcg.cloud.activity.ActivityConfigModels.XpRegionRuleDto;
 import com.osrstcg.cloud.api.CloudApiClient;
 import com.osrstcg.cloud.api.CloudApiException;
 import com.osrstcg.util.AtomicFiles;
@@ -33,9 +34,10 @@ import java.util.regex.PatternSyntaxException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Skill;
 /**
- * Fetches, caches, and compiles the server-driven activity config (chat-based credit rules and NPC
- * exclusions) used to award activity credits. Holds the current {@link CompiledActivityConfig} in an
+ * Fetches, caches, and compiles the server-driven activity config (chat-based credit rules, NPC
+ * exclusions, kill multipliers and region-gated XP rules) used to award activity credits. Holds the current {@link CompiledActivityConfig} in an
  * {@link AtomicReference} for lock-free reads; network refreshes run asynchronously on {@link #scheduler}
  * and never block callers of the getters. A copy is persisted to disk so the last-good config survives
  * restarts and cloud API failures.
@@ -272,8 +274,8 @@ public final class ActivityConfigService
 	}
 /**
 	 * Converts a raw {@link ActivityConfigDto} into an immutable {@link CompiledActivityConfig}: compiles
-	 * each chat rule (dropping invalid ones), expands NPC exclusion ids/ranges into a flat id set, and
-	 * parses per-NPC kill credit multipliers.
+	 * each chat rule (dropping invalid ones), expands NPC exclusion ids/ranges into a flat id set, parses
+	 * per-NPC kill credit multipliers, and compiles region-gated XP rules (dropping invalid ones).
 	 */
 	static CompiledActivityConfig compile(ActivityConfigDto dto)
 	{
@@ -350,8 +352,73 @@ public final class ActivityConfigService
 			}
 		}
 
+		List<CompiledActivityConfig.CompiledXpRegionRule> regionRules = new ArrayList<>();
+		if (dto.xpRegionRules != null)
+		{
+			for (XpRegionRuleDto rule : dto.xpRegionRules)
+			{
+				CompiledActivityConfig.CompiledXpRegionRule compiledRule = compileXpRegionRule(rule);
+				if (compiledRule != null)
+				{
+					regionRules.add(compiledRule);
+				}
+			}
+		}
+
 		String version = dto.version == null ? "" : dto.version.trim();
-		return new CompiledActivityConfig(version, rules, npcIds, killMultipliers);
+		return new CompiledActivityConfig(version, rules, npcIds, killMultipliers, regionRules);
+	}
+/**
+	 * Compiles one raw region-gated XP rule, or returns null if it's missing an activity id, names an
+	 * unknown skill, has no region ids, or has a non-positive chunk size.
+	 */
+	private static CompiledActivityConfig.CompiledXpRegionRule compileXpRegionRule(XpRegionRuleDto rule)
+	{
+		if (rule == null || rule.activityId == null || rule.activityId.isBlank() || rule.xpPerChunk <= 0L)
+		{
+			return null;
+		}
+		Skill skill = skillByName(rule.skill);
+		if (skill == null)
+		{
+			log.warn("Skipping xp region rule {} with unknown skill '{}'", rule.activityId, rule.skill);
+			return null;
+		}
+		Set<Integer> regionIds = new HashSet<>();
+		if (rule.regionIds != null)
+		{
+			for (Integer id : rule.regionIds)
+			{
+				if (id != null)
+				{
+					regionIds.add(id);
+				}
+			}
+		}
+		if (regionIds.isEmpty())
+		{
+			log.warn("Skipping xp region rule {} with no region ids", rule.activityId);
+			return null;
+		}
+		return new CompiledActivityConfig.CompiledXpRegionRule(
+			rule.activityId.trim(), skill, regionIds, rule.xpPerChunk, rule.credits, rule.label);
+	}
+/** Looks up a {@link Skill} by its display name (case-insensitive), or {@code null} if not found. */
+	private static Skill skillByName(String name)
+	{
+		if (name == null || name.isBlank())
+		{
+			return null;
+		}
+		String wanted = name.trim();
+		for (Skill skill : Skill.values())
+		{
+			if (wanted.equalsIgnoreCase(skill.getName()))
+			{
+				return skill;
+			}
+		}
+		return null;
 	}
 /**
 	 * Compiles one raw chat rule, or returns null if it's missing required fields or (for a regex rule)

--- a/src/main/java/com/osrstcg/cloud/activity/ActivityConfigService.java
+++ b/src/main/java/com/osrstcg/cloud/activity/ActivityConfigService.java
@@ -6,6 +6,7 @@ import com.osrstcg.cloud.activity.ActivityConfigModels.ActivitiesConfigResponse;
 import com.osrstcg.cloud.activity.ActivityConfigModels.ActivityChatRuleDto;
 import com.osrstcg.cloud.activity.ActivityConfigModels.ActivityConfigDto;
 import com.osrstcg.cloud.activity.ActivityConfigModels.KillCreditMultiplierDto;
+import com.osrstcg.cloud.activity.ActivityConfigModels.NonCombatXpRuleDto;
 import com.osrstcg.cloud.activity.ActivityConfigModels.NpcExclusionsDto;
 import com.osrstcg.cloud.activity.ActivityConfigModels.XpRegionRuleDto;
 import com.osrstcg.cloud.api.CloudApiClient;
@@ -37,7 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Skill;
 /**
  * Fetches, caches, and compiles the server-driven activity config (chat-based credit rules, NPC
- * exclusions, kill multipliers and region-gated XP rules) used to award activity credits. Holds the current {@link CompiledActivityConfig} in an
+ * exclusions, kill multipliers, region-gated XP rules and non-combat XP rules) used to award activity credits. Holds the current {@link CompiledActivityConfig} in an
  * {@link AtomicReference} for lock-free reads; network refreshes run asynchronously on {@link #scheduler}
  * and never block callers of the getters. A copy is persisted to disk so the last-good config survives
  * restarts and cloud API failures.
@@ -275,7 +276,7 @@ public final class ActivityConfigService
 /**
 	 * Converts a raw {@link ActivityConfigDto} into an immutable {@link CompiledActivityConfig}: compiles
 	 * each chat rule (dropping invalid ones), expands NPC exclusion ids/ranges into a flat id set, parses
-	 * per-NPC kill credit multipliers, and compiles region-gated XP rules (dropping invalid ones).
+	 * per-NPC kill credit multipliers, and compiles region-gated and non-combat XP rules (dropping invalid ones).
 	 */
 	static CompiledActivityConfig compile(ActivityConfigDto dto)
 	{
@@ -365,8 +366,44 @@ public final class ActivityConfigService
 			}
 		}
 
+		List<CompiledActivityConfig.CompiledNonCombatXpRule> nonCombatRules = new ArrayList<>();
+		if (dto.nonCombatXpRules != null)
+		{
+			for (NonCombatXpRuleDto rule : dto.nonCombatXpRules)
+			{
+				CompiledActivityConfig.CompiledNonCombatXpRule compiledRule = compileNonCombatXpRule(rule);
+				if (compiledRule != null)
+				{
+					nonCombatRules.add(compiledRule);
+				}
+			}
+		}
+
 		String version = dto.version == null ? "" : dto.version.trim();
-		return new CompiledActivityConfig(version, rules, npcIds, killMultipliers, regionRules);
+		return new CompiledActivityConfig(version, rules, npcIds, killMultipliers, regionRules, nonCombatRules);
+	}
+/**
+	 * Compiles one raw non-combat XP rule, or returns null if it's missing an activity id, names an unknown
+	 * skill, or has a non-positive chunk size. A missing lockout uses
+	 * {@link CompiledActivityConfig.CompiledNonCombatXpRule#DEFAULT_COMBAT_LOCKOUT_TICKS}.
+	 */
+	private static CompiledActivityConfig.CompiledNonCombatXpRule compileNonCombatXpRule(NonCombatXpRuleDto rule)
+	{
+		if (rule == null || rule.activityId == null || rule.activityId.isBlank() || rule.xpPerChunk <= 0L)
+		{
+			return null;
+		}
+		Skill skill = skillByName(rule.skill);
+		if (skill == null)
+		{
+			log.warn("Skipping non-combat xp rule {} with unknown skill '{}'", rule.activityId, rule.skill);
+			return null;
+		}
+		int lockout = rule.combatLockoutTicks == null
+			? CompiledActivityConfig.CompiledNonCombatXpRule.DEFAULT_COMBAT_LOCKOUT_TICKS
+			: rule.combatLockoutTicks;
+		return new CompiledActivityConfig.CompiledNonCombatXpRule(
+			rule.activityId.trim(), skill, rule.xpPerChunk, rule.credits, rule.label, lockout);
 	}
 /**
 	 * Compiles one raw region-gated XP rule, or returns null if it's missing an activity id, names an

--- a/src/main/java/com/osrstcg/cloud/activity/CompiledActivityConfig.java
+++ b/src/main/java/com/osrstcg/cloud/activity/CompiledActivityConfig.java
@@ -4,9 +4,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import net.runelite.api.Skill;
 /**
  * Immutable, thread-safe snapshot of activity config for chat matching, NPC id exclusions,
- * and per-NPC kill credit multipliers.
+ * per-NPC kill credit multipliers, and region-gated XP rules.
  */
 public final class CompiledActivityConfig
 {
@@ -15,23 +16,27 @@ public final class CompiledActivityConfig
 		"",
 		List.of(),
 		Set.of(),
-		Map.of());
+		Map.of(),
+		List.of());
 
 	private final String version;
 	private final List<CompiledChatRule> chatRules;
 	private final Set<Integer> excludedNpcIds;
 	private final Map<Integer, Double> killCreditMultipliers;
+	private final List<CompiledXpRegionRule> xpRegionRules;
 /** Normalizes nulls to empty and defensively copies the collections into immutable ones. */
 	CompiledActivityConfig(
 		String version,
 		List<CompiledChatRule> chatRules,
 		Set<Integer> excludedNpcIds,
-		Map<Integer, Double> killCreditMultipliers)
+		Map<Integer, Double> killCreditMultipliers,
+		List<CompiledXpRegionRule> xpRegionRules)
 	{
 		this.version = version == null ? "" : version;
 		this.chatRules = chatRules == null ? List.of() : List.copyOf(chatRules);
 		this.excludedNpcIds = excludedNpcIds == null ? Set.of() : Set.copyOf(excludedNpcIds);
 		this.killCreditMultipliers = killCreditMultipliers == null ? Map.of() : Map.copyOf(killCreditMultipliers);
+		this.xpRegionRules = xpRegionRules == null ? List.of() : List.copyOf(xpRegionRules);
 	}
 /** Opaque version string this config was compiled from; empty for {@link #EMPTY}. */
 	public String getVersion()
@@ -55,6 +60,88 @@ public final class CompiledActivityConfig
 	{
 		Double multiplier = killCreditMultipliers.get(npcId);
 		return multiplier == null ? 1.0 : multiplier;
+	}
+
+	public List<CompiledXpRegionRule> getXpRegionRules()
+	{
+		return xpRegionRules;
+	}
+/** First region-gated XP rule covering {@code skill} in map region {@code regionId}, or {@code null} if none. */
+	public CompiledXpRegionRule findXpRegionRule(Skill skill, int regionId)
+	{
+		if (skill == null)
+		{
+			return null;
+		}
+		for (CompiledXpRegionRule rule : xpRegionRules)
+		{
+			if (rule.matches(skill, regionId))
+			{
+				return rule;
+			}
+		}
+		return null;
+	}
+/** Precompiled region-gated XP rule: credits {@code skill} XP gained inside any of {@code regionIds}. */
+	public static final class CompiledXpRegionRule
+	{
+		private final String activityId;
+		private final Skill skill;
+		private final Set<Integer> regionIds;
+		private final long xpPerChunk;
+		private final long creditsPerChunk;
+		private final String label;
+/** Normalizes nulls and clamps credits to non-negative; callers must supply a non-null skill, non-empty regions and a positive chunk size. */
+		CompiledXpRegionRule(
+			String activityId,
+			Skill skill,
+			Set<Integer> regionIds,
+			long xpPerChunk,
+			long creditsPerChunk,
+			String label)
+		{
+			this.activityId = activityId == null ? "" : activityId;
+			this.skill = skill;
+			this.regionIds = regionIds == null ? Set.of() : Set.copyOf(regionIds);
+			this.xpPerChunk = Math.max(1L, xpPerChunk);
+			this.creditsPerChunk = Math.max(0L, creditsPerChunk);
+			this.label = label == null ? "" : label;
+		}
+/** True if this rule credits {@code skill} XP while the player is in map region {@code regionId}. */
+		public boolean matches(Skill skill, int regionId)
+		{
+			return this.skill == skill && regionIds.contains(regionId);
+		}
+
+		public String getActivityId()
+		{
+			return activityId;
+		}
+
+		public Skill getSkill()
+		{
+			return skill;
+		}
+
+		public Set<Integer> getRegionIds()
+		{
+			return regionIds;
+		}
+
+		public long getXpPerChunk()
+		{
+			return xpPerChunk;
+		}
+
+		public long getCreditsPerChunk()
+		{
+			return creditsPerChunk;
+		}
+
+		public String getLabel()
+		{
+			return label;
+		}
 	}
 /** Precompiled chat-message match rule: literal prefix or regex, mutually exclusive. */
 	public static final class CompiledChatRule

--- a/src/main/java/com/osrstcg/cloud/activity/CompiledActivityConfig.java
+++ b/src/main/java/com/osrstcg/cloud/activity/CompiledActivityConfig.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 import net.runelite.api.Skill;
 /**
  * Immutable, thread-safe snapshot of activity config for chat matching, NPC id exclusions,
- * per-NPC kill credit multipliers, and region-gated XP rules.
+ * per-NPC kill credit multipliers, region-gated XP rules, and non-combat XP rules.
  */
 public final class CompiledActivityConfig
 {
@@ -17,6 +17,7 @@ public final class CompiledActivityConfig
 		List.of(),
 		Set.of(),
 		Map.of(),
+		List.of(),
 		List.of());
 
 	private final String version;
@@ -24,19 +25,22 @@ public final class CompiledActivityConfig
 	private final Set<Integer> excludedNpcIds;
 	private final Map<Integer, Double> killCreditMultipliers;
 	private final List<CompiledXpRegionRule> xpRegionRules;
+	private final List<CompiledNonCombatXpRule> nonCombatXpRules;
 /** Normalizes nulls to empty and defensively copies the collections into immutable ones. */
 	CompiledActivityConfig(
 		String version,
 		List<CompiledChatRule> chatRules,
 		Set<Integer> excludedNpcIds,
 		Map<Integer, Double> killCreditMultipliers,
-		List<CompiledXpRegionRule> xpRegionRules)
+		List<CompiledXpRegionRule> xpRegionRules,
+		List<CompiledNonCombatXpRule> nonCombatXpRules)
 	{
 		this.version = version == null ? "" : version;
 		this.chatRules = chatRules == null ? List.of() : List.copyOf(chatRules);
 		this.excludedNpcIds = excludedNpcIds == null ? Set.of() : Set.copyOf(excludedNpcIds);
 		this.killCreditMultipliers = killCreditMultipliers == null ? Map.of() : Map.copyOf(killCreditMultipliers);
 		this.xpRegionRules = xpRegionRules == null ? List.of() : List.copyOf(xpRegionRules);
+		this.nonCombatXpRules = nonCombatXpRules == null ? List.of() : List.copyOf(nonCombatXpRules);
 	}
 /** Opaque version string this config was compiled from; empty for {@link #EMPTY}. */
 	public String getVersion()
@@ -81,6 +85,85 @@ public final class CompiledActivityConfig
 			}
 		}
 		return null;
+	}
+	public List<CompiledNonCombatXpRule> getNonCombatXpRules()
+	{
+		return nonCombatXpRules;
+	}
+/** First non-combat XP rule covering {@code skill}, or {@code null} if none. */
+	public CompiledNonCombatXpRule findNonCombatXpRule(Skill skill)
+	{
+		if (skill == null)
+		{
+			return null;
+		}
+		for (CompiledNonCombatXpRule rule : nonCombatXpRules)
+		{
+			if (rule.getSkill() == skill)
+			{
+				return rule;
+			}
+		}
+		return null;
+	}
+/** Precompiled non-combat XP rule: credits {@code skill} XP gained while the player is not in combat. */
+	public static final class CompiledNonCombatXpRule
+	{
+/** Default ticks after a combat signal during which XP is still treated as combat (about 5 seconds). */
+		public static final int DEFAULT_COMBAT_LOCKOUT_TICKS = 8;
+
+		private final String activityId;
+		private final Skill skill;
+		private final long xpPerChunk;
+		private final long creditsPerChunk;
+		private final String label;
+		private final int combatLockoutTicks;
+/** Normalizes nulls, clamps credits and lockout to non-negative; callers must supply a non-null skill and positive chunk size. */
+		CompiledNonCombatXpRule(
+			String activityId,
+			Skill skill,
+			long xpPerChunk,
+			long creditsPerChunk,
+			String label,
+			int combatLockoutTicks)
+		{
+			this.activityId = activityId == null ? "" : activityId;
+			this.skill = skill;
+			this.xpPerChunk = Math.max(1L, xpPerChunk);
+			this.creditsPerChunk = Math.max(0L, creditsPerChunk);
+			this.label = label == null ? "" : label;
+			this.combatLockoutTicks = Math.max(0, combatLockoutTicks);
+		}
+
+		public String getActivityId()
+		{
+			return activityId;
+		}
+
+		public Skill getSkill()
+		{
+			return skill;
+		}
+
+		public long getXpPerChunk()
+		{
+			return xpPerChunk;
+		}
+
+		public long getCreditsPerChunk()
+		{
+			return creditsPerChunk;
+		}
+
+		public String getLabel()
+		{
+			return label;
+		}
+
+		public int getCombatLockoutTicks()
+		{
+			return combatLockoutTicks;
+		}
 	}
 /** Precompiled region-gated XP rule: credits {@code skill} XP gained inside any of {@code regionIds}. */
 	public static final class CompiledXpRegionRule

--- a/src/main/java/com/osrstcg/credit/CombatEngagementTracker.java
+++ b/src/main/java/com/osrstcg/credit/CombatEngagementTracker.java
@@ -1,0 +1,125 @@
+package com.osrstcg.credit;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.api.Actor;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.Player;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.HitsplatApplied;
+import net.runelite.api.events.InteractingChanged;
+import net.runelite.client.eventbus.Subscribe;
+/**
+ * Tracks whether the local player is, or very recently was, in combat so that XP from non-combat spells
+ * (alchemy, enchanting, superheat, teleports, ...) can be told apart from combat-spell XP. Combat is
+ * inferred from three signals: the player targeting another actor (or being targeted), hitsplats dealt by
+ * or applied to the player, and Hitpoints XP gains reported by {@link CreditAwardService}. Splashing is
+ * treated as combat because the player is interacting with the target throughout. Subscribes to
+ * {@link InteractingChanged}, {@link HitsplatApplied} and {@link GameStateChanged}.
+ */
+@Singleton
+public final class CombatEngagementTracker
+{
+	private final Client client;
+/** Whether any combat signal has been seen since the last {@link #reset()}. */
+	private boolean combatSeen;
+/** Game tick of the most recent combat signal; only meaningful when {@link #combatSeen} is true. */
+	private int lastCombatTick;
+
+	@Inject
+	public CombatEngagementTracker(Client client)
+	{
+		this.client = client;
+	}
+/**
+	 * Whether the player should currently be treated as in combat: true if they are interacting with any
+	 * actor right now, or if a combat signal was seen within the last {@code lockoutTicks} game ticks.
+	 */
+	public boolean isInCombat(int lockoutTicks)
+	{
+		if (client == null)
+		{
+			return false;
+		}
+		Player local = client.getLocalPlayer();
+		if (local != null && local.getInteracting() != null)
+		{
+			return true;
+		}
+		return withinLockout(combatSeen, lastCombatTick, client.getTickCount(), lockoutTicks);
+	}
+/** Records a Hitpoints XP gain as a combat signal (Hitpoints XP only comes from dealing damage). */
+	public void noteHitpointsXpGain()
+	{
+		markCombat();
+	}
+/** Forgets all combat signals, e.g. on logout or world hop. */
+	public void reset()
+	{
+		combatSeen = false;
+		lastCombatTick = 0;
+	}
+/** Marks combat when the local player starts targeting an actor, or another actor starts targeting the player. */
+	@Subscribe
+	public void onInteractingChanged(InteractingChanged event)
+	{
+		if (client == null || event == null)
+		{
+			return;
+		}
+		Player local = client.getLocalPlayer();
+		if (local == null)
+		{
+			return;
+		}
+		Actor source = event.getSource();
+		Actor target = event.getTarget();
+		if ((source == local && target != null) || (target == local && source != null && source != local))
+		{
+			markCombat();
+		}
+	}
+/** Marks combat on any hitsplat dealt by the local player or applied to them. */
+	@Subscribe
+	public void onHitsplatApplied(HitsplatApplied event)
+	{
+		if (client == null || event == null || event.getHitsplat() == null)
+		{
+			return;
+		}
+		if (event.getActor() == client.getLocalPlayer() || event.getHitsplat().isMine())
+		{
+			markCombat();
+		}
+	}
+/** Clears combat state on logout or world hop so stale ticks from a previous session don't leak. */
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged event)
+	{
+		GameState state = event.getGameState();
+		if (state == GameState.LOGIN_SCREEN || state == GameState.HOPPING)
+		{
+			reset();
+		}
+	}
+/**
+	 * Whether {@code currentTick} falls within {@code lockoutTicks} of {@code lastCombatTick}. A negative
+	 * elapsed time (tick counter reset) is treated as out of combat.
+	 */
+	static boolean withinLockout(boolean combatSeen, int lastCombatTick, int currentTick, int lockoutTicks)
+	{
+		if (!combatSeen)
+		{
+			return false;
+		}
+		long elapsed = (long) currentTick - lastCombatTick;
+		return elapsed >= 0L && elapsed <= Math.max(0, lockoutTicks);
+	}
+
+	private void markCombat()
+	{
+		combatSeen = true;
+		lastCombatTick = client.getTickCount();
+	}
+}

--- a/src/main/java/com/osrstcg/credit/CreditAwardService.java
+++ b/src/main/java/com/osrstcg/credit/CreditAwardService.java
@@ -1,6 +1,8 @@
 package com.osrstcg.credit;
 
 import com.google.gson.JsonObject;
+import com.osrstcg.cloud.activity.ActivityConfigService;
+import com.osrstcg.cloud.activity.CompiledActivityConfig;
 import com.osrstcg.cloud.session.CloudSessionCoordinator;
 import com.osrstcg.cloud.session.CloudSessionService;
 import com.osrstcg.cloud.attest.CreditAttestCoalescer;
@@ -18,7 +20,10 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
 import net.runelite.api.GameState;
+import net.runelite.api.Player;
 import net.runelite.api.Skill;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.FakeXpDrop;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
@@ -29,7 +34,9 @@ import com.osrstcg.state.TcgStateService;
 /**
  * Central coordinator for awarding credits from XP gains and level-ups. Tracks per-skill XP/level baselines,
  * converts XP into credit chunks (with a separate, cheaper Slayer conversion), and enqueues optimistic
- * credit attest events via {@link CreditAttestQueue}. Also enforces a short cooldown after login/world-hop
+ * credit attest events via {@link CreditAttestQueue}. Combat-skill XP is normally ignored (kills are credited
+ * instead), except where a server-configured region XP rule covers the player's current map region, e.g.
+ * Magic XP inside the Magic Training Arena. Also enforces a short cooldown after login/world-hop
  * so transient stat resyncs (e.g. temporary boosts settling) don't get credited as real gains. Most XP/level
  * entry points ({@link #onStatChanged}, {@link #onFakeXpDrop}) are called directly from the plugin's event
  * handlers; {@link #onGameTick} is the only RuneLite-subscribed method here.
@@ -43,7 +50,10 @@ public class CreditAwardService
 	static final int CREDIT_COOLDOWN_TICKS = 3;
 /** Extra settle window after hopping off a restricted/event world (temp max stats). */
 	static final int RESTRICTED_WORLD_EXIT_SETTLE_TICKS = 12;
-/** Combat skills excluded from XP-based credit awards (XP here comes from combat, not standalone training). */
+/**
+	 * Combat skills excluded from XP-based credit awards (XP here comes from combat, not standalone training),
+	 * unless a region XP rule from {@link ActivityConfigService} covers the player's current region.
+	 */
 	private static final Set<Skill> COMBAT_SKILLS = EnumSet.of(
 		Skill.ATTACK,
 		Skill.DEFENCE,
@@ -58,6 +68,7 @@ public class CreditAwardService
 	private final CreditAttestQueue attestQueue;
 	private final ChatMessageManager chatMessageManager;
 	private final Provider<CloudSessionCoordinator> sessionCoordinator;
+	private final ActivityConfigService activityConfigService;
 	private final SkillCreditSession skills = new SkillCreditSession();
 	private boolean creditCooldownActive;
 	private int creditCooldownUntilTick;
@@ -69,7 +80,7 @@ public class CreditAwardService
 	@Inject
 	public CreditAwardService(Client client, TcgStateService stateService, CloudSessionService session,
 		CreditAttestQueue attestQueue, ChatMessageManager chatMessageManager,
-		Provider<CloudSessionCoordinator> sessionCoordinator)
+		Provider<CloudSessionCoordinator> sessionCoordinator, ActivityConfigService activityConfigService)
 	{
 		this.client = client;
 		this.stateService = stateService;
@@ -77,6 +88,7 @@ public class CreditAwardService
 		this.attestQueue = attestQueue;
 		this.chatMessageManager = chatMessageManager;
 		this.sessionCoordinator = sessionCoordinator;
+		this.activityConfigService = activityConfigService;
 	}
 /** Resets in-memory tracking and restores the uncredited XP pool from the persisted baseline, if any. */
 	public void resetExperienceCreditBaseline()
@@ -398,8 +410,9 @@ public class CreditAwardService
 	}
 /**
 	 * Updates the previous-XP baseline for {@code skill} and, if XP increased while not on cooldown, routes
-	 * the gain to the appropriate credit path (ignored for combat skills, Hitpoints attested without credit
-	 * bucketing, others accumulated toward an XP chunk). XP drops (e.g. from a stat reset) are ignored.
+	 * the gain to the appropriate credit path (combat skills ignored unless a region XP rule applies, Hitpoints
+	 * attested without credit bucketing, others accumulated toward an XP chunk). XP drops (e.g. from a stat
+	 * reset) are ignored.
 	 *
 	 * @return true if this call caused an XP chunk to be credited
 	 */
@@ -436,9 +449,7 @@ public class CreditAwardService
 			long xpGained = (long) currentXp - previousXp;
 			if (isCombatSkill(skill))
 			{
-				debugAward(String.format(
-					"Ignored +%s combat skill XP (%s)",
-					NumberFormatting.format(xpGained), skill.getName()));
+				xpChunkAwarded = trackCombatSkillXpGain(skill, xpGained);
 			}
 			else if (!isCreditAwardOnCooldown())
 			{
@@ -454,6 +465,109 @@ public class CreditAwardService
 		}
 		skills.previousSkillXp[skillIndex] = currentXp;
 		return xpChunkAwarded;
+	}
+/**
+	 * Handles a combat-skill XP gain: ignored unless a configured region XP rule covers {@code skill} in the
+	 * player's current map region (e.g. Magic in the Magic Training Arena), in which case the XP is pooled
+	 * under that rule and completed chunks are attested as {@code activity} events.
+	 *
+	 * @return true if this call caused an XP chunk to be credited
+	 */
+	private boolean trackCombatSkillXpGain(Skill skill, long xpGained)
+	{
+		int regionId = currentRegionId();
+		CompiledActivityConfig.CompiledXpRegionRule rule = regionId < 0
+			? null
+			: activityConfigService.getCompiled().findXpRegionRule(skill, regionId);
+		if (rule == null)
+		{
+			debugAward(String.format(
+				"Ignored +%s combat skill XP (%s)",
+				NumberFormatting.format(xpGained), skill.getName()));
+			return false;
+		}
+		if (isCreditAwardOnCooldown())
+		{
+			return false;
+		}
+		return applyRegionXpGain(rule, skill, regionId, xpGained);
+	}
+/**
+	 * Pools {@code xpGained} under {@code rule}'s activity id and, if attests can currently be collected,
+	 * converts completed {@code xpPerChunk} chunks to credits and enqueues one {@code activity} attest carrying
+	 * the credited XP, skill and region as evidence. If the cloud session is offline, the XP stays pooled.
+	 *
+	 * @return true if this call caused credit to be awarded
+	 */
+	private boolean applyRegionXpGain(CompiledActivityConfig.CompiledXpRegionRule rule, Skill skill,
+		int regionId, long xpGained)
+	{
+		if (rule == null || skill == null || xpGained <= 0L)
+		{
+			return false;
+		}
+
+		String activityId = rule.getActivityId();
+		String label = rule.getLabel().isBlank() ? activityId : rule.getLabel();
+		long pooled = skills.addRegionXp(activityId, xpGained);
+		debugAward(String.format("Registered +%s XP (%s, %s) -> %s / %s",
+			NumberFormatting.format(xpGained), skill.getName(), label,
+			NumberFormatting.format(pooled), NumberFormatting.format(rule.getXpPerChunk())));
+
+		long chunks = pooled / rule.getXpPerChunk();
+		if (chunks <= 0L)
+		{
+			return false;
+		}
+
+		long xpCredited = chunks * rule.getXpPerChunk();
+		long credits = chunks * rule.getCreditsPerChunk();
+		if (!session.canCollectAttests())
+		{
+			debugAward(String.format("Cloud offline; +%s XP (%s) pending until reconnected",
+				NumberFormatting.format(xpCredited), label));
+			return false;
+		}
+
+		JsonObject evidence = new JsonObject();
+		evidence.addProperty("activityId", activityId);
+		evidence.addProperty("skill", skill.getName());
+		evidence.addProperty("xpDelta", xpCredited);
+		evidence.addProperty("regionId", regionId);
+		if (!attestQueue.enqueue(CreditAttestCoalescer.TYPE_ACTIVITY, evidence, credits))
+		{
+			return false;
+		}
+
+		skills.subtractRegionXp(activityId, xpCredited);
+		debugAward(String.format("XP drop +%s (%s) -> +%s credits (total %s)",
+			NumberFormatting.format(xpCredited), label,
+			NumberFormatting.format(credits), NumberFormatting.format(stateService.getCredits())));
+		return credits > 0L;
+	}
+/**
+	 * Map region id of the local player's current tile, or -1 if unavailable. Instance-aware: inside an
+	 * instanced area this resolves to the template map region (the same value RuneLite's Ground Markers
+	 * record), and elsewhere it equals the ordinary world-location region.
+	 */
+	private int currentRegionId()
+	{
+		if (client == null)
+		{
+			return -1;
+		}
+		Player player = client.getLocalPlayer();
+		if (player == null)
+		{
+			return -1;
+		}
+		LocalPoint local = player.getLocalLocation();
+		if (local == null)
+		{
+			return -1;
+		}
+		WorldPoint location = WorldPoint.fromLocalInstance(client, local);
+		return location == null ? -1 : location.getRegionID();
 	}
 /**
 	 * Applies a positive XP gain (xp) for {@code skill}: routes Slayer XP through its own chunk conversion,

--- a/src/main/java/com/osrstcg/credit/CreditAwardService.java
+++ b/src/main/java/com/osrstcg/credit/CreditAwardService.java
@@ -1,5 +1,6 @@
 package com.osrstcg.credit;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.osrstcg.cloud.activity.ActivityConfigService;
 import com.osrstcg.cloud.activity.CompiledActivityConfig;
@@ -35,8 +36,9 @@ import com.osrstcg.state.TcgStateService;
  * Central coordinator for awarding credits from XP gains and level-ups. Tracks per-skill XP/level baselines,
  * converts XP into credit chunks (with a separate, cheaper Slayer conversion), and enqueues optimistic
  * credit attest events via {@link CreditAttestQueue}. Combat-skill XP is normally ignored (kills are credited
- * instead), except where a server-configured region XP rule covers the player's current map region, e.g.
- * Magic XP inside the Magic Training Arena. Also enforces a short cooldown after login/world-hop
+ * instead), except where a server-configured region XP rule covers the player's current map region (e.g.
+ * Magic XP inside the Magic Training Arena) or a non-combat XP rule applies and the player is not in combat
+ * per {@link CombatEngagementTracker} (e.g. alching or enchanting). Also enforces a short cooldown after login/world-hop
  * so transient stat resyncs (e.g. temporary boosts settling) don't get credited as real gains. Most XP/level
  * entry points ({@link #onStatChanged}, {@link #onFakeXpDrop}) are called directly from the plugin's event
  * handlers; {@link #onGameTick} is the only RuneLite-subscribed method here.
@@ -52,7 +54,8 @@ public class CreditAwardService
 	static final int RESTRICTED_WORLD_EXIT_SETTLE_TICKS = 12;
 /**
 	 * Combat skills excluded from XP-based credit awards (XP here comes from combat, not standalone training),
-	 * unless a region XP rule from {@link ActivityConfigService} covers the player's current region.
+	 * unless a region XP rule from {@link ActivityConfigService} covers the player's current region, or a
+	 * non-combat XP rule applies and the player is out of combat.
 	 */
 	private static final Set<Skill> COMBAT_SKILLS = EnumSet.of(
 		Skill.ATTACK,
@@ -69,6 +72,7 @@ public class CreditAwardService
 	private final ChatMessageManager chatMessageManager;
 	private final Provider<CloudSessionCoordinator> sessionCoordinator;
 	private final ActivityConfigService activityConfigService;
+	private final CombatEngagementTracker combatEngagement;
 	private final SkillCreditSession skills = new SkillCreditSession();
 	private boolean creditCooldownActive;
 	private int creditCooldownUntilTick;
@@ -80,7 +84,8 @@ public class CreditAwardService
 	@Inject
 	public CreditAwardService(Client client, TcgStateService stateService, CloudSessionService session,
 		CreditAttestQueue attestQueue, ChatMessageManager chatMessageManager,
-		Provider<CloudSessionCoordinator> sessionCoordinator, ActivityConfigService activityConfigService)
+		Provider<CloudSessionCoordinator> sessionCoordinator, ActivityConfigService activityConfigService,
+		CombatEngagementTracker combatEngagement)
 	{
 		this.client = client;
 		this.stateService = stateService;
@@ -89,6 +94,7 @@ public class CreditAwardService
 		this.chatMessageManager = chatMessageManager;
 		this.sessionCoordinator = sessionCoordinator;
 		this.activityConfigService = activityConfigService;
+		this.combatEngagement = combatEngagement;
 	}
 /** Resets in-memory tracking and restores the uncredited XP pool from the persisted baseline, if any. */
 	public void resetExperienceCreditBaseline()
@@ -447,6 +453,11 @@ public class CreditAwardService
 		if (skills.skillXpInitialized)
 		{
 			long xpGained = (long) currentXp - previousXp;
+			if (skill == Skill.HITPOINTS)
+			{
+				// Hitpoints XP only comes from dealing damage, so it is a reliable in-combat signal.
+				combatEngagement.noteHitpointsXpGain();
+			}
 			if (isCombatSkill(skill))
 			{
 				xpChunkAwarded = trackCombatSkillXpGain(skill, xpGained);
@@ -467,61 +478,87 @@ public class CreditAwardService
 		return xpChunkAwarded;
 	}
 /**
-	 * Handles a combat-skill XP gain: ignored unless a configured region XP rule covers {@code skill} in the
-	 * player's current map region (e.g. Magic in the Magic Training Arena), in which case the XP is pooled
-	 * under that rule and completed chunks are attested as {@code activity} events.
+	 * Handles a combat-skill XP gain. Ignored unless one of two server-configured rules applies, checked in
+	 * order: a region XP rule covering {@code skill} in the player's current map region (e.g. Magic in the
+	 * Magic Training Arena), or a non-combat XP rule for {@code skill} while the player is out of combat per
+	 * {@link CombatEngagementTracker} (e.g. alching, enchanting, teleporting). Matching XP is pooled under the
+	 * rule's activity id and completed chunks are attested as {@code activity} events.
 	 *
 	 * @return true if this call caused an XP chunk to be credited
 	 */
 	private boolean trackCombatSkillXpGain(Skill skill, long xpGained)
 	{
+		CompiledActivityConfig compiled = activityConfigService.getCompiled();
+
 		int regionId = currentRegionId();
-		CompiledActivityConfig.CompiledXpRegionRule rule = regionId < 0
+		CompiledActivityConfig.CompiledXpRegionRule regionRule = regionId < 0
 			? null
-			: activityConfigService.getCompiled().findXpRegionRule(skill, regionId);
-		if (rule == null)
+			: compiled.findXpRegionRule(skill, regionId);
+		if (regionRule != null)
 		{
-			debugAward(String.format(
-				"Ignored +%s combat skill XP (%s)",
-				NumberFormatting.format(xpGained), skill.getName()));
-			return false;
+			if (isCreditAwardOnCooldown())
+			{
+				return false;
+			}
+			JsonObject extraEvidence = new JsonObject();
+			extraEvidence.addProperty("regionId", regionId);
+			return applyActivityXpGain(regionRule.getActivityId(), regionRule.getLabel(),
+				regionRule.getXpPerChunk(), regionRule.getCreditsPerChunk(), skill, xpGained, extraEvidence);
 		}
-		if (isCreditAwardOnCooldown())
+
+		CompiledActivityConfig.CompiledNonCombatXpRule nonCombatRule = compiled.findNonCombatXpRule(skill);
+		if (nonCombatRule != null)
 		{
-			return false;
+			if (combatEngagement.isInCombat(nonCombatRule.getCombatLockoutTicks()))
+			{
+				debugAward(String.format(
+					"Ignored +%s %s XP gained in combat",
+					NumberFormatting.format(xpGained), skill.getName()));
+				return false;
+			}
+			if (isCreditAwardOnCooldown())
+			{
+				return false;
+			}
+			return applyActivityXpGain(nonCombatRule.getActivityId(), nonCombatRule.getLabel(),
+				nonCombatRule.getXpPerChunk(), nonCombatRule.getCreditsPerChunk(), skill, xpGained, null);
 		}
-		return applyRegionXpGain(rule, skill, regionId, xpGained);
+
+		debugAward(String.format(
+			"Ignored +%s combat skill XP (%s)",
+			NumberFormatting.format(xpGained), skill.getName()));
+		return false;
 	}
 /**
-	 * Pools {@code xpGained} under {@code rule}'s activity id and, if attests can currently be collected,
-	 * converts completed {@code xpPerChunk} chunks to credits and enqueues one {@code activity} attest carrying
-	 * the credited XP, skill and region as evidence. If the cloud session is offline, the XP stays pooled.
+	 * Pools {@code xpGained} under {@code activityId} and, if attests can currently be collected, converts
+	 * completed {@code xpPerChunk} chunks to credits and enqueues one {@code activity} attest carrying the
+	 * credited XP and skill (plus any {@code extraEvidence}) as evidence. If the cloud session is offline, the
+	 * XP stays pooled.
 	 *
 	 * @return true if this call caused credit to be awarded
 	 */
-	private boolean applyRegionXpGain(CompiledActivityConfig.CompiledXpRegionRule rule, Skill skill,
-		int regionId, long xpGained)
+	private boolean applyActivityXpGain(String activityId, String ruleLabel, long xpPerChunk, long creditsPerChunk,
+		Skill skill, long xpGained, JsonObject extraEvidence)
 	{
-		if (rule == null || skill == null || xpGained <= 0L)
+		if (activityId == null || activityId.isEmpty() || xpPerChunk <= 0L || skill == null || xpGained <= 0L)
 		{
 			return false;
 		}
 
-		String activityId = rule.getActivityId();
-		String label = rule.getLabel().isBlank() ? activityId : rule.getLabel();
-		long pooled = skills.addRegionXp(activityId, xpGained);
+		String label = ruleLabel == null || ruleLabel.isBlank() ? activityId : ruleLabel;
+		long pooled = skills.addActivityXp(activityId, xpGained);
 		debugAward(String.format("Registered +%s XP (%s, %s) -> %s / %s",
 			NumberFormatting.format(xpGained), skill.getName(), label,
-			NumberFormatting.format(pooled), NumberFormatting.format(rule.getXpPerChunk())));
+			NumberFormatting.format(pooled), NumberFormatting.format(xpPerChunk)));
 
-		long chunks = pooled / rule.getXpPerChunk();
+		long chunks = pooled / xpPerChunk;
 		if (chunks <= 0L)
 		{
 			return false;
 		}
 
-		long xpCredited = chunks * rule.getXpPerChunk();
-		long credits = chunks * rule.getCreditsPerChunk();
+		long xpCredited = chunks * xpPerChunk;
+		long credits = chunks * creditsPerChunk;
 		if (!session.canCollectAttests())
 		{
 			debugAward(String.format("Cloud offline; +%s XP (%s) pending until reconnected",
@@ -533,13 +570,19 @@ public class CreditAwardService
 		evidence.addProperty("activityId", activityId);
 		evidence.addProperty("skill", skill.getName());
 		evidence.addProperty("xpDelta", xpCredited);
-		evidence.addProperty("regionId", regionId);
+		if (extraEvidence != null)
+		{
+			for (Map.Entry<String, JsonElement> entry : extraEvidence.entrySet())
+			{
+				evidence.add(entry.getKey(), entry.getValue());
+			}
+		}
 		if (!attestQueue.enqueue(CreditAttestCoalescer.TYPE_ACTIVITY, evidence, credits))
 		{
 			return false;
 		}
 
-		skills.subtractRegionXp(activityId, xpCredited);
+		skills.subtractActivityXp(activityId, xpCredited);
 		debugAward(String.format("XP drop +%s (%s) -> +%s credits (total %s)",
 			NumberFormatting.format(xpCredited), label,
 			NumberFormatting.format(credits), NumberFormatting.format(stateService.getCredits())));

--- a/src/main/java/com/osrstcg/credit/SkillCreditSession.java
+++ b/src/main/java/com/osrstcg/credit/SkillCreditSession.java
@@ -3,6 +3,7 @@ package com.osrstcg.credit;
 import com.osrstcg.state.SkillCreditBaseline;
 import java.util.Arrays;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import net.runelite.api.Client;
@@ -25,6 +26,11 @@ final class SkillCreditSession
 	long pendingSlayerXpToAttest;
 /** Slayer XP short of a full {@link XpCreditMath#SLAYER_XP_PER_CHUNK} chunk, carried to the next gain. */
 	long slayerXpRemainder;
+/**
+	 * XP earned under a region-gated XP rule (e.g. Magic in the MTA) but short of a full chunk, keyed by the
+	 * rule's activity id. Session-only: not persisted, so at most one partial chunk is lost on logout.
+	 */
+	final Map<String, Long> uncreditedRegionXpByActivity = new HashMap<>();
 /** Clears level/XP baselines so the next snapshot re-establishes them from the client. */
 	void resetTracking()
 	{
@@ -33,12 +39,52 @@ final class SkillCreditSession
 		skillXpInitialized = false;
 		Arrays.fill(previousSkillXp, 0);
 	}
-/** Discards all pending uncredited XP (main pool and Slayer pending/remainder). */
+/** Discards all pending uncredited XP (main pool, Slayer pending/remainder, and region-rule pools). */
 	void clearUncreditedXpPool()
 	{
 		Arrays.fill(uncreditedXpBySkill, 0L);
 		pendingSlayerXpToAttest = 0L;
 		slayerXpRemainder = 0L;
+		uncreditedRegionXpByActivity.clear();
+	}
+/** Adds {@code xp} XP to the region rule's pool for {@code activityId} and returns the new pool total. */
+	long addRegionXp(String activityId, long xp)
+	{
+		if (activityId == null || activityId.isEmpty() || xp <= 0L)
+		{
+			return regionXpFor(activityId);
+		}
+
+		long next = regionXpFor(activityId) + xp;
+		uncreditedRegionXpByActivity.put(activityId, next);
+		return next;
+	}
+/** Currently uncredited XP pooled for the region rule {@code activityId} (0 if unknown/null). */
+	long regionXpFor(String activityId)
+	{
+		if (activityId == null || activityId.isEmpty())
+		{
+			return 0L;
+		}
+		Long pooled = uncreditedRegionXpByActivity.get(activityId);
+		return pooled == null ? 0L : pooled;
+	}
+/** Removes {@code xp} XP from the region rule's pool (clamped at 0), typically after crediting a chunk. */
+	void subtractRegionXp(String activityId, long xp)
+	{
+		if (activityId == null || activityId.isEmpty() || xp <= 0L)
+		{
+			return;
+		}
+		long remaining = Math.max(0L, regionXpFor(activityId) - xp);
+		if (remaining == 0L)
+		{
+			uncreditedRegionXpByActivity.remove(activityId);
+		}
+		else
+		{
+			uncreditedRegionXpByActivity.put(activityId, remaining);
+		}
 	}
 /** Replaces the uncredited XP pool with a persisted baseline (e.g. restored after a profile reload). */
 	void restoreUncreditedXp(SkillCreditBaseline saved)
@@ -46,6 +92,7 @@ final class SkillCreditSession
 		Arrays.fill(uncreditedXpBySkill, 0L);
 		pendingSlayerXpToAttest = 0L;
 		slayerXpRemainder = 0L;
+		uncreditedRegionXpByActivity.clear();
 
 		if (saved == null || !saved.isPresent())
 		{

--- a/src/main/java/com/osrstcg/credit/SkillCreditSession.java
+++ b/src/main/java/com/osrstcg/credit/SkillCreditSession.java
@@ -27,10 +27,11 @@ final class SkillCreditSession
 /** Slayer XP short of a full {@link XpCreditMath#SLAYER_XP_PER_CHUNK} chunk, carried to the next gain. */
 	long slayerXpRemainder;
 /**
-	 * XP earned under a region-gated XP rule (e.g. Magic in the MTA) but short of a full chunk, keyed by the
-	 * rule's activity id. Session-only: not persisted, so at most one partial chunk is lost on logout.
+	 * XP earned under an activity XP rule (region-gated, e.g. Magic in the MTA, or non-combat) but short of a
+	 * full chunk, keyed by the rule's activity id. Session-only: not persisted, so at most one partial chunk is
+	 * lost on logout.
 	 */
-	final Map<String, Long> uncreditedRegionXpByActivity = new HashMap<>();
+	final Map<String, Long> uncreditedXpByActivity = new HashMap<>();
 /** Clears level/XP baselines so the next snapshot re-establishes them from the client. */
 	void resetTracking()
 	{
@@ -39,51 +40,51 @@ final class SkillCreditSession
 		skillXpInitialized = false;
 		Arrays.fill(previousSkillXp, 0);
 	}
-/** Discards all pending uncredited XP (main pool, Slayer pending/remainder, and region-rule pools). */
+/** Discards all pending uncredited XP (main pool, Slayer pending/remainder, and activity-rule pools). */
 	void clearUncreditedXpPool()
 	{
 		Arrays.fill(uncreditedXpBySkill, 0L);
 		pendingSlayerXpToAttest = 0L;
 		slayerXpRemainder = 0L;
-		uncreditedRegionXpByActivity.clear();
+		uncreditedXpByActivity.clear();
 	}
-/** Adds {@code xp} XP to the region rule's pool for {@code activityId} and returns the new pool total. */
-	long addRegionXp(String activityId, long xp)
+/** Adds {@code xp} XP to the activity rule's pool for {@code activityId} and returns the new pool total. */
+	long addActivityXp(String activityId, long xp)
 	{
 		if (activityId == null || activityId.isEmpty() || xp <= 0L)
 		{
-			return regionXpFor(activityId);
+			return activityXpFor(activityId);
 		}
 
-		long next = regionXpFor(activityId) + xp;
-		uncreditedRegionXpByActivity.put(activityId, next);
+		long next = activityXpFor(activityId) + xp;
+		uncreditedXpByActivity.put(activityId, next);
 		return next;
 	}
-/** Currently uncredited XP pooled for the region rule {@code activityId} (0 if unknown/null). */
-	long regionXpFor(String activityId)
+/** Currently uncredited XP pooled for the activity rule {@code activityId} (0 if unknown/null). */
+	long activityXpFor(String activityId)
 	{
 		if (activityId == null || activityId.isEmpty())
 		{
 			return 0L;
 		}
-		Long pooled = uncreditedRegionXpByActivity.get(activityId);
+		Long pooled = uncreditedXpByActivity.get(activityId);
 		return pooled == null ? 0L : pooled;
 	}
-/** Removes {@code xp} XP from the region rule's pool (clamped at 0), typically after crediting a chunk. */
-	void subtractRegionXp(String activityId, long xp)
+/** Removes {@code xp} XP from the activity rule's pool (clamped at 0), typically after crediting a chunk. */
+	void subtractActivityXp(String activityId, long xp)
 	{
 		if (activityId == null || activityId.isEmpty() || xp <= 0L)
 		{
 			return;
 		}
-		long remaining = Math.max(0L, regionXpFor(activityId) - xp);
+		long remaining = Math.max(0L, activityXpFor(activityId) - xp);
 		if (remaining == 0L)
 		{
-			uncreditedRegionXpByActivity.remove(activityId);
+			uncreditedXpByActivity.remove(activityId);
 		}
 		else
 		{
-			uncreditedRegionXpByActivity.put(activityId, remaining);
+			uncreditedXpByActivity.put(activityId, remaining);
 		}
 	}
 /** Replaces the uncredited XP pool with a persisted baseline (e.g. restored after a profile reload). */
@@ -92,7 +93,7 @@ final class SkillCreditSession
 		Arrays.fill(uncreditedXpBySkill, 0L);
 		pendingSlayerXpToAttest = 0L;
 		slayerXpRemainder = 0L;
-		uncreditedRegionXpByActivity.clear();
+		uncreditedXpByActivity.clear();
 
 		if (saved == null || !saved.isPresent())
 		{

--- a/src/test/java/com/osrstcg/cloud/activity/ActivityConfigServiceTest.java
+++ b/src/test/java/com/osrstcg/cloud/activity/ActivityConfigServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.osrstcg.cloud.activity.ActivityConfigModels.ActivityConfigDto;
+import com.osrstcg.cloud.activity.ActivityConfigModels.NonCombatXpRuleDto;
 import com.osrstcg.cloud.activity.ActivityConfigModels.XpRegionRuleDto;
 import java.util.Arrays;
 import java.util.List;
@@ -115,6 +116,110 @@ public class ActivityConfigServiceTest
 	{
 		assertTrue(CompiledActivityConfig.EMPTY.getXpRegionRules().isEmpty());
 		assertNull(CompiledActivityConfig.EMPTY.findXpRegionRule(Skill.MAGIC, MTA_ROOMS_REGION));
+		assertTrue(CompiledActivityConfig.EMPTY.getNonCombatXpRules().isEmpty());
+		assertNull(CompiledActivityConfig.EMPTY.findNonCombatXpRule(Skill.MAGIC));
+	}
+
+	@Test
+	public void compilesNonCombatXpRuleWithDefaultLockout()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.nonCombatXpRules = List.of(nonCombatRule("magic_noncombat", "Magic", 1000L, 100L, null));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertEquals(1, compiled.getNonCombatXpRules().size());
+		CompiledActivityConfig.CompiledNonCombatXpRule matched = compiled.findNonCombatXpRule(Skill.MAGIC);
+		assertNotNull(matched);
+		assertEquals("magic_noncombat", matched.getActivityId());
+		assertEquals(Skill.MAGIC, matched.getSkill());
+		assertEquals(1000L, matched.getXpPerChunk());
+		assertEquals(100L, matched.getCreditsPerChunk());
+		assertEquals("Non-combat Magic", matched.getLabel());
+		assertEquals(
+			CompiledActivityConfig.CompiledNonCombatXpRule.DEFAULT_COMBAT_LOCKOUT_TICKS,
+			matched.getCombatLockoutTicks());
+	}
+
+	@Test
+	public void nonCombatXpRuleHonoursExplicitLockoutAndClampsNegative()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.nonCombatXpRules = List.of(
+			nonCombatRule("magic_noncombat", "Magic", 1000L, 100L, 15),
+			nonCombatRule("ranged_noncombat", "Ranged", 1000L, 100L, -3));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertEquals(15, compiled.findNonCombatXpRule(Skill.MAGIC).getCombatLockoutTicks());
+		assertEquals(0, compiled.findNonCombatXpRule(Skill.RANGED).getCombatLockoutTicks());
+	}
+
+	@Test
+	public void nonCombatXpRuleDoesNotMatchOtherSkill()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.nonCombatXpRules = List.of(nonCombatRule("magic_noncombat", "Magic", 1000L, 100L, null));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertNull(compiled.findNonCombatXpRule(Skill.RANGED));
+		assertNull(compiled.findNonCombatXpRule(Skill.ATTACK));
+		assertNull(compiled.findNonCombatXpRule(null));
+	}
+
+	@Test
+	public void invalidNonCombatXpRulesAreDropped()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.nonCombatXpRules = Arrays.asList(
+			null,
+			nonCombatRule("", "Magic", 1000L, 100L, null),
+			nonCombatRule("unknown_skill", "Not a skill", 1000L, 100L, null),
+			nonCombatRule("zero_chunk", "Magic", 0L, 100L, null),
+			nonCombatRule("valid", "Magic", 500L, 50L, null));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertEquals(1, compiled.getNonCombatXpRules().size());
+		assertEquals("valid", compiled.getNonCombatXpRules().get(0).getActivityId());
+	}
+
+	@Test
+	public void missingNonCombatXpRulesCompilesToEmptyList()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.nonCombatXpRules = null;
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertTrue(compiled.getNonCombatXpRules().isEmpty());
+	}
+
+	@Test
+	public void regionAndNonCombatRulesCompileSideBySide()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.xpRegionRules = List.of(rule("mta_magic", "Magic", MTA_REGIONS, 1000L, 100L));
+		dto.nonCombatXpRules = List.of(nonCombatRule("magic_noncombat", "Magic", 1000L, 100L, null));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertEquals("mta_magic", compiled.findXpRegionRule(Skill.MAGIC, MTA_ROOMS_REGION).getActivityId());
+		assertEquals("magic_noncombat", compiled.findNonCombatXpRule(Skill.MAGIC).getActivityId());
+	}
+
+	private static NonCombatXpRuleDto nonCombatRule(String activityId, String skill, long xpPerChunk,
+		long credits, Integer lockoutTicks)
+	{
+		NonCombatXpRuleDto dto = new NonCombatXpRuleDto();
+		dto.activityId = activityId;
+		dto.skill = skill;
+		dto.xpPerChunk = xpPerChunk;
+		dto.credits = credits;
+		dto.label = "Non-combat Magic";
+		dto.combatLockoutTicks = lockoutTicks;
+		return dto;
 	}
 
 	private static XpRegionRuleDto rule(String activityId, String skill, List<Integer> regionIds,

--- a/src/test/java/com/osrstcg/cloud/activity/ActivityConfigServiceTest.java
+++ b/src/test/java/com/osrstcg/cloud/activity/ActivityConfigServiceTest.java
@@ -1,0 +1,132 @@
+package com.osrstcg.cloud.activity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.osrstcg.cloud.activity.ActivityConfigModels.ActivityConfigDto;
+import com.osrstcg.cloud.activity.ActivityConfigModels.XpRegionRuleDto;
+import java.util.Arrays;
+import java.util.List;
+import net.runelite.api.Skill;
+import org.junit.Test;
+
+public class ActivityConfigServiceTest
+{
+	/** Map region of the Enchanting Chamber, Creature Graveyard and Alchemists' Playground (planes 0-2). */
+	private static final int MTA_ROOMS_REGION = 13462;
+	/** Map region of the Telekinetic Theatre mazes (planes 0-2), directly north of the main rooms. */
+	private static final int MTA_TELEKINETIC_REGION = 13463;
+	/** Surface region of the arena entrance hall with the room portals; not a training area. */
+	private static final int MTA_LOBBY_REGION = 13363;
+	private static final List<Integer> MTA_REGIONS = List.of(MTA_ROOMS_REGION, MTA_TELEKINETIC_REGION);
+
+	@Test
+	public void compilesXpRegionRuleAndMatchesSkillInEveryListedRegion()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.version = "v1";
+		dto.xpRegionRules = List.of(rule("mta_magic", "Magic", MTA_REGIONS, 1000L, 100L));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertEquals(1, compiled.getXpRegionRules().size());
+		for (int region : MTA_REGIONS)
+		{
+			CompiledActivityConfig.CompiledXpRegionRule matched = compiled.findXpRegionRule(Skill.MAGIC, region);
+			assertNotNull(matched);
+			assertEquals("mta_magic", matched.getActivityId());
+			assertEquals(Skill.MAGIC, matched.getSkill());
+			assertEquals(1000L, matched.getXpPerChunk());
+			assertEquals(100L, matched.getCreditsPerChunk());
+		}
+	}
+
+	@Test
+	public void xpRegionRuleDoesNotMatchOtherRegionOrSkill()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.xpRegionRules = List.of(rule("mta_magic", "Magic", MTA_REGIONS, 1000L, 100L));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertNull(compiled.findXpRegionRule(Skill.MAGIC, MTA_LOBBY_REGION));
+		assertNull(compiled.findXpRegionRule(Skill.MAGIC, MTA_TELEKINETIC_REGION + 1));
+		assertNull(compiled.findXpRegionRule(Skill.RANGED, MTA_ROOMS_REGION));
+		assertNull(compiled.findXpRegionRule(null, MTA_ROOMS_REGION));
+	}
+
+	@Test
+	public void skillNameIsCaseInsensitive()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.xpRegionRules = List.of(rule("mta_magic", "mAgIc", MTA_REGIONS, 1000L, 100L));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertNotNull(compiled.findXpRegionRule(Skill.MAGIC, MTA_ROOMS_REGION));
+	}
+
+	@Test
+	public void invalidXpRegionRulesAreDropped()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.xpRegionRules = Arrays.asList(
+			null,
+			rule("", "Magic", MTA_REGIONS, 1000L, 100L),
+			rule("unknown_skill", "Not a skill", MTA_REGIONS, 1000L, 100L),
+			rule("no_regions", "Magic", List.of(), 1000L, 100L),
+			rule("null_region_only", "Magic", Arrays.asList((Integer) null), 1000L, 100L),
+			rule("zero_chunk", "Magic", MTA_REGIONS, 0L, 100L),
+			rule("valid", "Magic", MTA_REGIONS, 500L, 50L));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertEquals(1, compiled.getXpRegionRules().size());
+		assertEquals("valid", compiled.getXpRegionRules().get(0).getActivityId());
+	}
+
+	@Test
+	public void negativeCreditsClampToZero()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.xpRegionRules = List.of(rule("mta_magic", "Magic", MTA_REGIONS, 1000L, -5L));
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertEquals(0L, compiled.getXpRegionRules().get(0).getCreditsPerChunk());
+	}
+
+	@Test
+	public void missingXpRegionRulesCompilesToEmptyList()
+	{
+		ActivityConfigDto dto = new ActivityConfigDto();
+		dto.xpRegionRules = null;
+
+		CompiledActivityConfig compiled = ActivityConfigService.compile(dto);
+
+		assertTrue(compiled.getXpRegionRules().isEmpty());
+		assertNull(compiled.findXpRegionRule(Skill.MAGIC, MTA_ROOMS_REGION));
+	}
+
+	@Test
+	public void emptyConfigHasNoXpRegionRules()
+	{
+		assertTrue(CompiledActivityConfig.EMPTY.getXpRegionRules().isEmpty());
+		assertNull(CompiledActivityConfig.EMPTY.findXpRegionRule(Skill.MAGIC, MTA_ROOMS_REGION));
+	}
+
+	private static XpRegionRuleDto rule(String activityId, String skill, List<Integer> regionIds,
+		long xpPerChunk, long credits)
+	{
+		XpRegionRuleDto dto = new XpRegionRuleDto();
+		dto.activityId = activityId;
+		dto.skill = skill;
+		dto.regionIds = regionIds;
+		dto.xpPerChunk = xpPerChunk;
+		dto.credits = credits;
+		dto.label = "Magic Training Arena";
+		return dto;
+	}
+}

--- a/src/test/java/com/osrstcg/credit/CombatEngagementTrackerTest.java
+++ b/src/test/java/com/osrstcg/credit/CombatEngagementTrackerTest.java
@@ -1,0 +1,56 @@
+package com.osrstcg.credit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class CombatEngagementTrackerTest
+{
+	@Test
+	public void noCombatSeenIsNeverLockedOut()
+	{
+		assertFalse(CombatEngagementTracker.withinLockout(false, 0, 0, 8));
+		assertFalse(CombatEngagementTracker.withinLockout(false, 100, 100, 8));
+	}
+
+	@Test
+	public void sameTickAsCombatIsLockedOut()
+	{
+		assertTrue(CombatEngagementTracker.withinLockout(true, 100, 100, 8));
+	}
+
+	@Test
+	public void lockoutIsInclusiveOfLastTick()
+	{
+		assertTrue(CombatEngagementTracker.withinLockout(true, 100, 108, 8));
+		assertFalse(CombatEngagementTracker.withinLockout(true, 100, 109, 8));
+	}
+
+	@Test
+	public void zeroLockoutOnlyCoversTheCombatTick()
+	{
+		assertTrue(CombatEngagementTracker.withinLockout(true, 100, 100, 0));
+		assertFalse(CombatEngagementTracker.withinLockout(true, 100, 101, 0));
+	}
+
+	@Test
+	public void negativeLockoutBehavesLikeZero()
+	{
+		assertTrue(CombatEngagementTracker.withinLockout(true, 100, 100, -5));
+		assertFalse(CombatEngagementTracker.withinLockout(true, 100, 101, -5));
+	}
+
+	@Test
+	public void tickCounterGoingBackwardsIsNotCombat()
+	{
+		assertFalse(CombatEngagementTracker.withinLockout(true, 100, 50, 8));
+	}
+
+	@Test
+	public void largeTickValuesDoNotOverflow()
+	{
+		assertTrue(CombatEngagementTracker.withinLockout(true, Integer.MAX_VALUE - 2, Integer.MAX_VALUE, 8));
+		assertFalse(CombatEngagementTracker.withinLockout(true, Integer.MAX_VALUE, Integer.MIN_VALUE, 8));
+	}
+}

--- a/src/test/java/com/osrstcg/credit/SkillCreditSessionTest.java
+++ b/src/test/java/com/osrstcg/credit/SkillCreditSessionTest.java
@@ -117,60 +117,60 @@ public class SkillCreditSessionTest
 	}
 
 	@Test
-	public void regionXpPoolsAccumulatePerActivity()
+	public void activityXpPoolsAccumulatePerActivity()
 	{
 		SkillCreditSession session = new SkillCreditSession();
 
-		assertEquals(0L, session.regionXpFor("mta_magic"));
-		assertEquals(400L, session.addRegionXp("mta_magic", 400L));
-		assertEquals(900L, session.addRegionXp("mta_magic", 500L));
-		assertEquals(250L, session.addRegionXp("other_rule", 250L));
+		assertEquals(0L, session.activityXpFor("mta_magic"));
+		assertEquals(400L, session.addActivityXp("mta_magic", 400L));
+		assertEquals(900L, session.addActivityXp("mta_magic", 500L));
+		assertEquals(250L, session.addActivityXp("other_rule", 250L));
 
-		assertEquals(900L, session.regionXpFor("mta_magic"));
-		assertEquals(250L, session.regionXpFor("other_rule"));
+		assertEquals(900L, session.activityXpFor("mta_magic"));
+		assertEquals(250L, session.activityXpFor("other_rule"));
 	}
 
 	@Test
-	public void regionXpChunkSubtractionKeepsRemainder()
+	public void activityXpChunkSubtractionKeepsRemainder()
 	{
 		SkillCreditSession session = new SkillCreditSession();
-		long pooled = session.addRegionXp("mta_magic", 2350L);
+		long pooled = session.addActivityXp("mta_magic", 2350L);
 
 		long chunks = pooled / 1000L;
 		assertEquals(2L, chunks);
-		session.subtractRegionXp("mta_magic", chunks * 1000L);
+		session.subtractActivityXp("mta_magic", chunks * 1000L);
 
-		assertEquals(350L, session.regionXpFor("mta_magic"));
+		assertEquals(350L, session.activityXpFor("mta_magic"));
 	}
 
 	@Test
-	public void regionXpIgnoresInvalidInput()
+	public void activityXpIgnoresInvalidInput()
 	{
 		SkillCreditSession session = new SkillCreditSession();
 
-		assertEquals(0L, session.addRegionXp(null, 100L));
-		assertEquals(0L, session.addRegionXp("", 100L));
-		assertEquals(0L, session.addRegionXp("mta_magic", 0L));
-		assertEquals(0L, session.addRegionXp("mta_magic", -5L));
-		assertEquals(0L, session.regionXpFor(null));
+		assertEquals(0L, session.addActivityXp(null, 100L));
+		assertEquals(0L, session.addActivityXp("", 100L));
+		assertEquals(0L, session.addActivityXp("mta_magic", 0L));
+		assertEquals(0L, session.addActivityXp("mta_magic", -5L));
+		assertEquals(0L, session.activityXpFor(null));
 
-		session.addRegionXp("mta_magic", 100L);
-		session.subtractRegionXp("mta_magic", 500L);
-		assertEquals(0L, session.regionXpFor("mta_magic"));
-		assertFalse(session.uncreditedRegionXpByActivity.containsKey("mta_magic"));
+		session.addActivityXp("mta_magic", 100L);
+		session.subtractActivityXp("mta_magic", 500L);
+		assertEquals(0L, session.activityXpFor("mta_magic"));
+		assertFalse(session.uncreditedXpByActivity.containsKey("mta_magic"));
 	}
 
 	@Test
-	public void clearAndRestoreDropRegionXpPools()
+	public void clearAndRestoreDropActivityXpPools()
 	{
 		SkillCreditSession session = new SkillCreditSession();
-		session.addRegionXp("mta_magic", 600L);
+		session.addActivityXp("mta_magic", 600L);
 		session.clearUncreditedXpPool();
-		assertEquals(0L, session.regionXpFor("mta_magic"));
+		assertEquals(0L, session.activityXpFor("mta_magic"));
 
-		session.addRegionXp("mta_magic", 600L);
+		session.addActivityXp("mta_magic", 600L);
 		session.restoreUncreditedXp(SkillCreditBaseline.of(Map.of("Woodcutting", 1000), Map.of("Woodcutting", 10L)));
-		assertEquals(0L, session.regionXpFor("mta_magic"));
+		assertEquals(0L, session.activityXpFor("mta_magic"));
 		assertEquals(10L, session.uncreditedXpFor(Skill.WOODCUTTING));
 	}
 }

--- a/src/test/java/com/osrstcg/credit/SkillCreditSessionTest.java
+++ b/src/test/java/com/osrstcg/credit/SkillCreditSessionTest.java
@@ -115,4 +115,62 @@ public class SkillCreditSessionTest
 		assertEquals(0L, session.pendingSlayerXpToAttest);
 		assertEquals(0L, session.slayerXpRemainder);
 	}
+
+	@Test
+	public void regionXpPoolsAccumulatePerActivity()
+	{
+		SkillCreditSession session = new SkillCreditSession();
+
+		assertEquals(0L, session.regionXpFor("mta_magic"));
+		assertEquals(400L, session.addRegionXp("mta_magic", 400L));
+		assertEquals(900L, session.addRegionXp("mta_magic", 500L));
+		assertEquals(250L, session.addRegionXp("other_rule", 250L));
+
+		assertEquals(900L, session.regionXpFor("mta_magic"));
+		assertEquals(250L, session.regionXpFor("other_rule"));
+	}
+
+	@Test
+	public void regionXpChunkSubtractionKeepsRemainder()
+	{
+		SkillCreditSession session = new SkillCreditSession();
+		long pooled = session.addRegionXp("mta_magic", 2350L);
+
+		long chunks = pooled / 1000L;
+		assertEquals(2L, chunks);
+		session.subtractRegionXp("mta_magic", chunks * 1000L);
+
+		assertEquals(350L, session.regionXpFor("mta_magic"));
+	}
+
+	@Test
+	public void regionXpIgnoresInvalidInput()
+	{
+		SkillCreditSession session = new SkillCreditSession();
+
+		assertEquals(0L, session.addRegionXp(null, 100L));
+		assertEquals(0L, session.addRegionXp("", 100L));
+		assertEquals(0L, session.addRegionXp("mta_magic", 0L));
+		assertEquals(0L, session.addRegionXp("mta_magic", -5L));
+		assertEquals(0L, session.regionXpFor(null));
+
+		session.addRegionXp("mta_magic", 100L);
+		session.subtractRegionXp("mta_magic", 500L);
+		assertEquals(0L, session.regionXpFor("mta_magic"));
+		assertFalse(session.uncreditedRegionXpByActivity.containsKey("mta_magic"));
+	}
+
+	@Test
+	public void clearAndRestoreDropRegionXpPools()
+	{
+		SkillCreditSession session = new SkillCreditSession();
+		session.addRegionXp("mta_magic", 600L);
+		session.clearUncreditedXpPool();
+		assertEquals(0L, session.regionXpFor("mta_magic"));
+
+		session.addRegionXp("mta_magic", 600L);
+		session.restoreUncreditedXp(SkillCreditBaseline.of(Map.of("Woodcutting", 1000), Map.of("Woodcutting", 10L)));
+		assertEquals(0L, session.regionXpFor("mta_magic"));
+		assertEquals(10L, session.uncreditedXpFor(Skill.WOODCUTTING));
+	}
 }


### PR DESCRIPTION
> **Stacked on #117.** This branch includes the MTA region-rule commit from #117 because it reuses the activity
> config plumbing and the per-activity XP pool introduced there. Once #117 merges, this PR reduces to the single
> "Credit non-combat Magic XP" commit.

## Problem

Magic is classed as a combat skill, so its XP is discarded at three layers (`CreditAwardService`,
`CreditAttestQueue`, `CreditAttestCoalescer`) and combat is rewarded via NPC kills instead. That's right for
combat spells, but it also means every non-combat Magic method earns nothing: High Alchemy, enchanting,
Superheat, Plank Make, teleports, charging orbs, Telekinetic Grab. Only Magic level-ups land credits.

#117 fixes this for the Magic Training Arena by region. This PR handles the general case.

## Approach

Add a second server-driven rule type to the activity config: **non-combat XP rules**. A rule names a skill, an
XP chunk size and a credit amount per chunk. XP in that skill is pooled and each completed chunk is attested as
an `activity` event, but only while the player is **out of combat**.

Combat is inferred by a new `CombatEngagementTracker` from three signals, any of which marks the player as in
combat:

- the local player is interacting with any actor (checked live at the moment XP lands)
- a hitsplat was dealt by, or applied to, the local player within the lockout window
- Hitpoints XP was gained within the lockout window (Hitpoints XP only comes from dealing damage)

The lockout window defaults to 8 ticks (about 5 seconds) and is configurable per rule via `combatLockoutTicks`.
It exists because a combat spell's XP can arrive a tick or two after the target dies and interaction ends.

This is deliberately signal-based rather than a spell list: no per-spell maintenance, and it degrades safely.
Every false positive (thinking the player is in combat when they aren't) costs the player a few credits; there
are no false negatives that pay out combat XP, because casting a combat spell sets interaction before the XP
lands, and splashing keeps interaction for the whole session.

Precedence with #117: if a region XP rule matches the player's current region, it wins and the non-combat rule
is not consulted, so Magic XP inside the MTA is credited exactly once.

The plugin change is inert until the server publishes a rule. Everything else behaves exactly as before.

Example config entry:

```json
"nonCombatXpRules": [
  {
    "activityId": "magic_noncombat",
    "skill": "Magic",
    "xpPerChunk": 1000,
    "credits": 100,
    "label": "Non-combat Magic",
    "combatLockoutTicks": 8
  }
]
```

Attest evidence emitted per chunk:

```json
{ "activityId": "magic_noncombat", "skill": "Magic", "xpDelta": 1000 }
```

## Changes

- `CombatEngagementTracker` (new): singleton subscribed to `InteractingChanged`, `HitsplatApplied` and
  `GameStateChanged`; exposes `isInCombat(lockoutTicks)` and `noteHitpointsXpGain()`. Resets on logout/hop.
- `ActivityConfigModels`: new `nonCombatXpRules` list and `NonCombatXpRuleDto`.
- `CompiledActivityConfig`: new `CompiledNonCombatXpRule` (with `DEFAULT_COMBAT_LOCKOUT_TICKS = 8`),
  `getNonCombatXpRules()` and `findNonCombatXpRule(skill)`.
- `ActivityConfigService.compile`: compiles non-combat rules, dropping ones with a blank id, unknown skill or
  non-positive chunk size; missing lockout uses the default, negative clamps to 0.
- `CreditAwardService`: combat-skill XP checks the region rule first, then the non-combat rule gated on the
  tracker. The pool/attest path from #117 is generalised into `applyActivityXpGain` and shared by both rule types.
  Hitpoints XP gains are forwarded to the tracker as a combat signal. Now injects `CombatEngagementTracker`.
- `SkillCreditSession`: the per-activity pool is renamed from "region" to "activity" since both rule types use it.
- `OsrsTcgPlugin`: registers/unregisters the tracker on the event bus.

## Tests

- `ActivityConfigServiceTest`: non-combat rule compile, default and explicit lockout, negative lockout clamping,
  skill matching, invalid-rule dropping, missing list, and both rule types compiling side by side.
- `CombatEngagementTrackerTest` (new): lockout window boundaries, zero/negative lockout, tick counter going
  backwards, and integer overflow at extreme tick values.
- `SkillCreditSessionTest`: updated for the pool rename.

## Server-side work needed (outside this repo)

1. Publish the `nonCombatXpRules` section in `GET /config/activities` and bump the version.
2. Accept `activity` attests with `activityId = magic_noncombat` and validate the `xpDelta` evidence.
3. Suggested starting rate: same as regular skilling, 100 credits per 1,000 XP. High Alchemy at roughly 78k
   XP/hour would yield about 7,800 credits/hour, comparable to a mid-rate skilling method. Config-driven, so it
   can be tuned or the lockout widened without a plugin release.

## Notes for review

- Any interaction counts as combat, including talking to an NPC or following a player. That's a deliberate
  false-positive bias: it only ever withholds credits, never pays out combat XP.
- Casting non-combat spells while being attacked (e.g. alching while an NPC hits you) is treated as combat and
  not credited. Same bias.
- `FakeXpDrop` for combat skills is still ignored, so a player at 200m Magic XP earns nothing from this path.
- Vengeance, Charge and similar self-cast combat-adjacent spells grant Magic XP without interaction and would be
  credited at the normal rate. They are low-XP and rune-costly, so this seemed acceptable, but it's a call for you.
- Spellbook-agnostic by design: nothing here inspects the spell. Non-combat spells on every book (standard
  alchemy/enchant/teleports, Ancient teleports, Lunar utility spells, Arceuus thralls and offerings) credit
  because they don't target an actor; combat spells on every book are excluded because they do.
- Known false positive: non-combat spells cast **on another player** (Heal Other, Vengeance Other, Cure Other,
  Energy Transfer, Tele Other) set interaction with the target and are treated as combat, so they earn nothing.
  Relaxing this to "player-target interaction only counts as combat if a hitsplat or Hitpoints XP also arrives"
  would fix them, but would also credit splashing on a consenting player in PvP areas, which is the AFK loophole
  the interaction signal exists to close. Left strict; your call.
- The rule is skill-generic on the client. Publishing one for Ranged or melee skills would make no sense (their
  XP is always combat) and nothing here encourages it; documented so it isn't a surprise.
