### PR TITLE
Updated webhook notifcations.

### DIFF
--- a/src/main/java/com/osrstcg/OsrsTcgConfig.java
+++ b/src/main/java/com/osrstcg/OsrsTcgConfig.java
@@ -323,6 +323,19 @@ public interface OsrsTcgConfig extends Config
 		return false;
 	}
 
+/** Whether Dink and webhook pack summaries include each card's grade and condition. */
+	@ConfigItem(
+		keyName = "showPullGradeAndCondition",
+		name = "Show grade and condition",
+		description = "Show card grades and condition values in Dink and webhook pack summaries.",
+		section = pullNotificationsSection,
+		position = 9
+	)
+	default boolean showPullGradeAndCondition()
+	{
+		return true;
+	}
+
 	@ConfigSection(
 		name = "Debug",
 		description = "Developer and troubleshooting options.",

--- a/src/main/java/com/osrstcg/notify/PullNotificationMessages.java
+++ b/src/main/java/com/osrstcg/notify/PullNotificationMessages.java
@@ -2,6 +2,7 @@ package com.osrstcg.notify;
 
 import com.osrstcg.catalog.RarityMath;
 import com.osrstcg.cloud.api.CloudEndpoints;
+import com.osrstcg.ui.card.CardGrade;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -25,6 +26,7 @@ public final class PullNotificationMessages
 		public final RarityMath.Tier tier;
 		public final String instanceId;
 		public final boolean notificationEligible;
+		public final Double condition;
 /** Stores the pull's display/rarity data and notification eligibility verbatim. */
 		public PackPull(
 			String cardName,
@@ -34,12 +36,25 @@ public final class PullNotificationMessages
 			String instanceId,
 			boolean notificationEligible)
 		{
+			this(cardName, newForCollection, foil, tier, instanceId, notificationEligible, null);
+		}
+
+		public PackPull(
+			String cardName,
+			boolean newForCollection,
+			boolean foil,
+			RarityMath.Tier tier,
+			String instanceId,
+			boolean notificationEligible,
+			Double condition)
+		{
 			this.cardName = cardName;
 			this.newForCollection = newForCollection;
 			this.foil = foil;
 			this.tier = tier;
 			this.instanceId = instanceId;
 			this.notificationEligible = notificationEligible;
+			this.condition = condition;
 		}
 	}
 /** A pack's pulls split into new-cards and duplicates summary lines, ordered by rarity. */
@@ -135,23 +150,38 @@ public final class PullNotificationMessages
 		}
 		return best == null ? pulls.get(0) : best;
 	}
-/** Renders one pull's summary bullet: card name (bolded if eligible), foil marker, and inspect link. */
+/** Renders a linked card title (bolded if eligible), foil marker, and available grade/condition. */
 	public static String summaryLine(PackPull pull)
 	{
+		return summaryLine(pull, true);
+	}
+/** Renders a summary title with optional grade/condition, preserving its link and eligibility emphasis. */
+	public static String summaryLine(PackPull pull, boolean showGradeAndCondition)
+	{
 		String displayName = pull.cardName.trim() + (pull.foil ? " (foil)" : "");
+		String inspectUrl = inspectUrl(pull.instanceId);
+		if (!inspectUrl.isEmpty())
+		{
+			displayName = "[" + displayName + "](" + inspectUrl + ")";
+		}
 		if (pull.notificationEligible)
 		{
 			displayName = "**" + displayName + "**";
 		}
-		String inspectUrl = inspectUrl(pull.instanceId);
-		if (!inspectUrl.isEmpty())
+		CardGrade grade = CardGrade.gradeFromCondition(pull.condition);
+		if (showGradeAndCondition && grade != null)
 		{
-			displayName = displayName + " — [Inspect](" + inspectUrl + ")";
+			displayName += " - " + grade.name() + " (" + CardGrade.formatCondition(pull.condition) + ")";
 		}
 		return displayName;
 	}
 /** Splits pulls into new-cards/duplicates summary lines, sorted highest-tier first within each group. */
 	public static PackSummarySections buildSummarySections(List<PackPull> pulls)
+	{
+		return buildSummarySections(pulls, true);
+	}
+/** Splits and sorts summary lines, applying the grade/condition display setting to every card. */
+	public static PackSummarySections buildSummarySections(List<PackPull> pulls, boolean showGradeAndCondition)
 	{
 		List<String> newCards = new ArrayList<>();
 		List<String> duplicates = new ArrayList<>();
@@ -167,7 +197,7 @@ public final class PullNotificationMessages
 			{
 				continue;
 			}
-			(pull.newForCollection ? newCards : duplicates).add(summaryLine(pull));
+			(pull.newForCollection ? newCards : duplicates).add(summaryLine(pull, showGradeAndCondition));
 		}
 		return new PackSummarySections(newCards, duplicates);
 	}

--- a/src/main/java/com/osrstcg/notify/PullNotifySupport.java
+++ b/src/main/java/com/osrstcg/notify/PullNotifySupport.java
@@ -124,7 +124,8 @@ public class PullNotifySupport
 				card.getPull().isFoil(),
 				card.getTier(),
 				card.getPull().getInstanceId(),
-				shouldNotify(card.getTier(), card.getPull().isFoil(), card.isNew())));
+				shouldNotify(card.getTier(), card.getPull().isFoil(), card.isNew()),
+				card.getPull().getCondition()));
 		}
 		return pulls;
 	}
@@ -138,7 +139,8 @@ public class PullNotifySupport
 		{
 			return Optional.empty();
 		}
-		PullNotificationMessages.PackSummarySections sections = PullNotificationMessages.buildSummarySections(pulls);
+		PullNotificationMessages.PackSummarySections sections = PullNotificationMessages.buildSummarySections(
+			pulls, config.showPullGradeAndCondition());
 		if (sections.newCards.isEmpty() && sections.duplicates.isEmpty())
 		{
 			return Optional.empty();

--- a/src/test/java/com/osrstcg/notify/PullNotificationMessagesTest.java
+++ b/src/test/java/com/osrstcg/notify/PullNotificationMessagesTest.java
@@ -16,6 +16,63 @@ import static org.junit.Assert.assertTrue;
 public class PullNotificationMessagesTest
 {
 	@Test
+	public void summaryLinksBoldTitleAndShowsGradeAndCondition()
+	{
+		PullNotificationMessages.PackPull pull = new PullNotificationMessages.PackPull(
+			" Masori Chaps ", true, false, RarityMath.Tier.COMMON, " instance-123 ", true, 95.44);
+		assertEquals(
+			"%USERNAME% opened a booster pack!\n\n**New cards**\n- **[Masori Chaps]("
+				+ PullNotificationMessages.inspectUrl("instance-123") + ")** - S (95.44)",
+			packSummaryMessage("%USERNAME%", buildSummarySections(Collections.singletonList(pull), true)));
+	}
+
+	@Test
+	public void summaryHidesGradeAndConditionWhilePreservingLinksFoilAndBoldTitles()
+	{
+		List<PullNotificationMessages.PackPull> pulls = Arrays.asList(
+			new PullNotificationMessages.PackPull(
+				"Masori Chaps", true, false, RarityMath.Tier.COMMON, "instance-123", true, 95.44),
+			new PullNotificationMessages.PackPull(
+				"Goblin", false, true, RarityMath.Tier.COMMON, "instance-456", false, 74.5));
+		assertEquals(
+			"%USERNAME% opened a booster pack!\n\n**New cards**\n- **[Masori Chaps]("
+				+ PullNotificationMessages.inspectUrl("instance-123") + ")**"
+				+ "\n\n**Duplicates**\n- [Goblin (foil)]("
+				+ PullNotificationMessages.inspectUrl("instance-456") + ")",
+			packSummaryMessage("%USERNAME%", buildSummarySections(pulls, false)));
+	}
+
+	@Test
+	public void summaryPreservesFoilAndUnboldedIneligibleTitle()
+	{
+		PullNotificationMessages.PackPull pull = new PullNotificationMessages.PackPull(
+			"Goblin", false, true, RarityMath.Tier.COMMON, "instance-456", false, 74.5);
+		assertEquals(
+			"[Goblin (foil)](" + PullNotificationMessages.inspectUrl("instance-456") + ") - B (74.50)",
+			PullNotificationMessages.summaryLine(pull));
+	}
+
+	@Test
+	public void summaryShowsConditionWithoutAnInspectLinkWhenInstanceIsMissing()
+	{
+		PullNotificationMessages.PackPull pull = new PullNotificationMessages.PackPull(
+			"Goblin", true, false, RarityMath.Tier.COMMON, " ", true, 5.0);
+		assertEquals("**Goblin** - D (5.00)", PullNotificationMessages.summaryLine(pull));
+	}
+
+	@Test
+	public void summaryOmitsMissingOrInvalidCondition()
+	{
+		for (Double condition : Arrays.asList(null, Double.NaN, Double.POSITIVE_INFINITY))
+		{
+			PullNotificationMessages.PackPull pull = new PullNotificationMessages.PackPull(
+				"Goblin", true, false, RarityMath.Tier.COMMON, "instance-789", true, condition);
+			assertEquals("**[Goblin](" + PullNotificationMessages.inspectUrl("instance-789") + ")**",
+				PullNotificationMessages.summaryLine(pull));
+		}
+	}
+
+	@Test
 	public void packSummaryOmitsEmptyDuplicatesSection()
 	{
 		List<PullNotificationMessages.PackPull> pulls = Arrays.asList(


### PR DESCRIPTION
- Added ability to display grade/condition in Dink notification (Can be switched on/off in configuration)
- Moved 'Inspect' endpoint to behind the card title

**Example of what it looks like on a Dink notification**
<img width="288" height="177" alt="image" src="https://github.com/user-attachments/assets/0c67fa98-d76d-4fe0-899b-2f50c21584d5" />

**Added configuration option to turn on/off grade/condition**
<img width="224" height="348" alt="image" src="https://github.com/user-attachments/assets/210a0289-969b-4a9f-804b-d267ae94bca4" />
